### PR TITLE
feat: Add platform-native image sharing for mobile routing editor

### DIFF
--- a/lib/ui/synchronized_screen.dart
+++ b/lib/ui/synchronized_screen.dart
@@ -456,11 +456,21 @@ class _SynchronizedScreenState extends State<SynchronizedScreen>
                           tooltip: 'Center View',
                         ),
 
-                        // Copy Nodes Image (tight bounds, 24px margin)
+                        // Share/Copy Nodes Image (tight bounds, 24px margin)
                         IconButton(
-                          icon: const Icon(Icons.image_outlined),
-                          onPressed: () => _editorController.copyNodesImage(),
-                          tooltip: 'Copy Nodes Image',
+                          icon: Icon(_platformService.isMobilePlatform() 
+                              ? Icons.share 
+                              : Icons.image_outlined),
+                          onPressed: () {
+                            if (_platformService.isMobilePlatform()) {
+                              _editorController.shareNodesImage();
+                            } else {
+                              _editorController.copyNodesImage();
+                            }
+                          },
+                          tooltip: _platformService.isMobilePlatform() 
+                              ? 'Share Nodes Image' 
+                              : 'Copy Nodes Image',
                         ),
                       ],
                     );

--- a/lib/ui/widgets/routing/routing_editor_controller.dart
+++ b/lib/ui/widgets/routing/routing_editor_controller.dart
@@ -6,21 +6,29 @@ class RoutingEditorController {
   Future<void> Function()? _copyCanvasImage;
   Future<void> Function()? _copyCanvasImageFit;
   Future<void> Function()? _copyNodesImage;
+  Future<void> Function()? _shareCanvasImage;
+  Future<void> Function()? _shareNodesImage;
 
   void attach({
     required VoidCallback fitToView,
     required Future<void> Function() copyCanvasImage,
     required Future<void> Function() copyCanvasImageFit,
     required Future<void> Function() copyNodesImage,
+    Future<void> Function()? shareCanvasImage,
+    Future<void> Function()? shareNodesImage,
   }) {
     _fitToView = fitToView;
     _copyCanvasImage = copyCanvasImage;
     _copyCanvasImageFit = copyCanvasImageFit;
     _copyNodesImage = copyNodesImage;
+    _shareCanvasImage = shareCanvasImage;
+    _shareNodesImage = shareNodesImage;
   }
 
   void fitToView() => _fitToView?.call();
   Future<void> copyCanvasImage() async => await _copyCanvasImage?.call();
   Future<void> copyCanvasImageFit() async => await _copyCanvasImageFit?.call();
   Future<void> copyNodesImage() async => await _copyNodesImage?.call();
+  Future<void> shareCanvasImage() async => await _shareCanvasImage?.call();
+  Future<void> shareNodesImage() async => await _shareNodesImage?.call();
 }


### PR DESCRIPTION
Add native platform sharing for routing editor images on mobile platforms.

## Changes
- Add share functionality using share_plus package for mobile platforms
- Extract image capture logic into reusable helper functions
- Update routing editor controller to support share operations
- Modify UI to show share icon on mobile, copy icon on desktop
- Automatically detect platform and use appropriate sharing method
- Maintain backward compatibility with existing clipboard functionality

Resolves #78

🤖 Generated with [Claude Code](https://claude.ai/code)