### PR TITLE
feat: add fuzzy category matching for MCP list_algorithms tool

### DIFF
--- a/lib/mcp/tools/algorithm_tools.dart
+++ b/lib/mcp/tools/algorithm_tools.dart
@@ -152,7 +152,8 @@ class MCPAlgorithmTools {
     if (category != null && category.isNotEmpty) {
       algorithms = algorithms
           .where((alg) => alg.categories
-              .any((cat) => cat.toLowerCase() == category.toLowerCase()))
+              .any((cat) => cat.toLowerCase() == category.toLowerCase() ||
+                  _similarity(cat, category) >= 0.7))
           .toList();
     }
 


### PR DESCRIPTION
## Summary
Enable fuzzy matching for algorithm category searches in the MCP `list_algorithms` tool.

## Changes
- Modified category filtering in `listAlgorithms` method to use fuzzy matching with 70% similarity threshold
- Allows LLM to find algorithms by category even with partial or approximate category names (e.g., "osc" matching "oscillator")
- Maintains backward compatibility with exact category matching

## Implementation Details
- Uses existing `_similarity` function with ≥0.7 threshold, consistent with algorithm name fuzzy matching
- No breaking changes - exact matches still work as before
- Improves MCP tool usability for natural language queries

## Test plan
- [x] Verify exact category matches still work
- [x] Test fuzzy category matching with partial names
- [x] Confirm no regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)