### PR TITLE
Add MIDI device disconnect button to packed mapping editor

### DIFF
--- a/lib/ui/midi_listener/midi_detector_widget.dart
+++ b/lib/ui/midi_listener/midi_detector_widget.dart
@@ -183,12 +183,23 @@ class _MidiDetectorContentsState extends State<_MidiDetectorContents> {
       mainAxisSize: MainAxisSize.min,
       children: [
         DropdownMenu<MidiDevice>(
-          width: 250,
+          width: 200,
           requestFocusOnTap: false,
           label: const Text('MIDI Device'),
           initialSelection: _selectedDevice,
           dropdownMenuEntries: entries,
           onSelected: _onDeviceSelected,
+        ),
+        const SizedBox(width: 8),
+        BlocBuilder<MidiListenerCubit, MidiListenerState>(
+          builder: (context, state) {
+            final isConnected = state is Data && state.isConnected;
+            return ElevatedButton.icon(
+              onPressed: isConnected ? _onDisconnectPressed : null,
+              icon: const Icon(Icons.close),
+              label: const Text('Disconnect'),
+            );
+          },
         ),
       ],
     );
@@ -217,6 +228,11 @@ class _MidiDetectorContentsState extends State<_MidiDetectorContents> {
     if (device == null) return;
     setState(() => _selectedDevice = device);
     _cubit.connectToDevice(device);
+  }
+
+  void _onDisconnectPressed() {
+    setState(() => _selectedDevice = null);
+    _cubit.disconnectDevice();
   }
 
   void _showStatusMessage(String newMessage) {

--- a/lib/ui/midi_listener/midi_listener_cubit.dart
+++ b/lib/ui/midi_listener/midi_listener_cubit.dart
@@ -74,6 +74,34 @@ class MidiListenerCubit extends Cubit<MidiListenerState> {
     }
   }
 
+  Future<void> disconnectDevice() async {
+    // Cancel subscription
+    await _midiSubscription?.cancel();
+    _midiSubscription = null;
+
+    // Disconnect device
+    final currentState = state;
+    if (currentState is Data) {
+      if (currentState.selectedDevice != null) {
+        _midiCommand.disconnectDevice(currentState.selectedDevice!);
+      }
+      // Update the state to show disconnected
+      emit(currentState.copyWith(
+        selectedDevice: null,
+        isConnected: false,
+        lastDetectedType: null,
+        lastDetectedChannel: null,
+        lastDetectedCc: null,
+        lastDetectedNote: null,
+        lastDetectedTime: null,
+      ));
+    }
+
+    // Reset consecutive count and signature
+    _consecutiveCount = 0;
+    _lastEventSignature = null;
+  }
+
   void _handleMidiData(MidiPacket packet) {
     final data = packet.data;
     // Basic validation: need at least 3 bytes for most channel messages


### PR DESCRIPTION
Add disconnect button for MIDI mapping feature so users can disconnect from a device and select a different one.

- Add disconnectDevice() method to MidiListenerCubit to properly disconnect from devices
- Add disconnect button to MidiDetectorWidget UI that appears when a device is connected
- Clear selected device state and reset MIDI detection state on disconnect
- Allow users to disconnect from current device to select a different one

Fixes #69

Generated with [Claude Code](https://claude.ai/code)