### PR TITLE
feat: Add manual refresh button to algorithm list screen

### DIFF
--- a/lib/cubit/disting_cubit.dart
+++ b/lib/cubit/disting_cubit.dart
@@ -1143,6 +1143,12 @@ class DistingCubit extends Cubit<DistingState> {
     }();
   }
 
+  // Public method to trigger algorithm list refresh from UI
+  void refreshAlgorithms() {
+    debugPrint("[DistingCubit] Manual algorithm refresh requested from UI");
+    _refreshAlgorithmsInBackground();
+  }
+
   // Handle parameter string updates from the queue
   void _onParameterStringUpdated(
     int algorithmIndex,

--- a/lib/ui/add_algorithm_screen.dart
+++ b/lib/ui/add_algorithm_screen.dart
@@ -421,6 +421,22 @@ class _AddAlgorithmScreenState extends State<AddAlgorithmScreen> {
         title: const Text('Add Algorithm'),
         actions: [
           IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh Algorithm List',
+            onPressed: () {
+              // Call the refresh method from DistingCubit
+              context.read<DistingCubit>().refreshAlgorithms();
+              
+              // Show a brief feedback to user
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Refreshing algorithm list...'),
+                  duration: Duration(seconds: 2),
+                ),
+              );
+            },
+          ),
+          IconButton(
             icon: const Icon(Icons.help_outline),
             onPressed: () {
               showDialog(


### PR DESCRIPTION
Fixes #49

Added manual refresh capability to the add algorithm screen for hardware algorithm discovery.

## Changes
- Added public `refreshAlgorithms()` method to `DistingCubit`
- Added refresh icon button in AppBar of `AddAlgorithmScreen`
- Shows user feedback via SnackBar when refresh is triggered
- Allows manual algorithm refresh for hardware discovery without app restart

## Benefits
- Users can now manually refresh algorithm list when hardware doesn't detect new algorithms
- No app restart required for algorithm discovery
- Uses existing tested refresh logic from plugin installation
- Non-blocking background refresh maintains UI responsiveness

🤖 Generated with [Claude Code](https://claude.ai/code)