### PR TITLE
Add comprehensive tests for plugin loading double-press bug fix

### DIFF
--- a/test/cubit/disting_cubit_plugin_loading_test.dart
+++ b/test/cubit/disting_cubit_plugin_loading_test.dart
@@ -1,0 +1,365 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/cubit/disting_cubit.dart';
+import 'package:nt_helper/domain/i_disting_midi_manager.dart';
+import 'package:nt_helper/domain/disting_nt_sysex.dart';
+import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/db/daos/metadata_dao.dart';
+
+class MockAppDatabase extends Mock implements AppDatabase {}
+
+class MockMetadataDao extends Mock implements MetadataDao {}
+
+class MockDistingMidiManager extends Mock implements IDistingMidiManager {}
+
+void main() {
+  late DistingCubit cubit;
+  late MockAppDatabase mockDatabase;
+  late MockMetadataDao mockMetadataDao;
+  late MockDistingMidiManager mockDisting;
+
+  late AlgorithmInfo unloadedPlugin;
+  late AlgorithmInfo loadedPlugin;
+  late AlgorithmInfo factoryAlgorithm;
+
+  setUpAll(() {
+    registerFallbackValue(DistingState.initial());
+  });
+
+  setUp(() {
+    mockDatabase = MockAppDatabase();
+    mockMetadataDao = MockMetadataDao();
+    mockDisting = MockDistingMidiManager();
+
+    // Setup database mock
+    when(() => mockDatabase.metadataDao).thenReturn(mockMetadataDao);
+    when(() => mockMetadataDao.hasCachedAlgorithms()).thenAnswer((_) async => false);
+
+    cubit = DistingCubit(mockDatabase);
+
+    // Create test algorithm data
+    unloadedPlugin = const AlgorithmInfo(
+      guid: 'TestPlugin',
+      name: 'Test Plugin',
+      numSpecifications: 0,
+      specifications: [],
+      isLoaded: false,
+    );
+
+    loadedPlugin = const AlgorithmInfo(
+      guid: 'TestPlugin',
+      name: 'Test Plugin',
+      numSpecifications: 2,
+      specifications: [
+        SpecificationInfo(name: 'Param 1', min: 0, max: 100, defaultValue: 50),
+        SpecificationInfo(name: 'Param 2', min: -10, max: 10, defaultValue: 0),
+      ],
+      isLoaded: true,
+    );
+
+    factoryAlgorithm = const AlgorithmInfo(
+      guid: 'clck',
+      name: 'Clock',
+      numSpecifications: 1,
+      specifications: [
+        SpecificationInfo(name: 'Rate', min: 0, max: 255, defaultValue: 128),
+      ],
+      isLoaded: true,
+    );
+  });
+
+  tearDown(() {
+    cubit.close();
+  });
+
+  group('DistingCubit loadPlugin', () {
+    test('returns null when not in synchronized state', () async {
+      // Arrange - cubit starts in initial state
+      expect(cubit.state, isA<DistingStateInitial>());
+
+      // Act
+      final result = await cubit.loadPlugin('TestPlugin');
+
+      // Assert
+      expect(result, isNull);
+    });
+
+    test('returns null when algorithm not found', () async {
+      // Arrange
+      cubit.emit(
+        DistingState.synchronized(
+          disting: mockDisting,
+          distingVersion: '1.0',
+          firmwareVersion: null,
+          presetName: 'Test',
+          algorithms: [factoryAlgorithm],
+          slots: const [],
+          unitStrings: const [],
+          inputDevice: null,
+          outputDevice: null,
+          loading: false,
+          offline: false,
+          screenshot: null,
+          demo: false,
+          videoStream: null,
+        ),
+      );
+
+      // Act
+      final result = await cubit.loadPlugin('NonExistentPlugin');
+
+      // Assert
+      expect(result, isNull);
+    });
+
+    test('returns algorithm immediately if already loaded', () async {
+      // Arrange
+      cubit.emit(
+        DistingState.synchronized(
+          disting: mockDisting,
+          distingVersion: '1.0',
+          firmwareVersion: null,
+          presetName: 'Test',
+          algorithms: [loadedPlugin], // Already loaded
+          slots: const [],
+          unitStrings: const [],
+          inputDevice: null,
+          outputDevice: null,
+          loading: false,
+          offline: false,
+          screenshot: null,
+          demo: false,
+          videoStream: null,
+        ),
+      );
+
+      // Act
+      final result = await cubit.loadPlugin('TestPlugin');
+
+      // Assert
+      expect(result, equals(loadedPlugin));
+      verifyNever(() => mockDisting.requestLoadPlugin(any()));
+    });
+
+    test('loads plugin and updates state correctly', () async {
+      // Arrange
+      cubit.emit(
+        DistingState.synchronized(
+          disting: mockDisting,
+          distingVersion: '1.0',
+          firmwareVersion: null,
+          presetName: 'Test',
+          algorithms: [factoryAlgorithm, unloadedPlugin],
+          slots: const [],
+          unitStrings: const [],
+          inputDevice: null,
+          outputDevice: null,
+          loading: false,
+          offline: false,
+          screenshot: null,
+          demo: false,
+          videoStream: null,
+        ),
+      );
+
+      // Mock successful plugin loading
+      when(() => mockDisting.requestLoadPlugin('TestPlugin')).thenAnswer((_) async => {});
+      when(() => mockDisting.requestAlgorithmInfo(1)).thenAnswer((_) async => loadedPlugin);
+
+      // Act
+      final result = await cubit.loadPlugin('TestPlugin');
+
+      // Assert
+      expect(result, equals(loadedPlugin));
+
+      // Verify the state was updated correctly
+      final newState = cubit.state as DistingStateSynchronized;
+      expect(newState.algorithms.length, equals(2));
+      expect(newState.algorithms[0], equals(factoryAlgorithm)); // Unchanged
+      expect(newState.algorithms[1], equals(loadedPlugin)); // Updated
+      expect(newState.algorithms[1].isLoaded, isTrue);
+      expect(newState.algorithms[1].numSpecifications, equals(2));
+
+      // Verify correct calls were made
+      verify(() => mockDisting.requestLoadPlugin('TestPlugin')).called(1);
+      verify(() => mockDisting.requestAlgorithmInfo(1)).called(1);
+    });
+
+    test('handles plugin loading failure gracefully', () async {
+      // Arrange
+      cubit.emit(
+        DistingState.synchronized(
+          disting: mockDisting,
+          distingVersion: '1.0',
+          firmwareVersion: null,
+          presetName: 'Test',
+          algorithms: [unloadedPlugin],
+          slots: const [],
+          unitStrings: const [],
+          inputDevice: null,
+          outputDevice: null,
+          loading: false,
+          offline: false,
+          screenshot: null,
+          demo: false,
+          videoStream: null,
+        ),
+      );
+
+      // Mock failed plugin loading
+      when(() => mockDisting.requestLoadPlugin('TestPlugin')).thenThrow(Exception('Load failed'));
+
+      // Act
+      final result = await cubit.loadPlugin('TestPlugin');
+
+      // Assert
+      expect(result, isNull);
+
+      // State should remain unchanged
+      final state = cubit.state as DistingStateSynchronized;
+      expect(state.algorithms.length, equals(1));
+      expect(state.algorithms[0], equals(unloadedPlugin));
+      expect(state.algorithms[0].isLoaded, isFalse);
+
+      verify(() => mockDisting.requestLoadPlugin('TestPlugin')).called(1);
+      verifyNever(() => mockDisting.requestAlgorithmInfo(any()));
+    });
+
+    test('handles algorithm info request failure gracefully', () async {
+      // Arrange
+      cubit.emit(
+        DistingState.synchronized(
+          disting: mockDisting,
+          distingVersion: '1.0',
+          firmwareVersion: null,
+          presetName: 'Test',
+          algorithms: [unloadedPlugin],
+          slots: const [],
+          unitStrings: const [],
+          inputDevice: null,
+          outputDevice: null,
+          loading: false,
+          offline: false,
+          screenshot: null,
+          demo: false,
+          videoStream: null,
+        ),
+      );
+
+      // Mock successful load but failed info request
+      when(() => mockDisting.requestLoadPlugin('TestPlugin')).thenAnswer((_) async => {});
+      when(() => mockDisting.requestAlgorithmInfo(0)).thenAnswer((_) async => null);
+
+      // Act
+      final result = await cubit.loadPlugin('TestPlugin');
+
+      // Assert
+      expect(result, isNull);
+
+      // State should remain unchanged
+      final state = cubit.state as DistingStateSynchronized;
+      expect(state.algorithms.length, equals(1));
+      expect(state.algorithms[0], equals(unloadedPlugin));
+
+      verify(() => mockDisting.requestLoadPlugin('TestPlugin')).called(1);
+      verify(() => mockDisting.requestAlgorithmInfo(0)).called(1);
+    });
+
+    test('preserves other algorithms when loading one plugin', () async {
+      // Arrange
+      final anotherPlugin = const AlgorithmInfo(
+        guid: 'AnotherPlugin',
+        name: 'Another Plugin',
+        numSpecifications: 0,
+        specifications: [],
+        isLoaded: false,
+      );
+
+      cubit.emit(
+        DistingState.synchronized(
+          disting: mockDisting,
+          distingVersion: '1.0',
+          firmwareVersion: null,
+          presetName: 'Test',
+          algorithms: [factoryAlgorithm, unloadedPlugin, anotherPlugin],
+          slots: const [],
+          unitStrings: const [],
+          inputDevice: null,
+          outputDevice: null,
+          loading: false,
+          offline: false,
+          screenshot: null,
+          demo: false,
+          videoStream: null,
+        ),
+      );
+
+      // Mock successful plugin loading
+      when(() => mockDisting.requestLoadPlugin('TestPlugin')).thenAnswer((_) async => {});
+      when(() => mockDisting.requestAlgorithmInfo(1)).thenAnswer((_) async => loadedPlugin);
+
+      // Act
+      final result = await cubit.loadPlugin('TestPlugin');
+
+      // Assert
+      expect(result, equals(loadedPlugin));
+
+      // Verify all algorithms are preserved with only the target one updated
+      final newState = cubit.state as DistingStateSynchronized;
+      expect(newState.algorithms.length, equals(3));
+      expect(newState.algorithms[0], equals(factoryAlgorithm)); // Unchanged
+      expect(newState.algorithms[1], equals(loadedPlugin)); // Updated
+      expect(newState.algorithms[2], equals(anotherPlugin)); // Unchanged
+    });
+
+    group('Plugin Loading Integration', () {
+      test('demonstrates fix for double-button-press bug', () async {
+        // This test demonstrates that the cubit properly updates the algorithm
+        // state, which should be reflected in the UI without requiring a second button press.
+
+        // Arrange - Start with unloaded plugin
+        cubit.emit(
+          DistingState.synchronized(
+            disting: mockDisting,
+            distingVersion: '1.0',
+            firmwareVersion: null,
+            presetName: 'Test',
+            algorithms: [unloadedPlugin],
+            slots: const [],
+            unitStrings: const [],
+            inputDevice: null,
+            outputDevice: null,
+            loading: false,
+            offline: false,
+            screenshot: null,
+            demo: false,
+            videoStream: null,
+          ),
+        );
+
+        // Mock successful loading
+        when(() => mockDisting.requestLoadPlugin('TestPlugin')).thenAnswer((_) async => {});
+        when(() => mockDisting.requestAlgorithmInfo(0)).thenAnswer((_) async => loadedPlugin);
+
+        // Verify initial state
+        var currentState = cubit.state as DistingStateSynchronized;
+        expect(currentState.algorithms[0].isLoaded, isFalse);
+        expect(currentState.algorithms[0].numSpecifications, equals(0));
+
+        // Act - Load plugin
+        final result = await cubit.loadPlugin('TestPlugin');
+
+        // Assert - Algorithm is now loaded in the cubit's state
+        expect(result, equals(loadedPlugin));
+        
+        currentState = cubit.state as DistingStateSynchronized;
+        expect(currentState.algorithms[0].isLoaded, isTrue);
+        expect(currentState.algorithms[0].numSpecifications, equals(2));
+        expect(currentState.algorithms[0].specifications.length, equals(2));
+
+        // This updated state should cause the widget to rebuild and show
+        // the "Add to Preset" button without requiring a second button press
+      });
+    });
+  });
+}

--- a/test/ui/add_algorithm_screen_test.dart
+++ b/test/ui/add_algorithm_screen_test.dart
@@ -1,0 +1,508 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/cubit/disting_cubit.dart';
+import 'package:nt_helper/ui/add_algorithm_screen.dart';
+import 'package:nt_helper/domain/disting_nt_sysex.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MockDistingCubit extends Mock implements DistingCubit {}
+
+class MockSharedPreferences extends Mock implements SharedPreferences {}
+
+void main() {
+  late MockDistingCubit mockCubit;
+  late AlgorithmInfo mockFactoryAlgorithm;
+  late AlgorithmInfo mockUnloadedPlugin;
+  late AlgorithmInfo mockLoadedPlugin;
+
+  setUpAll(() {
+    // Register fallback values for mocktail
+    registerFallbackValue(DistingState.initial());
+  });
+
+  setUp(() {
+    mockCubit = MockDistingCubit();
+
+    // Create mock algorithms for testing
+    mockFactoryAlgorithm = const AlgorithmInfo(
+      guid: 'clck',
+      name: 'Clock',
+      numSpecifications: 0,
+      specifications: [],
+      isLoaded: true, // Factory algorithms are always loaded
+    );
+
+    mockUnloadedPlugin = const AlgorithmInfo(
+      guid: 'TestPlugin',
+      name: 'Test Plugin',
+      numSpecifications: 0,
+      specifications: [],
+      isLoaded: false, // Plugin not loaded
+    );
+
+    mockLoadedPlugin = const AlgorithmInfo(
+      guid: 'TestPlugin',
+      name: 'Test Plugin',
+      numSpecifications: 2,
+      specifications: [
+        SpecificationInfo(name: 'Spec 1', min: 0, max: 10, defaultValue: 5),
+        SpecificationInfo(name: 'Spec 2', min: -5, max: 5, defaultValue: 0),
+      ],
+      isLoaded: true, // Plugin loaded with specifications
+    );
+
+    // Set up SharedPreferences mocks
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Widget createTestWidget() {
+    return MaterialApp(
+      home: BlocProvider<DistingCubit>.value(
+        value: mockCubit,
+        child: const AddAlgorithmScreen(),
+      ),
+    );
+  }
+
+  group('AddAlgorithmScreen Plugin Loading', () {
+    testWidgets('displays Load Plugin button for unloaded plugin', (tester) async {
+      // Arrange
+      when(() => mockCubit.state).thenReturn(
+        DistingState.synchronized(
+          disting: null,
+          distingVersion: '',
+          firmwareVersion: null,
+          presetName: 'Test Preset',
+          algorithms: [mockFactoryAlgorithm, mockUnloadedPlugin],
+          slots: const [],
+          unitStrings: const [],
+          inputDevice: null,
+          outputDevice: null,
+          loading: false,
+          offline: false,
+          screenshot: null,
+          demo: false,
+          videoStream: null,
+        ),
+      );
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      // Act
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      // Select the unloaded plugin
+      await tester.tap(find.text('Test Plugin'));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text('Load Plugin'), findsOneWidget);
+      expect(find.text('Add to Preset'), findsNothing);
+
+      // Verify button is enabled
+      final button = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, 'Load Plugin'),
+      );
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('displays Add to Preset button for loaded plugin', (tester) async {
+      // Arrange
+      when(() => mockCubit.state).thenReturn(
+        DistingState.synchronized(
+          disting: null,
+          distingVersion: '',
+          firmwareVersion: null,
+          presetName: 'Test Preset',
+          algorithms: [mockFactoryAlgorithm, mockLoadedPlugin],
+          slots: const [],
+          unitStrings: const [],
+          inputDevice: null,
+          outputDevice: null,
+          loading: false,
+          offline: false,
+          screenshot: null,
+          demo: false,
+          videoStream: null,
+        ),
+      );
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      // Act
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      // Select the loaded plugin
+      await tester.tap(find.text('Test Plugin'));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text('Add to Preset'), findsOneWidget);
+      expect(find.text('Load Plugin'), findsNothing);
+
+      // Verify button is enabled
+      final button = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, 'Add to Preset'),
+      );
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('displays Add to Preset button for factory algorithm', (tester) async {
+      // Arrange
+      when(() => mockCubit.state).thenReturn(
+        DistingState.synchronized(
+          disting: null,
+          distingVersion: '',
+          firmwareVersion: null,
+          presetName: 'Test Preset',
+          algorithms: [mockFactoryAlgorithm],
+          slots: const [],
+          unitStrings: const [],
+          inputDevice: null,
+          outputDevice: null,
+          loading: false,
+          offline: false,
+          screenshot: null,
+          demo: false,
+          videoStream: null,
+        ),
+      );
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      // Act
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      // Select the factory algorithm
+      await tester.tap(find.text('Clock'));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text('Add to Preset'), findsOneWidget);
+      expect(find.text('Load Plugin'), findsNothing);
+    });
+
+    group('Plugin Loading Workflow', () {
+      testWidgets('button changes to Add to Preset after successful plugin load', (tester) async {
+        // This is the key test for the bug fix
+        
+        // Initial state: unloaded plugin
+        when(() => mockCubit.state).thenReturn(
+          DistingState.synchronized(
+            disting: null,
+            distingVersion: '',
+            firmwareVersion: null,
+            presetName: 'Test Preset',
+            algorithms: [mockUnloadedPlugin],
+            slots: const [],
+            unitStrings: const [],
+            inputDevice: null,
+            outputDevice: null,
+            loading: false,
+            offline: false,
+            screenshot: null,
+            demo: false,
+            videoStream: null,
+          ),
+        );
+
+        // Mock successful plugin loading
+        when(() => mockCubit.loadPlugin('TestPlugin')).thenAnswer((_) async => mockLoadedPlugin);
+
+        // Stream to simulate state updates
+        final stateController = StreamController<DistingState>();
+        when(() => mockCubit.stream).thenAnswer((_) => stateController.stream);
+
+        // Act
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // Select the unloaded plugin
+        await tester.tap(find.text('Test Plugin'));
+        await tester.pumpAndSettle();
+
+        // Verify initial state shows Load Plugin button
+        expect(find.text('Load Plugin'), findsOneWidget);
+
+        // Tap Load Plugin button
+        await tester.tap(find.text('Load Plugin'));
+        await tester.pump(); // Start the async operation
+
+        // Simulate cubit state update after successful load
+        when(() => mockCubit.state).thenReturn(
+          DistingState.synchronized(
+            disting: null,
+            distingVersion: '',
+            firmwareVersion: null,
+            presetName: 'Test Preset',
+            algorithms: [mockLoadedPlugin], // Now loaded
+            slots: const [],
+            unitStrings: const [],
+            inputDevice: null,
+            outputDevice: null,
+            loading: false,
+            offline: false,
+            screenshot: null,
+            demo: false,
+            videoStream: null,
+          ),
+        );
+
+        // Emit the updated state
+        stateController.add(
+          DistingState.synchronized(
+            disting: null,
+            distingVersion: '',
+            firmwareVersion: null,
+            presetName: 'Test Preset',
+            algorithms: [mockLoadedPlugin],
+            slots: const [],
+            unitStrings: const [],
+            inputDevice: null,
+            outputDevice: null,
+            loading: false,
+            offline: false,
+            screenshot: null,
+            demo: false,
+            videoStream: null,
+          ),
+        );
+
+        await tester.pumpAndSettle(); // Process the state update
+
+        // Assert: Button should now show "Add to Preset" without requiring another press
+        expect(find.text('Add to Preset'), findsOneWidget);
+        expect(find.text('Load Plugin'), findsNothing);
+
+        // Verify loadPlugin was called
+        verify(() => mockCubit.loadPlugin('TestPlugin')).called(1);
+
+        stateController.close();
+      });
+
+      testWidgets('handles plugin loading failure gracefully', (tester) async {
+        // Initial state: unloaded plugin
+        when(() => mockCubit.state).thenReturn(
+          DistingState.synchronized(
+            disting: null,
+            distingVersion: '',
+            firmwareVersion: null,
+            presetName: 'Test Preset',
+            algorithms: [mockUnloadedPlugin],
+            slots: const [],
+            unitStrings: const [],
+            inputDevice: null,
+            outputDevice: null,
+            loading: false,
+            offline: false,
+            screenshot: null,
+            demo: false,
+            videoStream: null,
+          ),
+        );
+
+        // Mock failed plugin loading
+        when(() => mockCubit.loadPlugin('TestPlugin')).thenAnswer((_) async => null);
+
+        when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+        // Act
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // Select the unloaded plugin
+        await tester.tap(find.text('Test Plugin'));
+        await tester.pumpAndSettle();
+
+        // Tap Load Plugin button
+        await tester.tap(find.text('Load Plugin'));
+        await tester.pumpAndSettle();
+
+        // Assert: Button should still show "Load Plugin" since loading failed
+        expect(find.text('Load Plugin'), findsOneWidget);
+        expect(find.text('Add to Preset'), findsNothing);
+
+        // Check for error snackbar
+        expect(find.text('Failed to load Test Plugin'), findsOneWidget);
+
+        // Verify loadPlugin was called
+        verify(() => mockCubit.loadPlugin('TestPlugin')).called(1);
+      });
+
+      testWidgets('shows loading snackbar during plugin load', (tester) async {
+        // Initial state: unloaded plugin
+        when(() => mockCubit.state).thenReturn(
+          DistingState.synchronized(
+            disting: null,
+            distingVersion: '',
+            firmwareVersion: null,
+            presetName: 'Test Preset',
+            algorithms: [mockUnloadedPlugin],
+            slots: const [],
+            unitStrings: const [],
+            inputDevice: null,
+            outputDevice: null,
+            loading: false,
+            offline: false,
+            screenshot: null,
+            demo: false,
+            videoStream: null,
+          ),
+        );
+
+        // Mock delayed plugin loading
+        final completer = Completer<AlgorithmInfo?>();
+        when(() => mockCubit.loadPlugin('TestPlugin')).thenAnswer((_) => completer.future);
+
+        when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+        // Act
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // Select the unloaded plugin
+        await tester.tap(find.text('Test Plugin'));
+        await tester.pumpAndSettle();
+
+        // Tap Load Plugin button
+        await tester.tap(find.text('Load Plugin'));
+        await tester.pump(); // Start the async operation
+
+        // Assert: Loading snackbar should be visible
+        expect(find.text('Loading plugin Test Plugin...'), findsOneWidget);
+
+        // Complete the loading
+        completer.complete(mockLoadedPlugin);
+        await tester.pumpAndSettle();
+
+        // Assert: Success snackbar should now be visible
+        expect(find.text('Test Plugin loaded with 2 specifications'), findsOneWidget);
+
+        // Verify loadPlugin was called
+        verify(() => mockCubit.loadPlugin('TestPlugin')).called(1);
+      });
+    });
+
+    group('Plugin Type Detection', () {
+      testWidgets('correctly identifies factory algorithms vs plugins', (tester) async {
+        when(() => mockCubit.state).thenReturn(
+          DistingState.synchronized(
+            disting: null,
+            distingVersion: '',
+            firmwareVersion: null,
+            presetName: 'Test Preset',
+            algorithms: [mockFactoryAlgorithm, mockUnloadedPlugin],
+            slots: const [],
+            unitStrings: const [],
+            inputDevice: null,
+            outputDevice: null,
+            loading: false,
+            offline: false,
+            screenshot: null,
+            demo: false,
+            videoStream: null,
+          ),
+        );
+        when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // Factory algorithm (lowercase GUID) should show extension icon for community plugins only
+        await tester.tap(find.text('Clock'));
+        await tester.pumpAndSettle();
+        expect(find.text('Add to Preset'), findsOneWidget);
+
+        // Plugin (uppercase GUID) should show load button when unloaded
+        await tester.tap(find.text('Test Plugin'));
+        await tester.pumpAndSettle();
+        expect(find.text('Load Plugin'), findsOneWidget);
+      });
+    });
+
+    group('State Synchronization', () {
+      testWidgets('updates algorithm list when cubit state changes', (tester) async {
+        final stateController = StreamController<DistingState>();
+
+        when(() => mockCubit.stream).thenAnswer((_) => stateController.stream);
+
+        // Initial state with one algorithm
+        when(() => mockCubit.state).thenReturn(
+          DistingState.synchronized(
+            disting: null,
+            distingVersion: '',
+            firmwareVersion: null,
+            presetName: 'Test Preset',
+            algorithms: [mockFactoryAlgorithm],
+            slots: const [],
+            unitStrings: const [],
+            inputDevice: null,
+            outputDevice: null,
+            loading: false,
+            offline: false,
+            screenshot: null,
+            demo: false,
+            videoStream: null,
+          ),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // Should show only the factory algorithm
+        expect(find.text('Clock'), findsOneWidget);
+        expect(find.text('Test Plugin'), findsNothing);
+
+        // Update state to include the plugin
+        when(() => mockCubit.state).thenReturn(
+          DistingState.synchronized(
+            disting: null,
+            distingVersion: '',
+            firmwareVersion: null,
+            presetName: 'Test Preset',
+            algorithms: [mockFactoryAlgorithm, mockLoadedPlugin],
+            slots: const [],
+            unitStrings: const [],
+            inputDevice: null,
+            outputDevice: null,
+            loading: false,
+            offline: false,
+            screenshot: null,
+            demo: false,
+            videoStream: null,
+          ),
+        );
+
+        // Emit new state
+        stateController.add(
+          DistingState.synchronized(
+            disting: null,
+            distingVersion: '',
+            firmwareVersion: null,
+            presetName: 'Test Preset',
+            algorithms: [mockFactoryAlgorithm, mockLoadedPlugin],
+            slots: const [],
+            unitStrings: const [],
+            inputDevice: null,
+            outputDevice: null,
+            loading: false,
+            offline: false,
+            screenshot: null,
+            demo: false,
+            videoStream: null,
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Should now show both algorithms
+        expect(find.text('Clock'), findsOneWidget);
+        expect(find.text('Test Plugin'), findsOneWidget);
+
+        stateController.close();
+      });
+    });
+  });
+}


### PR DESCRIPTION
Add comprehensive test suites to verify the plugin loading fix works correctly and prevents the double-press bug.

## Widget Tests (`test/ui/add_algorithm_screen_test.dart`)
- Tests plugin state display and button behavior
- Verifies double-press bug fix with state simulation
- Covers error handling and loading indicators
- Tests state synchronization between cubit and widget

## Unit Tests (`test/cubit/disting_cubit_plugin_loading_test.dart`)
- Tests DistingCubit loadPlugin method behavior
- Verifies proper state management during plugin loading
- Tests error handling and edge cases
- Demonstrates fix prevents double-button-press requirement

These tests serve as both verification of the fix and regression prevention.

Fixes #86

🤖 Generated with [Claude Code](https://claude.ai/code)