### PR TITLE
feat: Add three-panel preset browser with Miller columns navigation

### DIFF
--- a/.agent-os/specs/2025-09-09-preset-browser-navigation/spec-lite.md
+++ b/.agent-os/specs/2025-09-09-preset-browser-navigation/spec-lite.md
@@ -1,0 +1,3 @@
+# Spec Summary (Lite)
+
+Implement a three-panel preset browser with macOS Finder-style navigation for browsing and loading Disting NT presets via SysEx directory traversal. The interface will provide visual progress feedback during operations, support flexible root directories, and offer sorting options for efficient preset discovery and loading.

--- a/.agent-os/specs/2025-09-09-preset-browser-navigation/spec.md
+++ b/.agent-os/specs/2025-09-09-preset-browser-navigation/spec.md
@@ -1,0 +1,48 @@
+# Spec Requirements Document
+
+> Spec: Three-Panel Preset Browser Navigation
+> Created: 2025-09-09
+
+## Overview
+
+Implement a three-panel preset browser navigation system similar to macOS Finder for browsing and loading Disting NT presets via SysEx directory traversal. This feature will replace the broken preset loading functionality and provide an intuitive, beautiful interface for navigating preset collections with visual feedback during SysEx operations.
+
+## User Stories
+
+### Preset Collection Browser
+
+As a Disting NT user, I want to browse my preset collection using a three-panel navigation interface, so that I can quickly navigate through nested directories and find the presets I need.
+
+The user opens the preset browser from the SynchronizedScreen menu. They see their preset directory structure in the first panel. When they select a directory, its contents appear in the second panel. Selecting a subdirectory shows its contents in the third panel. A progress bar appears during SysEx read operations, providing visual feedback. They can navigate back using a back button, sort by name or date, and quickly access recent presets.
+
+### Flexible Root Directory Support
+
+As a user with a custom preset directory structure, I want the browser to automatically detect my preset root directory, so that I can access my presets regardless of where they're stored on the SD card.
+
+When the user opens the preset browser, the system first checks for /presets directory. If it doesn't exist, the browser starts at the root / directory of the SD card. This ensures all users can access their presets regardless of their storage configuration.
+
+## Spec Scope
+
+1. **Three-Panel Navigation Interface** - Miller columns style navigation with three panels showing directory hierarchy
+2. **SysEx Directory Traversal** - Integration with existing SysEx commands for reading directory contents from Disting NT
+3. **Visual Progress Feedback** - Horizontal progress bar during SysEx operations to indicate loading state
+4. **Sorting Options** - Toggle between alphabetic and date-based sorting for files and directories
+5. **Recent Presets Display** - Quick access to recently loaded presets in the interface
+
+## Out of Scope
+
+- Creating or editing presets within the browser
+- Preset preview functionality before loading
+- Batch operations on multiple presets
+- Cloud storage or network preset sharing
+
+## Expected Deliverable
+
+1. Three-panel preset browser dialog accessible from SynchronizedScreen menu that displays directory contents via SysEx traversal
+2. Working navigation with back button, sorting toggle, and visual folder/file icons
+3. Successful preset loading with full path construction (/presets/...) when user selects a JSON file
+
+## Spec Documentation
+
+- Tasks: @.agent-os/specs/2025-09-09-preset-browser-navigation/tasks.md
+- Technical Specification: @.agent-os/specs/2025-09-09-preset-browser-navigation/sub-specs/technical-spec.md

--- a/.agent-os/specs/2025-09-09-preset-browser-navigation/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2025-09-09-preset-browser-navigation/sub-specs/technical-spec.md
@@ -1,0 +1,103 @@
+# Technical Specification
+
+This is the technical specification for the spec detailed in @.agent-os/specs/2025-09-09-preset-browser-navigation/spec.md
+
+> Created: 2025-09-09
+> Version: 1.0.0
+
+## Technical Requirements
+
+- **Three-Panel Navigation Widget**: Implement a custom Flutter widget with three horizontally arranged panels using Row layout with flex sizing
+- **Directory Traversal via SysEx**: Use existing `IDistingMidiManager.requestDirectoryListing(String path)` method that returns `DirectoryListing?`
+- **State Management**: Create a new PresetBrowserCubit following existing patterns with Freezed immutable state objects
+- **Progress Indicator**: Implement LinearProgressIndicator in `SizedBox(height: 8)` following existing patterns from LoadPresetDialog
+- **Icon System**: Use Flutter's built-in Icons.folder for directories and Icons.insert_drive_file for files
+- **Sorting Logic**: Implement dual sorting modes (alphabetic and date-based) with unified file/directory lists
+- **Path Management**: Build full paths from root (/ or /presets) maintaining path state across navigation
+- **Back Navigation**: Track navigation history stack for back button functionality
+- **Recent Presets**: Integrate with existing SharedPreferences history (key: 'presetHistory') - no database table exists currently
+- **Dialog Presentation**: Modal AlertDialog launched from SynchronizedScreen PopupMenuItem, returns Map with sdCardPath, action, displayName
+- **Error Handling**: Check `FirmwareVersion.hasSdCardSupport` and `!state.offline` before operations
+- **Responsive Design**: Ensure panels resize appropriately for different screen sizes
+- **Visual Feedback**: Highlight selected items in each panel, show loading states per panel
+
+## Approach
+
+### Widget Architecture
+- **PresetBrowserDialog**: Main dialog container with responsive sizing
+- **ThreePanelNavigator**: Core navigation widget with three Column widgets in a Row
+- **DirectoryPanel**: Reusable panel widget for displaying directory contents
+- **PresetItem**: Individual list item widget with icon, name, and selection state
+
+### State Management Layer
+```dart
+class PresetBrowserCubit extends Cubit<PresetBrowserState> {
+  final IDistingMidiManager midiManager;
+  final DatabaseService database;
+  
+  // Navigation state
+  List<String> navigationHistory = [];
+  String currentPath = '/';
+  Map<String, List<FileSystemItem>> directoryCache = {};
+  
+  // Panel state
+  List<FileSystemItem> leftPanelItems = [];
+  List<FileSystemItem> centerPanelItems = [];
+  List<FileSystemItem> rightPanelItems = [];
+  
+  // Selection state
+  String? selectedLeftItem;
+  String? selectedCenterItem;
+  String? selectedRightItem;
+}
+```
+
+### SysEx Integration
+- Use existing `requestDirectoryListing(String path)` method from IDistingMidiManager
+- Leverage `DistingCubit._scanDirectory()` pattern for recursive traversal
+- Implement caching strategy to avoid repeated SysEx calls
+- Handle timeout scenarios with fallback UI states
+- Parse DirectoryListing responses into FileSystemItem objects
+
+### Navigation Logic
+- **Three-level traversal**: Root → Category → Specific presets/subdirectories
+- **Path building**: Concatenate selections to build full file paths
+- **History management**: Push/pop navigation states for back functionality
+- **Deep linking**: Support direct navigation to specific paths
+
+### UI/UX Implementation
+- **Panel layout**: Flex(1) for each panel to ensure equal width distribution
+- **Loading states**: Individual LinearProgressIndicator per panel during SysEx operations
+- **Selection feedback**: ListTile with selected highlighting using Theme colors
+- **Icons**: Consistent iconography (folders vs files) across all panels
+- **Scrolling**: ListView.builder for efficient rendering of large directories
+
+### Storage Integration
+- Use SharedPreferences for preset history (key: 'presetHistory')
+- Update preset history when user selects preset files
+- Cache directory structures in memory for session persistence
+
+## Integration with Existing Code
+
+### Files to Modify/Extend
+- **LoadPresetDialog** (`lib/ui/widgets/load_preset_dialog.dart`): Create complementary three-panel browser dialog
+- **DistingCubit** (`lib/cubit/disting_cubit.dart`): Reuse `fetchSdCardPresets()` and `_scanDirectory()` methods
+- **SynchronizedScreen**: Add new menu option for three-panel browser alongside existing preset loader
+
+### Existing Methods to Leverage
+- `IDistingMidiManager.requestDirectoryListing(String path)` - Returns DirectoryListing with files/folders
+- `DistingCubit._scanDirectory(String path)` - Recursive directory traversal pattern
+- `DistingCubit.fetchSdCardPresets()` - Starting point for SD card scanning
+- SharedPreferences for preset history management
+
+### Return Value Format
+Must return Map with keys:
+- `'sdCardPath'`: Full path to selected preset
+- `'action'`: PresetAction enum (load/append/export)
+- `'displayName'`: User-friendly name for display
+
+### Compatibility Requirements
+- Maintain drag-and-drop support for .zip and .json files
+- Preserve existing preset loading workflow  
+- Check firmware version for SD card support
+- Handle offline state gracefully

--- a/.agent-os/specs/2025-09-09-preset-browser-navigation/tasks.md
+++ b/.agent-os/specs/2025-09-09-preset-browser-navigation/tasks.md
@@ -1,0 +1,51 @@
+# Spec Tasks
+
+These are the tasks to be completed for the spec detailed in @.agent-os/specs/2025-09-09-preset-browser-navigation/spec.md
+
+> Created: 2025-09-09
+> Status: Ready for Implementation
+
+## Tasks
+
+- [ ] 1. Create PresetBrowserCubit and State Management
+  - [ ] 1.1 Write tests for PresetBrowserCubit state transitions
+  - [ ] 1.2 Create PresetBrowserState with Freezed (initial, loading, loaded, error states)
+  - [ ] 1.3 Implement PresetBrowserCubit with navigation history and panel state management
+  - [ ] 1.4 Add directory caching mechanism for SysEx responses
+  - [ ] 1.5 Implement sorting logic (alphabetic/date toggle)
+  - [ ] 1.6 Verify all state management tests pass
+
+- [ ] 2. Build Three-Panel Navigation Widget
+  - [ ] 2.1 Write tests for ThreePanelNavigator widget
+  - [ ] 2.2 Create ThreePanelNavigator widget with Row and three flex panels
+  - [ ] 2.3 Implement DirectoryPanel widget for reusable panel display
+  - [ ] 2.4 Add selection highlighting and item interaction handlers
+  - [ ] 2.5 Implement folder/file icons with proper visual distinction
+  - [ ] 2.6 Add horizontal LinearProgressIndicator below panels
+  - [ ] 2.7 Verify all widget tests pass
+
+- [ ] 3. Integrate SysEx Directory Operations
+  - [ ] 3.1 Write tests for directory traversal logic
+  - [ ] 3.2 Connect requestDirectoryListing() to PresetBrowserCubit
+  - [ ] 3.3 Implement root directory detection (/presets fallback to /)
+  - [ ] 3.4 Add firmware version and offline state checks
+  - [ ] 3.5 Handle DirectoryListing parsing into FileSystemItem models
+  - [ ] 3.6 Implement error handling for timeouts and failed operations
+  - [ ] 3.7 Verify all SysEx integration tests pass
+
+- [ ] 4. Add Navigation Controls and History
+  - [ ] 4.1 Write tests for navigation controls
+  - [ ] 4.2 Implement back button with navigation history stack
+  - [ ] 4.3 Add sorting toggle button (alphabetic/date)
+  - [ ] 4.4 Integrate SharedPreferences preset history (key: 'presetHistory')
+  - [ ] 4.5 Build full path construction for selected files
+  - [ ] 4.6 Create return Map with sdCardPath, action, displayName
+  - [ ] 4.7 Verify all navigation tests pass
+
+- [ ] 5. Connect to SynchronizedScreen Menu
+  - [ ] 5.1 Write integration tests for menu option
+  - [ ] 5.2 Add new PopupMenuItem for three-panel browser
+  - [ ] 5.3 Implement dialog launch and result handling
+  - [ ] 5.4 Maintain compatibility with existing LoadPresetDialog
+  - [ ] 5.5 Test preset loading workflow end-to-end
+  - [ ] 5.6 Verify all integration tests pass

--- a/lib/cubit/preset_browser_cubit.dart
+++ b/lib/cubit/preset_browser_cubit.dart
@@ -1,0 +1,330 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:nt_helper/cubit/preset_browser_state.dart';
+import 'package:nt_helper/domain/i_disting_midi_manager.dart';
+import 'package:nt_helper/models/sd_card_file_system.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+export 'preset_browser_state.dart';
+
+class PresetBrowserCubit extends Cubit<PresetBrowserState> {
+  final IDistingMidiManager midiManager;
+  final SharedPreferences prefs;
+  final Map<String, List<DirectoryEntry>> _directoryCache = {};
+  
+  static const String _historyKey = 'presetHistory';
+  static const int _maxHistoryItems = 20;
+
+  PresetBrowserCubit({
+    required this.midiManager,
+    required this.prefs,
+  }) : super(const PresetBrowserState.initial());
+
+  Future<void> loadRootDirectory() async {
+    emit(const PresetBrowserState.loading());
+
+    try {
+      // Try /presets first
+      DirectoryListing? listing = await midiManager.requestDirectoryListing('/presets');
+      String rootPath = '/presets';
+
+      // If /presets doesn't exist, fall back to root
+      if (listing == null) {
+        listing = await midiManager.requestDirectoryListing('/');
+        rootPath = '/';
+      }
+
+      if (listing != null) {
+        final sortedEntries = _sortEntries(listing.entries, false);
+        _directoryCache[rootPath] = sortedEntries;
+
+        emit(PresetBrowserState.loaded(
+          currentPath: rootPath,
+          leftPanelItems: sortedEntries,
+          centerPanelItems: const [],
+          rightPanelItems: const [],
+          selectedLeftItem: null,
+          selectedCenterItem: null,
+          selectedRightItem: null,
+          navigationHistory: [],
+          sortByDate: false,
+          directoryCache: Map.from(_directoryCache),
+        ));
+      } else {
+        emit(const PresetBrowserState.error(
+          message: 'Failed to load directory listing',
+        ));
+      }
+    } catch (e) {
+      emit(PresetBrowserState.error(
+        message: 'Error loading directory: $e',
+      ));
+    }
+  }
+
+  Future<void> selectDirectory(DirectoryEntry entry, PanelPosition panel) async {
+    await state.maybeMap(
+      loaded: (currentState) async {
+        if (!entry.isDirectory) return;
+
+        emit(const PresetBrowserState.loading());
+
+        try {
+          final path = _buildPath(currentState.currentPath, entry.name, panel);
+          
+          // Check cache first
+          List<DirectoryEntry>? entries = _directoryCache[path];
+          
+          if (entries == null) {
+            // Load from device
+            final listing = await midiManager.requestDirectoryListing(path);
+            if (listing != null) {
+              entries = _sortEntries(listing.entries, currentState.sortByDate);
+              _directoryCache[path] = entries;
+            } else {
+              entries = [];
+            }
+          }
+
+          // Update panels based on which panel was clicked
+          final newState = _updatePanelState(currentState, panel, entry, entries);
+          emit(newState);
+        } catch (e) {
+          emit(PresetBrowserState.error(
+            message: 'Error loading directory: $e',
+            lastPath: currentState.currentPath,
+          ));
+        }
+      },
+      orElse: () async {},
+    );
+  }
+
+  Future<void> selectFile(DirectoryEntry entry, PanelPosition panel) async {
+    await state.maybeMap(
+      loaded: (currentState) async {
+        if (entry.isDirectory) return;
+
+        // Build full path for the selected file
+        final path = _buildPath(currentState.currentPath, entry.name, panel);
+        
+        // Add to history
+        await addToHistory(path);
+        
+        // Return the selected preset path to the dialog
+        // This will be handled by the dialog widget
+      },
+      orElse: () async {},
+    );
+  }
+
+  void toggleSortMode() {
+    state.maybeMap(
+      loaded: (currentState) {
+        final newSortByDate = !currentState.sortByDate;
+        
+        emit(currentState.copyWith(
+          sortByDate: newSortByDate,
+          leftPanelItems: _sortEntries(currentState.leftPanelItems, newSortByDate),
+          centerPanelItems: _sortEntries(currentState.centerPanelItems, newSortByDate),
+          rightPanelItems: _sortEntries(currentState.rightPanelItems, newSortByDate),
+        ));
+      },
+      orElse: () {},
+    );
+  }
+
+  Future<void> navigateBack() async {
+    await state.maybeMap(
+      loaded: (currentState) async {
+        if (currentState.navigationHistory.isEmpty) return;
+
+        emit(const PresetBrowserState.loading());
+
+        try {
+          final previousPath = currentState.navigationHistory.last;
+          final newHistory = List<String>.from(currentState.navigationHistory)
+            ..removeLast();
+
+          // Load directory from cache or device
+          List<DirectoryEntry>? entries = _directoryCache[previousPath];
+          
+          if (entries == null) {
+            final listing = await midiManager.requestDirectoryListing(previousPath);
+            if (listing != null) {
+              entries = _sortEntries(listing.entries, currentState.sortByDate);
+              _directoryCache[previousPath] = entries;
+            } else {
+              entries = [];
+            }
+          }
+
+          emit(PresetBrowserState.loaded(
+            currentPath: previousPath,
+            leftPanelItems: entries,
+            centerPanelItems: const [],
+            rightPanelItems: const [],
+            selectedLeftItem: null,
+            selectedCenterItem: null,
+            selectedRightItem: null,
+            navigationHistory: newHistory,
+            sortByDate: currentState.sortByDate,
+            directoryCache: Map.from(_directoryCache),
+          ));
+        } catch (e) {
+          emit(PresetBrowserState.error(
+            message: 'Error navigating back: $e',
+            lastPath: currentState.currentPath,
+          ));
+        }
+      },
+      orElse: () async {},
+    );
+  }
+
+  Future<List<String>> loadRecentPresets() async {
+    return prefs.getStringList(_historyKey) ?? [];
+  }
+
+  Future<void> addToHistory(String presetPath) async {
+    final history = await loadRecentPresets();
+    
+    // Remove if already exists and add to front
+    history.remove(presetPath);
+    history.insert(0, presetPath);
+    
+    // Limit history size
+    if (history.length > _maxHistoryItems) {
+      history.removeRange(_maxHistoryItems, history.length);
+    }
+    
+    await prefs.setStringList(_historyKey, history);
+  }
+
+  Future<void> clearCache() async {
+    _directoryCache.clear();
+  }
+
+  // Helper methods
+  
+  List<DirectoryEntry> _sortEntries(List<DirectoryEntry> entries, bool byDate) {
+    final sorted = List<DirectoryEntry>.from(entries);
+    
+    if (byDate) {
+      sorted.sort((a, b) {
+        // Folders first, then by date/time
+        if (a.isDirectory != b.isDirectory) {
+          return a.isDirectory ? -1 : 1;
+        }
+        // Compare by date first, then time
+        final dateCompare = b.date.compareTo(a.date);
+        if (dateCompare != 0) return dateCompare;
+        return b.time.compareTo(a.time);
+      });
+    } else {
+      sorted.sort((a, b) {
+        // Folders first, then alphabetically
+        if (a.isDirectory != b.isDirectory) {
+          return a.isDirectory ? -1 : 1;
+        }
+        // Remove trailing slash for directories when comparing
+        final aName = a.name.endsWith('/') ? a.name.substring(0, a.name.length - 1) : a.name;
+        final bName = b.name.endsWith('/') ? b.name.substring(0, b.name.length - 1) : b.name;
+        return aName.toLowerCase().compareTo(bName.toLowerCase());
+      });
+    }
+    
+    return sorted;
+  }
+
+  String _buildPath(String currentPath, String entryName, PanelPosition panel) {
+    // Remove trailing slash from entry name if present (directories have it)
+    final cleanName = entryName.endsWith('/') 
+        ? entryName.substring(0, entryName.length - 1) 
+        : entryName;
+    
+    final pathSegments = currentPath.split('/').where((s) => s.isNotEmpty).toList();
+    
+    switch (panel) {
+      case PanelPosition.left:
+        // Replace entire path with new selection
+        if (currentPath == '/' || currentPath == '/presets') {
+          final base = currentPath == '/' ? '' : currentPath;
+          return '$base/$cleanName';
+        }
+        return '/${pathSegments.first}/$cleanName';
+        
+      case PanelPosition.center:
+        // Build path up to second level
+        if (pathSegments.isNotEmpty) {
+          return '/${pathSegments[0]}/$cleanName';
+        }
+        return '/$cleanName';
+        
+      case PanelPosition.right:
+        // Build path up to third level
+        if (pathSegments.length >= 2) {
+          return '/${pathSegments[0]}/${pathSegments[1]}/$cleanName';
+        }
+        return currentPath.endsWith('/') 
+            ? '$currentPath$cleanName' 
+            : '$currentPath/$cleanName';
+    }
+  }
+
+  PresetBrowserState _updatePanelState(
+    dynamic currentState, // Will be _Loaded but can't reference it directly
+    PanelPosition panel,
+    DirectoryEntry selectedEntry,
+    List<DirectoryEntry> newEntries,
+  ) {
+    // Cast the navigation history properly
+    final navHistory = currentState.navigationHistory as List;
+    final currentPath = currentState.currentPath as String;
+    
+    switch (panel) {
+      case PanelPosition.left:
+        return currentState.copyWith(
+          selectedLeftItem: selectedEntry,
+          centerPanelItems: newEntries,
+          rightPanelItems: <DirectoryEntry>[],
+          selectedCenterItem: null,
+          selectedRightItem: null,
+          navigationHistory: [...navHistory.cast<String>(), currentPath],
+        );
+        
+      case PanelPosition.center:
+        return currentState.copyWith(
+          selectedCenterItem: selectedEntry,
+          rightPanelItems: newEntries,
+          selectedRightItem: null,
+        );
+        
+      case PanelPosition.right:
+        return currentState.copyWith(
+          selectedRightItem: selectedEntry,
+        );
+    }
+  }
+
+  String getSelectedPath() {
+    return state.maybeMap(
+      loaded: (currentState) {
+        // Build path from selections
+        if (currentState.selectedRightItem != null && !currentState.selectedRightItem!.isDirectory) {
+          return _buildPath(currentState.currentPath, currentState.selectedRightItem!.name, PanelPosition.right);
+        }
+        if (currentState.selectedCenterItem != null && !currentState.selectedCenterItem!.isDirectory) {
+          return _buildPath(currentState.currentPath, currentState.selectedCenterItem!.name, PanelPosition.center);
+        }
+        if (currentState.selectedLeftItem != null && !currentState.selectedLeftItem!.isDirectory) {
+          return _buildPath(currentState.currentPath, currentState.selectedLeftItem!.name, PanelPosition.left);
+        }
+        
+        return '';
+      },
+      orElse: () => '',
+    );
+  }
+}

--- a/lib/cubit/preset_browser_cubit.dart
+++ b/lib/cubit/preset_browser_cubit.dart
@@ -340,21 +340,44 @@ class PresetBrowserCubit extends Cubit<PresetBrowserState> {
   String getSelectedPath() {
     return state.maybeMap(
       loaded: (currentState) {
-        // Build path from selections - only return if it's a .json file
-        if (currentState.selectedRightItem != null && 
-            !currentState.selectedRightItem!.isDirectory &&
-            currentState.selectedRightItem!.name.toLowerCase().endsWith('.json')) {
-          return _buildPath(currentState.currentPath, currentState.selectedRightItem!.name, PanelPosition.right);
+        // Build the complete path from the base path and selected items
+        String fullPath = currentState.currentPath;
+        
+        // If we have a selected directory in the left panel, add it to the path
+        if (currentState.selectedLeftItem != null && currentState.selectedLeftItem!.isDirectory) {
+          final cleanName = currentState.selectedLeftItem!.name.endsWith('/')
+              ? currentState.selectedLeftItem!.name.substring(0, currentState.selectedLeftItem!.name.length - 1)
+              : currentState.selectedLeftItem!.name;
+          fullPath = fullPath.endsWith('/') ? '$fullPath$cleanName' : '$fullPath/$cleanName';
+          
+          // If we have a selected directory in the center panel, add it too
+          if (currentState.selectedCenterItem != null && currentState.selectedCenterItem!.isDirectory) {
+            final cleanCenterName = currentState.selectedCenterItem!.name.endsWith('/')
+                ? currentState.selectedCenterItem!.name.substring(0, currentState.selectedCenterItem!.name.length - 1)
+                : currentState.selectedCenterItem!.name;
+            fullPath = '$fullPath/$cleanCenterName';
+            
+            // Check if we have a JSON file selected in the right panel
+            if (currentState.selectedRightItem != null && 
+                !currentState.selectedRightItem!.isDirectory &&
+                currentState.selectedRightItem!.name.toLowerCase().endsWith('.json')) {
+              return '$fullPath/${currentState.selectedRightItem!.name}';
+            }
+          }
+          // Check if we have a JSON file selected in the center panel (no directory selected)
+          else if (currentState.selectedCenterItem != null && 
+              !currentState.selectedCenterItem!.isDirectory &&
+              currentState.selectedCenterItem!.name.toLowerCase().endsWith('.json')) {
+            return '$fullPath/${currentState.selectedCenterItem!.name}';
+          }
         }
-        if (currentState.selectedCenterItem != null && 
-            !currentState.selectedCenterItem!.isDirectory &&
-            currentState.selectedCenterItem!.name.toLowerCase().endsWith('.json')) {
-          return _buildPath(currentState.currentPath, currentState.selectedCenterItem!.name, PanelPosition.center);
-        }
-        if (currentState.selectedLeftItem != null && 
+        // Check if we have a JSON file selected in the left panel (no directory selected)
+        else if (currentState.selectedLeftItem != null && 
             !currentState.selectedLeftItem!.isDirectory &&
             currentState.selectedLeftItem!.name.toLowerCase().endsWith('.json')) {
-          return _buildPath(currentState.currentPath, currentState.selectedLeftItem!.name, PanelPosition.left);
+          return fullPath.endsWith('/') 
+              ? '$fullPath${currentState.selectedLeftItem!.name}'
+              : '$fullPath/${currentState.selectedLeftItem!.name}';
         }
         
         return '';

--- a/lib/cubit/preset_browser_state.dart
+++ b/lib/cubit/preset_browser_state.dart
@@ -1,0 +1,33 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:nt_helper/models/sd_card_file_system.dart';
+
+part 'preset_browser_state.freezed.dart';
+
+enum PanelPosition { left, center, right }
+
+enum SortMode { alphabetic, date }
+
+@freezed
+class PresetBrowserState with _$PresetBrowserState {
+  const factory PresetBrowserState.initial() = _Initial;
+
+  const factory PresetBrowserState.loading() = _Loading;
+
+  const factory PresetBrowserState.loaded({
+    required String currentPath,
+    required List<DirectoryEntry> leftPanelItems,
+    required List<DirectoryEntry> centerPanelItems,
+    required List<DirectoryEntry> rightPanelItems,
+    DirectoryEntry? selectedLeftItem,
+    DirectoryEntry? selectedCenterItem,
+    DirectoryEntry? selectedRightItem,
+    required List<String> navigationHistory,
+    required bool sortByDate,
+    Map<String, List<DirectoryEntry>>? directoryCache,
+  }) = _Loaded;
+
+  const factory PresetBrowserState.error({
+    required String message,
+    String? lastPath,
+  }) = _Error;
+}

--- a/lib/cubit/preset_browser_state.freezed.dart
+++ b/lib/cubit/preset_browser_state.freezed.dart
@@ -1,0 +1,440 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'preset_browser_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$PresetBrowserState {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PresetBrowserState);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PresetBrowserState()';
+}
+
+
+}
+
+/// @nodoc
+class $PresetBrowserStateCopyWith<$Res>  {
+$PresetBrowserStateCopyWith(PresetBrowserState _, $Res Function(PresetBrowserState) __);
+}
+
+
+/// Adds pattern-matching-related methods to [PresetBrowserState].
+extension PresetBrowserStatePatterns on PresetBrowserState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( _Initial value)?  initial,TResult Function( _Loading value)?  loading,TResult Function( _Loaded value)?  loaded,TResult Function( _Error value)?  error,required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Initial() when initial != null:
+return initial(_that);case _Loading() when loading != null:
+return loading(_that);case _Loaded() when loaded != null:
+return loaded(_that);case _Error() when error != null:
+return error(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( _Initial value)  initial,required TResult Function( _Loading value)  loading,required TResult Function( _Loaded value)  loaded,required TResult Function( _Error value)  error,}){
+final _that = this;
+switch (_that) {
+case _Initial():
+return initial(_that);case _Loading():
+return loading(_that);case _Loaded():
+return loaded(_that);case _Error():
+return error(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( _Initial value)?  initial,TResult? Function( _Loading value)?  loading,TResult? Function( _Loaded value)?  loaded,TResult? Function( _Error value)?  error,}){
+final _that = this;
+switch (_that) {
+case _Initial() when initial != null:
+return initial(_that);case _Loading() when loading != null:
+return loading(_that);case _Loaded() when loaded != null:
+return loaded(_that);case _Error() when error != null:
+return error(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  initial,TResult Function()?  loading,TResult Function( String currentPath,  List<DirectoryEntry> leftPanelItems,  List<DirectoryEntry> centerPanelItems,  List<DirectoryEntry> rightPanelItems,  DirectoryEntry? selectedLeftItem,  DirectoryEntry? selectedCenterItem,  DirectoryEntry? selectedRightItem,  List<String> navigationHistory,  bool sortByDate,  Map<String, List<DirectoryEntry>>? directoryCache)?  loaded,TResult Function( String message,  String? lastPath)?  error,required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Initial() when initial != null:
+return initial();case _Loading() when loading != null:
+return loading();case _Loaded() when loaded != null:
+return loaded(_that.currentPath,_that.leftPanelItems,_that.centerPanelItems,_that.rightPanelItems,_that.selectedLeftItem,_that.selectedCenterItem,_that.selectedRightItem,_that.navigationHistory,_that.sortByDate,_that.directoryCache);case _Error() when error != null:
+return error(_that.message,_that.lastPath);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  initial,required TResult Function()  loading,required TResult Function( String currentPath,  List<DirectoryEntry> leftPanelItems,  List<DirectoryEntry> centerPanelItems,  List<DirectoryEntry> rightPanelItems,  DirectoryEntry? selectedLeftItem,  DirectoryEntry? selectedCenterItem,  DirectoryEntry? selectedRightItem,  List<String> navigationHistory,  bool sortByDate,  Map<String, List<DirectoryEntry>>? directoryCache)  loaded,required TResult Function( String message,  String? lastPath)  error,}) {final _that = this;
+switch (_that) {
+case _Initial():
+return initial();case _Loading():
+return loading();case _Loaded():
+return loaded(_that.currentPath,_that.leftPanelItems,_that.centerPanelItems,_that.rightPanelItems,_that.selectedLeftItem,_that.selectedCenterItem,_that.selectedRightItem,_that.navigationHistory,_that.sortByDate,_that.directoryCache);case _Error():
+return error(_that.message,_that.lastPath);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  initial,TResult? Function()?  loading,TResult? Function( String currentPath,  List<DirectoryEntry> leftPanelItems,  List<DirectoryEntry> centerPanelItems,  List<DirectoryEntry> rightPanelItems,  DirectoryEntry? selectedLeftItem,  DirectoryEntry? selectedCenterItem,  DirectoryEntry? selectedRightItem,  List<String> navigationHistory,  bool sortByDate,  Map<String, List<DirectoryEntry>>? directoryCache)?  loaded,TResult? Function( String message,  String? lastPath)?  error,}) {final _that = this;
+switch (_that) {
+case _Initial() when initial != null:
+return initial();case _Loading() when loading != null:
+return loading();case _Loaded() when loaded != null:
+return loaded(_that.currentPath,_that.leftPanelItems,_that.centerPanelItems,_that.rightPanelItems,_that.selectedLeftItem,_that.selectedCenterItem,_that.selectedRightItem,_that.navigationHistory,_that.sortByDate,_that.directoryCache);case _Error() when error != null:
+return error(_that.message,_that.lastPath);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _Initial implements PresetBrowserState {
+  const _Initial();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Initial);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PresetBrowserState.initial()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class _Loading implements PresetBrowserState {
+  const _Loading();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Loading);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'PresetBrowserState.loading()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class _Loaded implements PresetBrowserState {
+  const _Loaded({required this.currentPath, required final  List<DirectoryEntry> leftPanelItems, required final  List<DirectoryEntry> centerPanelItems, required final  List<DirectoryEntry> rightPanelItems, this.selectedLeftItem, this.selectedCenterItem, this.selectedRightItem, required final  List<String> navigationHistory, required this.sortByDate, final  Map<String, List<DirectoryEntry>>? directoryCache}): _leftPanelItems = leftPanelItems,_centerPanelItems = centerPanelItems,_rightPanelItems = rightPanelItems,_navigationHistory = navigationHistory,_directoryCache = directoryCache;
+  
+
+ final  String currentPath;
+ final  List<DirectoryEntry> _leftPanelItems;
+ List<DirectoryEntry> get leftPanelItems {
+  if (_leftPanelItems is EqualUnmodifiableListView) return _leftPanelItems;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_leftPanelItems);
+}
+
+ final  List<DirectoryEntry> _centerPanelItems;
+ List<DirectoryEntry> get centerPanelItems {
+  if (_centerPanelItems is EqualUnmodifiableListView) return _centerPanelItems;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_centerPanelItems);
+}
+
+ final  List<DirectoryEntry> _rightPanelItems;
+ List<DirectoryEntry> get rightPanelItems {
+  if (_rightPanelItems is EqualUnmodifiableListView) return _rightPanelItems;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_rightPanelItems);
+}
+
+ final  DirectoryEntry? selectedLeftItem;
+ final  DirectoryEntry? selectedCenterItem;
+ final  DirectoryEntry? selectedRightItem;
+ final  List<String> _navigationHistory;
+ List<String> get navigationHistory {
+  if (_navigationHistory is EqualUnmodifiableListView) return _navigationHistory;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_navigationHistory);
+}
+
+ final  bool sortByDate;
+ final  Map<String, List<DirectoryEntry>>? _directoryCache;
+ Map<String, List<DirectoryEntry>>? get directoryCache {
+  final value = _directoryCache;
+  if (value == null) return null;
+  if (_directoryCache is EqualUnmodifiableMapView) return _directoryCache;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+
+/// Create a copy of PresetBrowserState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$LoadedCopyWith<_Loaded> get copyWith => __$LoadedCopyWithImpl<_Loaded>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Loaded&&(identical(other.currentPath, currentPath) || other.currentPath == currentPath)&&const DeepCollectionEquality().equals(other._leftPanelItems, _leftPanelItems)&&const DeepCollectionEquality().equals(other._centerPanelItems, _centerPanelItems)&&const DeepCollectionEquality().equals(other._rightPanelItems, _rightPanelItems)&&(identical(other.selectedLeftItem, selectedLeftItem) || other.selectedLeftItem == selectedLeftItem)&&(identical(other.selectedCenterItem, selectedCenterItem) || other.selectedCenterItem == selectedCenterItem)&&(identical(other.selectedRightItem, selectedRightItem) || other.selectedRightItem == selectedRightItem)&&const DeepCollectionEquality().equals(other._navigationHistory, _navigationHistory)&&(identical(other.sortByDate, sortByDate) || other.sortByDate == sortByDate)&&const DeepCollectionEquality().equals(other._directoryCache, _directoryCache));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,currentPath,const DeepCollectionEquality().hash(_leftPanelItems),const DeepCollectionEquality().hash(_centerPanelItems),const DeepCollectionEquality().hash(_rightPanelItems),selectedLeftItem,selectedCenterItem,selectedRightItem,const DeepCollectionEquality().hash(_navigationHistory),sortByDate,const DeepCollectionEquality().hash(_directoryCache));
+
+@override
+String toString() {
+  return 'PresetBrowserState.loaded(currentPath: $currentPath, leftPanelItems: $leftPanelItems, centerPanelItems: $centerPanelItems, rightPanelItems: $rightPanelItems, selectedLeftItem: $selectedLeftItem, selectedCenterItem: $selectedCenterItem, selectedRightItem: $selectedRightItem, navigationHistory: $navigationHistory, sortByDate: $sortByDate, directoryCache: $directoryCache)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$LoadedCopyWith<$Res> implements $PresetBrowserStateCopyWith<$Res> {
+  factory _$LoadedCopyWith(_Loaded value, $Res Function(_Loaded) _then) = __$LoadedCopyWithImpl;
+@useResult
+$Res call({
+ String currentPath, List<DirectoryEntry> leftPanelItems, List<DirectoryEntry> centerPanelItems, List<DirectoryEntry> rightPanelItems, DirectoryEntry? selectedLeftItem, DirectoryEntry? selectedCenterItem, DirectoryEntry? selectedRightItem, List<String> navigationHistory, bool sortByDate, Map<String, List<DirectoryEntry>>? directoryCache
+});
+
+
+
+
+}
+/// @nodoc
+class __$LoadedCopyWithImpl<$Res>
+    implements _$LoadedCopyWith<$Res> {
+  __$LoadedCopyWithImpl(this._self, this._then);
+
+  final _Loaded _self;
+  final $Res Function(_Loaded) _then;
+
+/// Create a copy of PresetBrowserState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? currentPath = null,Object? leftPanelItems = null,Object? centerPanelItems = null,Object? rightPanelItems = null,Object? selectedLeftItem = freezed,Object? selectedCenterItem = freezed,Object? selectedRightItem = freezed,Object? navigationHistory = null,Object? sortByDate = null,Object? directoryCache = freezed,}) {
+  return _then(_Loaded(
+currentPath: null == currentPath ? _self.currentPath : currentPath // ignore: cast_nullable_to_non_nullable
+as String,leftPanelItems: null == leftPanelItems ? _self._leftPanelItems : leftPanelItems // ignore: cast_nullable_to_non_nullable
+as List<DirectoryEntry>,centerPanelItems: null == centerPanelItems ? _self._centerPanelItems : centerPanelItems // ignore: cast_nullable_to_non_nullable
+as List<DirectoryEntry>,rightPanelItems: null == rightPanelItems ? _self._rightPanelItems : rightPanelItems // ignore: cast_nullable_to_non_nullable
+as List<DirectoryEntry>,selectedLeftItem: freezed == selectedLeftItem ? _self.selectedLeftItem : selectedLeftItem // ignore: cast_nullable_to_non_nullable
+as DirectoryEntry?,selectedCenterItem: freezed == selectedCenterItem ? _self.selectedCenterItem : selectedCenterItem // ignore: cast_nullable_to_non_nullable
+as DirectoryEntry?,selectedRightItem: freezed == selectedRightItem ? _self.selectedRightItem : selectedRightItem // ignore: cast_nullable_to_non_nullable
+as DirectoryEntry?,navigationHistory: null == navigationHistory ? _self._navigationHistory : navigationHistory // ignore: cast_nullable_to_non_nullable
+as List<String>,sortByDate: null == sortByDate ? _self.sortByDate : sortByDate // ignore: cast_nullable_to_non_nullable
+as bool,directoryCache: freezed == directoryCache ? _self._directoryCache : directoryCache // ignore: cast_nullable_to_non_nullable
+as Map<String, List<DirectoryEntry>>?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class _Error implements PresetBrowserState {
+  const _Error({required this.message, this.lastPath});
+  
+
+ final  String message;
+ final  String? lastPath;
+
+/// Create a copy of PresetBrowserState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ErrorCopyWith<_Error> get copyWith => __$ErrorCopyWithImpl<_Error>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Error&&(identical(other.message, message) || other.message == message)&&(identical(other.lastPath, lastPath) || other.lastPath == lastPath));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,message,lastPath);
+
+@override
+String toString() {
+  return 'PresetBrowserState.error(message: $message, lastPath: $lastPath)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ErrorCopyWith<$Res> implements $PresetBrowserStateCopyWith<$Res> {
+  factory _$ErrorCopyWith(_Error value, $Res Function(_Error) _then) = __$ErrorCopyWithImpl;
+@useResult
+$Res call({
+ String message, String? lastPath
+});
+
+
+
+
+}
+/// @nodoc
+class __$ErrorCopyWithImpl<$Res>
+    implements _$ErrorCopyWith<$Res> {
+  __$ErrorCopyWithImpl(this._self, this._then);
+
+  final _Error _self;
+  final $Res Function(_Error) _then;
+
+/// Create a copy of PresetBrowserState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? message = null,Object? lastPath = freezed,}) {
+  return _then(_Error(
+message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,lastPath: freezed == lastPath ? _self.lastPath : lastPath // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/ui/widgets/preset_browser_dialog.dart
+++ b/lib/ui/widgets/preset_browser_dialog.dart
@@ -1,0 +1,325 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:nt_helper/cubit/preset_browser_cubit.dart';
+import 'package:nt_helper/models/sd_card_file_system.dart';
+import 'package:nt_helper/ui/widgets/load_preset_dialog.dart';
+
+class PresetBrowserDialog extends StatefulWidget {
+  const PresetBrowserDialog({super.key});
+
+  @override
+  State<PresetBrowserDialog> createState() => _PresetBrowserDialogState();
+}
+
+class _PresetBrowserDialogState extends State<PresetBrowserDialog> {
+  @override
+  void initState() {
+    super.initState();
+    // Load root directory when dialog opens
+    context.read<PresetBrowserCubit>().loadRootDirectory();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Row(
+        children: [
+          const Text('Browse Presets'),
+          const Spacer(),
+          // Navigation controls
+          BlocBuilder<PresetBrowserCubit, PresetBrowserState>(
+            builder: (context, state) {
+              return Row(
+                children: [
+                  // Back button
+                  state.maybeMap(
+                    loaded: (loaded) => loaded.navigationHistory.isNotEmpty
+                        ? IconButton(
+                            icon: const Icon(Icons.arrow_back),
+                            onPressed: () {
+                              context.read<PresetBrowserCubit>().navigateBack();
+                            },
+                            tooltip: 'Back',
+                          )
+                        : const SizedBox.shrink(),
+                    orElse: () => const SizedBox.shrink(),
+                  ),
+                  // Sort toggle
+                  state.maybeMap(
+                    loaded: (loaded) => IconButton(
+                      icon: Icon(
+                        loaded.sortByDate ? Icons.date_range : Icons.sort_by_alpha,
+                      ),
+                      onPressed: () {
+                        context.read<PresetBrowserCubit>().toggleSortMode();
+                      },
+                      tooltip: loaded.sortByDate ? 'Sort by date' : 'Sort alphabetically',
+                    ),
+                    orElse: () => const SizedBox.shrink(),
+                  ),
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+      content: SizedBox(
+        width: MediaQuery.of(context).size.width * 0.8,
+        height: MediaQuery.of(context).size.height * 0.6,
+        child: Column(
+          children: [
+            // Main content area
+            Expanded(
+              child: BlocBuilder<PresetBrowserCubit, PresetBrowserState>(
+                builder: (context, state) {
+                  return state.map(
+                    initial: (_) => const Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                    loading: (_) => const Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                    loaded: (loaded) => ThreePanelNavigator(
+                      leftPanelItems: loaded.leftPanelItems,
+                      centerPanelItems: loaded.centerPanelItems,
+                      rightPanelItems: loaded.rightPanelItems,
+                      selectedLeftItem: loaded.selectedLeftItem,
+                      selectedCenterItem: loaded.selectedCenterItem,
+                      selectedRightItem: loaded.selectedRightItem,
+                      onItemSelected: _handleItemSelected,
+                    ),
+                    error: (error) => Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const Icon(
+                            Icons.error_outline,
+                            color: Colors.red,
+                            size: 48,
+                          ),
+                          const SizedBox(height: 16),
+                          Text(
+                            error.message,
+                            textAlign: TextAlign.center,
+                          ),
+                          const SizedBox(height: 16),
+                          ElevatedButton(
+                            onPressed: () {
+                              context.read<PresetBrowserCubit>().loadRootDirectory();
+                            },
+                            child: const Text('Retry'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+            // Progress indicator bar
+            BlocBuilder<PresetBrowserCubit, PresetBrowserState>(
+              builder: (context, state) {
+                return state.maybeMap(
+                  loading: (_) => const SizedBox(
+                    height: 8,
+                    child: LinearProgressIndicator(),
+                  ),
+                  orElse: () => const SizedBox(height: 8),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Text('Cancel'),
+        ),
+        BlocBuilder<PresetBrowserCubit, PresetBrowserState>(
+          builder: (context, state) {
+            final selectedPath = context.read<PresetBrowserCubit>().getSelectedPath();
+            return ElevatedButton(
+              onPressed: selectedPath.isNotEmpty
+                  ? () {
+                      Navigator.of(context).pop({
+                        'sdCardPath': selectedPath,
+                        'action': PresetAction.load,
+                        'displayName': selectedPath.split('/').last,
+                      });
+                    }
+                  : null,
+              child: const Text('Load'),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  void _handleItemSelected(DirectoryEntry item, PanelPosition position) {
+    final cubit = context.read<PresetBrowserCubit>();
+    
+    if (item.isDirectory) {
+      cubit.selectDirectory(item, position);
+    } else {
+      cubit.selectFile(item, position);
+      // Update the state to enable the Load button
+      setState(() {});
+    }
+  }
+}
+
+class ThreePanelNavigator extends StatelessWidget {
+  final List<DirectoryEntry> leftPanelItems;
+  final List<DirectoryEntry> centerPanelItems;
+  final List<DirectoryEntry> rightPanelItems;
+  final DirectoryEntry? selectedLeftItem;
+  final DirectoryEntry? selectedCenterItem;
+  final DirectoryEntry? selectedRightItem;
+  final Function(DirectoryEntry, PanelPosition) onItemSelected;
+
+  const ThreePanelNavigator({
+    super.key,
+    required this.leftPanelItems,
+    required this.centerPanelItems,
+    required this.rightPanelItems,
+    this.selectedLeftItem,
+    this.selectedCenterItem,
+    this.selectedRightItem,
+    required this.onItemSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: DirectoryPanel(
+            items: leftPanelItems,
+            selectedItem: selectedLeftItem,
+            onItemTap: (item) => onItemSelected(item, PanelPosition.left),
+            position: PanelPosition.left,
+          ),
+        ),
+        const VerticalDivider(width: 1),
+        Expanded(
+          child: DirectoryPanel(
+            items: centerPanelItems,
+            selectedItem: selectedCenterItem,
+            onItemTap: (item) => onItemSelected(item, PanelPosition.center),
+            position: PanelPosition.center,
+          ),
+        ),
+        const VerticalDivider(width: 1),
+        Expanded(
+          child: DirectoryPanel(
+            items: rightPanelItems,
+            selectedItem: selectedRightItem,
+            onItemTap: (item) => onItemSelected(item, PanelPosition.right),
+            position: PanelPosition.right,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class DirectoryPanel extends StatelessWidget {
+  final List<DirectoryEntry> items;
+  final DirectoryEntry? selectedItem;
+  final Function(DirectoryEntry) onItemTap;
+  final PanelPosition position;
+
+  const DirectoryPanel({
+    super.key,
+    required this.items,
+    required this.selectedItem,
+    required this.onItemTap,
+    required this.position,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) {
+      return Container(
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface,
+          border: Border.all(
+            color: Theme.of(context).dividerColor,
+            width: 0.5,
+          ),
+        ),
+        child: const Center(
+          child: Text(
+            'Empty',
+            style: TextStyle(
+              color: Colors.grey,
+              fontStyle: FontStyle.italic,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        border: Border.all(
+          color: Theme.of(context).dividerColor,
+          width: 0.5,
+        ),
+      ),
+      child: ListView.builder(
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          final item = items[index];
+          final isSelected = item == selectedItem;
+          
+          // Clean up the display name
+          String displayName = item.name;
+          if (displayName.endsWith('/')) {
+            displayName = displayName.substring(0, displayName.length - 1);
+          }
+          
+          return ListTile(
+            leading: Icon(
+              item.isDirectory ? Icons.folder : Icons.insert_drive_file,
+              color: item.isDirectory
+                  ? Theme.of(context).colorScheme.primary
+                  : Theme.of(context).colorScheme.secondary,
+            ),
+            title: Text(
+              displayName,
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+              ),
+            ),
+            subtitle: !item.isDirectory
+                ? Text(
+                    _formatFileSize(item.size),
+                    style: const TextStyle(fontSize: 12),
+                  )
+                : null,
+            selected: isSelected,
+            selectedTileColor: Theme.of(context).colorScheme.primaryContainer,
+            onTap: () => onItemTap(item),
+            dense: true,
+          );
+        },
+      ),
+    );
+  }
+
+  String _formatFileSize(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    if (bytes < 1024 * 1024 * 1024) {
+      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+    }
+    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
+  }
+}

--- a/lib/ui/widgets/preset_browser_dialog.dart
+++ b/lib/ui/widgets/preset_browser_dialog.dart
@@ -284,12 +284,20 @@ class DirectoryPanel extends StatelessWidget {
             displayName = displayName.substring(0, displayName.length - 1);
           }
           
+          final isJsonPreset = !item.isDirectory && item.name.toLowerCase().endsWith('.json');
+          
           return ListTile(
             leading: Icon(
-              item.isDirectory ? Icons.folder : Icons.insert_drive_file,
+              item.isDirectory 
+                  ? Icons.folder 
+                  : isJsonPreset 
+                      ? Icons.music_note 
+                      : Icons.insert_drive_file,
               color: item.isDirectory
                   ? Theme.of(context).colorScheme.primary
-                  : Theme.of(context).colorScheme.secondary,
+                  : isJsonPreset
+                      ? Theme.of(context).colorScheme.tertiary
+                      : Theme.of(context).colorScheme.secondary,
             ),
             title: Text(
               displayName,

--- a/test/cubit/preset_browser_cubit_test.dart
+++ b/test/cubit/preset_browser_cubit_test.dart
@@ -1,0 +1,279 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/cubit/preset_browser_cubit.dart';
+import 'package:nt_helper/domain/i_disting_midi_manager.dart';
+import 'package:nt_helper/models/sd_card_file_system.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MockDistingMidiManager extends Mock implements IDistingMidiManager {}
+
+class MockSharedPreferences extends Mock implements SharedPreferences {}
+
+void main() {
+  late PresetBrowserCubit cubit;
+  late MockDistingMidiManager mockMidiManager;
+  late MockSharedPreferences mockPrefs;
+
+  setUp(() {
+    mockMidiManager = MockDistingMidiManager();
+    mockPrefs = MockSharedPreferences();
+    cubit = PresetBrowserCubit(
+      midiManager: mockMidiManager,
+      prefs: mockPrefs,
+    );
+  });
+
+  tearDown(() {
+    cubit.close();
+  });
+
+  group('PresetBrowserCubit', () {
+    test('initial state is correct', () {
+      expect(cubit.state, const PresetBrowserState.initial());
+    });
+
+    group('loadRootDirectory', () {
+      blocTest<PresetBrowserCubit, PresetBrowserState>(
+        'emits loading then loaded with presets directory when it exists',
+        build: () {
+          when(() => mockMidiManager.requestDirectoryListing('/presets'))
+              .thenAnswer((_) async => DirectoryListing(
+                    entries: [
+                      DirectoryEntry(
+                        name: 'Factory/',
+                        attributes: 0x10, // Directory attribute
+                        date: 0,
+                        time: 0,
+                        size: 0,
+                      ),
+                      DirectoryEntry(
+                        name: 'User/',
+                        attributes: 0x10, // Directory attribute
+                        date: 0,
+                        time: 0,
+                        size: 0,
+                      ),
+                    ],
+                  ));
+          return cubit;
+        },
+        act: (cubit) => cubit.loadRootDirectory(),
+        expect: () => [
+          const PresetBrowserState.loading(),
+          isA<PresetBrowserState>().having(
+            (s) => s.maybeMap(
+              loaded: (loaded) => loaded.currentPath,
+              orElse: () => null,
+            ),
+            'currentPath',
+            '/presets',
+          ),
+        ],
+      );
+
+      blocTest<PresetBrowserCubit, PresetBrowserState>(
+        'emits loading then loaded with root directory when presets does not exist',
+        build: () {
+          when(() => mockMidiManager.requestDirectoryListing('/presets'))
+              .thenAnswer((_) async => null);
+          when(() => mockMidiManager.requestDirectoryListing('/'))
+              .thenAnswer((_) async => DirectoryListing(
+                    entries: [
+                      DirectoryEntry(
+                        name: 'System/',
+                        attributes: 0x10, // Directory attribute
+                        date: 0,
+                        time: 0,
+                        size: 0,
+                      ),
+                    ],
+                  ));
+          return cubit;
+        },
+        act: (cubit) => cubit.loadRootDirectory(),
+        expect: () => [
+          const PresetBrowserState.loading(),
+          isA<PresetBrowserState>().having(
+            (s) => s.maybeMap(
+              loaded: (loaded) => loaded.currentPath,
+              orElse: () => null,
+            ),
+            'currentPath',
+            '/',
+          ),
+        ],
+      );
+
+      blocTest<PresetBrowserCubit, PresetBrowserState>(
+        'emits error when directory listing fails',
+        build: () {
+          when(() => mockMidiManager.requestDirectoryListing(any()))
+              .thenThrow(Exception('Network error'));
+          return cubit;
+        },
+        act: (cubit) => cubit.loadRootDirectory(),
+        expect: () => [
+          const PresetBrowserState.loading(),
+          isA<PresetBrowserState>().having(
+            (s) => s.maybeMap(
+              error: (error) => error.message,
+              orElse: () => null,
+            ),
+            'error message',
+            contains('Network error'),
+          ),
+        ],
+      );
+    });
+
+    group('selectDirectory', () {
+      final testEntry = DirectoryEntry(
+        name: 'TestFolder/',
+        attributes: 0x10,
+        date: 0,
+        time: 0,
+        size: 0,
+      );
+
+      blocTest<PresetBrowserCubit, PresetBrowserState>(
+        'loads directory contents and updates panel states',
+        build: () {
+          when(() => mockMidiManager.requestDirectoryListing('/presets/TestFolder'))
+              .thenAnswer((_) async => DirectoryListing(
+                    entries: [
+                      DirectoryEntry(
+                        name: 'preset1.json',
+                        attributes: 0, // File attribute
+                        date: 0,
+                        time: 0,
+                        size: 1024,
+                      ),
+                    ],
+                  ));
+          return cubit;
+        },
+        seed: () => PresetBrowserState.loaded(
+          currentPath: '/presets',
+          leftPanelItems: [testEntry],
+          centerPanelItems: const [],
+          rightPanelItems: const [],
+          selectedLeftItem: null,
+          selectedCenterItem: null,
+          selectedRightItem: null,
+          navigationHistory: const [],
+          sortByDate: false,
+        ),
+        act: (cubit) => cubit.selectDirectory(testEntry, PanelPosition.left),
+        expect: () => [
+          isA<PresetBrowserState>().having(
+            (s) => s.maybeMap(
+              loading: (_) => true,
+              orElse: () => false,
+            ),
+            'is loading',
+            true,
+          ),
+          isA<PresetBrowserState>().having(
+            (s) => s.maybeMap(
+              loaded: (loaded) => loaded.selectedLeftItem?.name,
+              orElse: () => null,
+            ),
+            'selected left item',
+            'TestFolder/',
+          ),
+        ],
+      );
+    });
+
+    group('toggleSortMode', () {
+      blocTest<PresetBrowserCubit, PresetBrowserState>(
+        'toggles between alphabetic and date sorting',
+        build: () => cubit,
+        seed: () => PresetBrowserState.loaded(
+          currentPath: '/',
+          leftPanelItems: [],
+          centerPanelItems: const [],
+          rightPanelItems: const [],
+          selectedLeftItem: null,
+          selectedCenterItem: null,
+          selectedRightItem: null,
+          navigationHistory: const [],
+          sortByDate: false,
+        ),
+        act: (cubit) => cubit.toggleSortMode(),
+        expect: () => [
+          isA<PresetBrowserState>().having(
+            (s) => s.maybeMap(
+              loaded: (loaded) => loaded.sortByDate,
+              orElse: () => false,
+            ),
+            'sort by date',
+            true,
+          ),
+        ],
+      );
+    });
+
+    group('navigateBack', () {
+      blocTest<PresetBrowserCubit, PresetBrowserState>(
+        'navigates to previous directory in history',
+        build: () {
+          when(() => mockMidiManager.requestDirectoryListing('/presets'))
+              .thenAnswer((_) async => DirectoryListing(
+                    entries: [],
+                  ));
+          return cubit;
+        },
+        seed: () => PresetBrowserState.loaded(
+          currentPath: '/presets/Factory',
+          leftPanelItems: [],
+          centerPanelItems: const [],
+          rightPanelItems: const [],
+          selectedLeftItem: null,
+          selectedCenterItem: null,
+          selectedRightItem: null,
+          navigationHistory: ['/presets'],
+          sortByDate: false,
+        ),
+        act: (cubit) => cubit.navigateBack(),
+        expect: () => [
+          const PresetBrowserState.loading(),
+          isA<PresetBrowserState>().having(
+            (s) => s.maybeMap(
+              loaded: (loaded) => loaded.currentPath,
+              orElse: () => null,
+            ),
+            'current path',
+            '/presets',
+          ),
+        ],
+      );
+    });
+
+    group('preset history', () {
+      test('loadRecentPresets loads from SharedPreferences', () async {
+        when(() => mockPrefs.getStringList('presetHistory'))
+            .thenReturn(['/presets/recent1.json', '/presets/recent2.json']);
+
+        final recent = await cubit.loadRecentPresets();
+
+        expect(recent, ['/presets/recent1.json', '/presets/recent2.json']);
+      });
+
+      test('addToHistory saves to SharedPreferences', () async {
+        when(() => mockPrefs.getStringList('presetHistory'))
+            .thenReturn(['/presets/old.json']);
+        when(() => mockPrefs.setStringList('presetHistory', any()))
+            .thenAnswer((_) async => true);
+
+        await cubit.addToHistory('/presets/new.json');
+
+        verify(() => mockPrefs.setStringList(
+              'presetHistory',
+              ['/presets/new.json', '/presets/old.json'],
+            )).called(1);
+      });
+    });
+  });
+}

--- a/test/cubit/preset_browser_cubit_test.dart
+++ b/test/cubit/preset_browser_cubit_test.dart
@@ -251,6 +251,118 @@ void main() {
       );
     });
 
+    group('getSelectedPath', () {
+      test('returns full path when file is selected in right panel', () {
+        cubit.emit(PresetBrowserState.loaded(
+          currentPath: '/presets',
+          leftPanelItems: [],
+          centerPanelItems: [],
+          rightPanelItems: [],
+          selectedLeftItem: DirectoryEntry(
+            name: 'Factory/',
+            attributes: 0x10,
+            date: 0,
+            time: 0,
+            size: 0,
+          ),
+          selectedCenterItem: DirectoryEntry(
+            name: 'Synths/',
+            attributes: 0x10,
+            date: 0,
+            time: 0,
+            size: 0,
+          ),
+          selectedRightItem: DirectoryEntry(
+            name: 'lead.json',
+            attributes: 0,
+            date: 0,
+            time: 0,
+            size: 1024,
+          ),
+          navigationHistory: [],
+          sortByDate: false,
+        ));
+
+        final path = cubit.getSelectedPath();
+        expect(path, '/presets/Factory/Synths/lead.json');
+      });
+
+      test('returns full path when file is selected in center panel', () {
+        cubit.emit(PresetBrowserState.loaded(
+          currentPath: '/presets',
+          leftPanelItems: [],
+          centerPanelItems: [],
+          rightPanelItems: [],
+          selectedLeftItem: DirectoryEntry(
+            name: 'User/',
+            attributes: 0x10,
+            date: 0,
+            time: 0,
+            size: 0,
+          ),
+          selectedCenterItem: DirectoryEntry(
+            name: 'preset.json',
+            attributes: 0,
+            date: 0,
+            time: 0,
+            size: 2048,
+          ),
+          selectedRightItem: null,
+          navigationHistory: [],
+          sortByDate: false,
+        ));
+
+        final path = cubit.getSelectedPath();
+        expect(path, '/presets/User/preset.json');
+      });
+
+      test('returns full path when file is selected in left panel', () {
+        cubit.emit(PresetBrowserState.loaded(
+          currentPath: '/presets',
+          leftPanelItems: [],
+          centerPanelItems: [],
+          rightPanelItems: [],
+          selectedLeftItem: DirectoryEntry(
+            name: 'default.json',
+            attributes: 0,
+            date: 0,
+            time: 0,
+            size: 512,
+          ),
+          selectedCenterItem: null,
+          selectedRightItem: null,
+          navigationHistory: [],
+          sortByDate: false,
+        ));
+
+        final path = cubit.getSelectedPath();
+        expect(path, '/presets/default.json');
+      });
+
+      test('returns empty string when no JSON file is selected', () {
+        cubit.emit(PresetBrowserState.loaded(
+          currentPath: '/presets',
+          leftPanelItems: [],
+          centerPanelItems: [],
+          rightPanelItems: [],
+          selectedLeftItem: DirectoryEntry(
+            name: 'Factory/',
+            attributes: 0x10,
+            date: 0,
+            time: 0,
+            size: 0,
+          ),
+          selectedCenterItem: null,
+          selectedRightItem: null,
+          navigationHistory: [],
+          sortByDate: false,
+        ));
+
+        final path = cubit.getSelectedPath();
+        expect(path, '');
+      });
+    });
+
     group('preset history', () {
       test('loadRecentPresets loads from SharedPreferences', () async {
         when(() => mockPrefs.getStringList('presetHistory'))

--- a/test/ui/widgets/preset_browser_dialog_test.dart
+++ b/test/ui/widgets/preset_browser_dialog_test.dart
@@ -271,19 +271,27 @@ void main() {
     });
 
     testWidgets('displays file icons for files', (tester) async {
-      final testFile = DirectoryEntry(
-        name: 'file.json',
+      final testJsonFile = DirectoryEntry(
+        name: 'preset.json',
         attributes: 0,
         date: 0,
         time: 0,
         size: 1024,
+      );
+      
+      final testOtherFile = DirectoryEntry(
+        name: 'readme.txt',
+        attributes: 0,
+        date: 0,
+        time: 0,
+        size: 512,
       );
 
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: DirectoryPanel(
-              items: [testFile],
+              items: [testJsonFile, testOtherFile],
               selectedItem: null,
               onItemTap: (_) {},
               position: PanelPosition.left,
@@ -292,6 +300,9 @@ void main() {
         ),
       );
 
+      // JSON files should show music note icon
+      expect(find.byIcon(Icons.music_note), findsOneWidget);
+      // Other files should show generic file icon
       expect(find.byIcon(Icons.insert_drive_file), findsOneWidget);
     });
 

--- a/test/ui/widgets/preset_browser_dialog_test.dart
+++ b/test/ui/widgets/preset_browser_dialog_test.dart
@@ -1,0 +1,325 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/cubit/preset_browser_cubit.dart';
+import 'package:nt_helper/ui/widgets/preset_browser_dialog.dart';
+import 'package:nt_helper/models/sd_card_file_system.dart';
+import 'package:nt_helper/domain/i_disting_midi_manager.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MockPresetBrowserCubit extends Mock implements PresetBrowserCubit {}
+
+class MockDistingMidiManager extends Mock implements IDistingMidiManager {}
+
+class MockSharedPreferences extends Mock implements SharedPreferences {}
+
+class FakeDirectoryEntry extends Fake implements DirectoryEntry {}
+
+void main() {
+  late MockPresetBrowserCubit mockCubit;
+
+  setUpAll(() {
+    registerFallbackValue(FakeDirectoryEntry());
+    registerFallbackValue(PanelPosition.left);
+  });
+
+  setUp(() {
+    mockCubit = MockPresetBrowserCubit();
+    // Mock loadRootDirectory to return a Future<void>
+    when(() => mockCubit.loadRootDirectory()).thenAnswer((_) async {});
+    // Mock getSelectedPath to return empty string by default
+    when(() => mockCubit.getSelectedPath()).thenReturn('');
+  });
+
+  Widget createTestWidget({required Widget child}) {
+    return MaterialApp(
+      home: BlocProvider<PresetBrowserCubit>.value(
+        value: mockCubit,
+        child: child,
+      ),
+    );
+  }
+
+  group('PresetBrowserDialog', () {
+    testWidgets('displays three panels in row layout', (tester) async {
+      when(() => mockCubit.state).thenReturn(
+        PresetBrowserState.loaded(
+          currentPath: '/presets',
+          leftPanelItems: const [],
+          centerPanelItems: const [],
+          rightPanelItems: const [],
+          selectedLeftItem: null,
+          selectedCenterItem: null,
+          selectedRightItem: null,
+          navigationHistory: const [],
+          sortByDate: false,
+        ),
+      );
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      await tester.pumpWidget(
+        createTestWidget(
+          child: const PresetBrowserDialog(),
+        ),
+      );
+
+      // Should find three panel containers
+      expect(find.byType(DirectoryPanel), findsNWidgets(3));
+      
+      // Should be in a Row
+      expect(
+        find.descendant(
+          of: find.byType(Row),
+          matching: find.byType(DirectoryPanel),
+        ),
+        findsNWidgets(3),
+      );
+    });
+
+    testWidgets('displays loading indicator when loading', (tester) async {
+      when(() => mockCubit.state).thenReturn(
+        const PresetBrowserState.loading(),
+      );
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      await tester.pumpWidget(
+        createTestWidget(
+          child: const PresetBrowserDialog(),
+        ),
+      );
+
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('displays error message when error state', (tester) async {
+      when(() => mockCubit.state).thenReturn(
+        const PresetBrowserState.error(
+          message: 'Test error message',
+        ),
+      );
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      await tester.pumpWidget(
+        createTestWidget(
+          child: const PresetBrowserDialog(),
+        ),
+      );
+
+      expect(find.text('Test error message'), findsOneWidget);
+    });
+
+    testWidgets('displays back button and sort toggle', (tester) async {
+      when(() => mockCubit.state).thenReturn(
+        PresetBrowserState.loaded(
+          currentPath: '/presets',
+          leftPanelItems: const [],
+          centerPanelItems: const [],
+          rightPanelItems: const [],
+          selectedLeftItem: null,
+          selectedCenterItem: null,
+          selectedRightItem: null,
+          navigationHistory: const ['/'],
+          sortByDate: false,
+        ),
+      );
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      await tester.pumpWidget(
+        createTestWidget(
+          child: const PresetBrowserDialog(),
+        ),
+      );
+
+      // Mock the navigateBack and toggleSortMode methods
+      when(() => mockCubit.navigateBack()).thenAnswer((_) async {});
+      when(() => mockCubit.toggleSortMode()).thenReturn(null);
+      
+      // Back button should be visible when history exists
+      expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+      
+      // Sort toggle should be visible
+      expect(find.byIcon(Icons.sort_by_alpha), findsOneWidget);
+    });
+
+    testWidgets('calls selectDirectory when directory tapped', (tester) async {
+      final testEntry = DirectoryEntry(
+        name: 'TestFolder/',
+        attributes: 0x10,
+        date: 0,
+        time: 0,
+        size: 0,
+      );
+
+      when(() => mockCubit.state).thenReturn(
+        PresetBrowserState.loaded(
+          currentPath: '/presets',
+          leftPanelItems: [testEntry],
+          centerPanelItems: const [],
+          rightPanelItems: const [],
+          selectedLeftItem: null,
+          selectedCenterItem: null,
+          selectedRightItem: null,
+          navigationHistory: const [],
+          sortByDate: false,
+        ),
+      );
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+      when(() => mockCubit.selectDirectory(any(), any())).thenAnswer((_) async {});
+
+      await tester.pumpWidget(
+        createTestWidget(
+          child: Scaffold(
+            body: ThreePanelNavigator(
+              leftPanelItems: [testEntry],
+              centerPanelItems: const [],
+              rightPanelItems: const [],
+              selectedLeftItem: null,
+              selectedCenterItem: null,
+              selectedRightItem: null,
+              onItemSelected: (item, position) {
+                mockCubit.selectDirectory(item, position);
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Clean the display name (remove trailing slash) - widget shows "TestFolder" not "TestFolder/"
+      await tester.tap(find.text('TestFolder'));
+      await tester.pumpAndSettle();
+
+      verify(() => mockCubit.selectDirectory(testEntry, PanelPosition.left)).called(1);
+    });
+
+    testWidgets('calls selectFile when file tapped', (tester) async {
+      final testFile = DirectoryEntry(
+        name: 'preset.json',
+        attributes: 0,
+        date: 0,
+        time: 0,
+        size: 1024,
+      );
+
+      when(() => mockCubit.state).thenReturn(
+        PresetBrowserState.loaded(
+          currentPath: '/presets',
+          leftPanelItems: [testFile],
+          centerPanelItems: const [],
+          rightPanelItems: const [],
+          selectedLeftItem: null,
+          selectedCenterItem: null,
+          selectedRightItem: null,
+          navigationHistory: const [],
+          sortByDate: false,
+        ),
+      );
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+      when(() => mockCubit.getSelectedPath()).thenReturn('/presets/preset.json');
+      when(() => mockCubit.selectFile(any(), any())).thenAnswer((_) async {});
+
+      await tester.pumpWidget(
+        createTestWidget(
+          child: Scaffold(
+            body: ThreePanelNavigator(
+              leftPanelItems: [testFile],
+              centerPanelItems: const [],
+              rightPanelItems: const [],
+              selectedLeftItem: null,
+              selectedCenterItem: null,
+              selectedRightItem: null,
+              onItemSelected: (item, position) {
+                mockCubit.selectFile(item, position);
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Tap on the file
+      await tester.tap(find.text('preset.json'));
+      await tester.pumpAndSettle();
+
+      verify(() => mockCubit.selectFile(testFile, PanelPosition.left)).called(1);
+    });
+  });
+
+  group('DirectoryPanel', () {
+    testWidgets('displays folder icons for directories', (tester) async {
+      final testDirectory = DirectoryEntry(
+        name: 'Folder/',
+        attributes: 0x10,
+        date: 0,
+        time: 0,
+        size: 0,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DirectoryPanel(
+              items: [testDirectory],
+              selectedItem: null,
+              onItemTap: (_) {},
+              position: PanelPosition.left,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.folder), findsOneWidget);
+    });
+
+    testWidgets('displays file icons for files', (tester) async {
+      final testFile = DirectoryEntry(
+        name: 'file.json',
+        attributes: 0,
+        date: 0,
+        time: 0,
+        size: 1024,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DirectoryPanel(
+              items: [testFile],
+              selectedItem: null,
+              onItemTap: (_) {},
+              position: PanelPosition.left,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.insert_drive_file), findsOneWidget);
+    });
+
+    testWidgets('highlights selected item', (tester) async {
+      final testItem = DirectoryEntry(
+        name: 'selected.json',
+        attributes: 0,
+        date: 0,
+        time: 0,
+        size: 1024,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DirectoryPanel(
+              items: [testItem],
+              selectedItem: testItem,
+              onItemTap: (_) {},
+              position: PanelPosition.left,
+            ),
+          ),
+        ),
+      );
+
+      // Find the ListTile and check if it's selected
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.selected, true);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Implements a new preset browser dialog with macOS Finder-style three-panel navigation
- Provides intuitive directory browsing through the SD card file system
- Integrates seamlessly with the existing preset loading workflow

## Features
- **Three-Panel Miller Columns Layout**: Navigate directories in a familiar macOS Finder style
- **SysEx Directory Operations**: Uses MIDI SysEx for directory listing with caching
- **Dual Sorting Modes**: Toggle between alphabetic and date-based sorting
- **Navigation History**: Back button with full navigation history support
- **Visual Enhancements**: File size formatting, folder/file icons, selected item highlighting
- **Performance Optimized**: Directory caching to minimize SysEx calls
- **History Tracking**: SharedPreferences integration for recent preset history

## Test Plan
- [x] Run preset browser unit tests: `flutter test test/cubit/preset_browser_cubit_test.dart`
- [x] Run preset browser widget tests: `flutter test test/ui/widgets/preset_browser_dialog_test.dart`
- [ ] Test on actual Disting NT hardware
- [ ] Verify navigation through preset directories
- [ ] Test sorting modes (alphabetic/date)
- [ ] Verify back button navigation
- [ ] Test preset loading from browser

## Implementation Details
The implementation follows the BLoC pattern with:
- `PresetBrowserCubit` for state management
- `PresetBrowserState` using Freezed for immutable state
- `PresetBrowserDialog` with `ThreePanelNavigator` and `DirectoryPanel` widgets
- Integration with existing `IDistingMidiManager` for SysEx operations

## Breaking Changes
None - this is an additive feature that provides an alternative preset browsing experience alongside the existing search-based preset dialog.

🤖 Generated with [Claude Code](https://claude.ai/code)