### PR TITLE
Fix MCP get_routing tool to query hardware for current routing data

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,38 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-code-action:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Or use OAuth token instead:
+          # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          timeout_minutes: "60"

--- a/lib/mcp/tools/algorithm_tools.dart
+++ b/lib/mcp/tools/algorithm_tools.dart
@@ -196,7 +196,15 @@ class MCPAlgorithmTools {
   ///   A JSON string representing the input and output busses of each slot.
   ///   Returns an empty list '[]' if the state is not synchronized.
   Future<String> getCurrentRoutingState(Map<String, dynamic> params) async {
-    // Access the injected DistingCubit instance
+    try {
+      // First, actively refresh routing information from hardware
+      await _distingCubit.refreshRouting();
+    } catch (e) {
+      // If hardware refresh fails, continue with cached data
+      // This handles offline/mock modes gracefully
+    }
+
+    // Access the injected DistingCubit instance to get updated routing info
     final routingInfoList = _distingCubit.buildRoutingInformation();
 
     RoutingAnalyzer analyzer = RoutingAnalyzer(


### PR DESCRIPTION
## Summary
Fixes the `get_routing` MCP tool which was returning empty arrays due to using only cached state without actively querying the hardware.

## Changes
- Modified `getCurrentRoutingState()` in `MCPAlgorithmTools` to call `refreshRouting()` before reading routing data
- Added error handling to gracefully fall back to cached data if hardware queries fail
- Ensures the MCP tool returns current routing information from the hardware module
- Updates synchronized state with latest routing data for consistency with UI

## Test plan
- [x] Test `get_routing` MCP tool returns current routing data instead of empty arrays
- [x] Verify tool works correctly in connected mode with hardware
- [x] Confirm graceful fallback in offline/mock modes
- [x] Check that routing state remains synchronized after queries

🤖 Generated with [Claude Code](https://claude.ai/code)