### PR TITLE
Fix: Reload algorithms after plugin installation

### DIFF
--- a/lib/cubit/disting_cubit.dart
+++ b/lib/cubit/disting_cubit.dart
@@ -3469,6 +3469,10 @@ class DistingCubit extends Cubit<DistingState> {
     }
 
     debugPrint("[DistingCubit] Successfully uploaded $fileName to $targetPath");
+    
+    // Refresh algorithm list to include newly installed plugin
+    _refreshAlgorithmsInBackground();
+    debugPrint("[DistingCubit] Triggered algorithm refresh after plugin installation");
   }
 
   /// Uploads a single chunk of file data.


### PR DESCRIPTION
Fixes #issue-49

Added algorithm refresh after successful plugin installation to ensure new plugins appear immediately in the algorithm list without requiring app restart.

## Changes
- Added `_refreshAlgorithmsInBackground()` call to `installPlugin` method
- New plugins now appear in algorithm list immediately after installation
- Resolves issue where app restart was required to see installed plugins

Generated with [Claude Code](https://claude.ai/code)