### PR TITLE
Refactor plugin loading to rely on cubit state management

### DIFF
--- a/lib/ui/add_algorithm_screen.dart
+++ b/lib/ui/add_algorithm_screen.dart
@@ -333,20 +333,14 @@ class _AddAlgorithmScreenState extends State<AddAlgorithmScreen> {
           ),
         );
 
-        // Update the algorithm info in our local list
-        final index = _allAlgorithms.indexWhere(
-          (algo) => algo.guid == algorithmGuid,
-        );
-        if (index != -1) {
+        // The cubit has already updated the global state, no need for manual local updates
+        // Just update the currently selected algorithm info if it matches
+        if (selectedAlgorithmGuid == algorithmGuid) {
           setState(() {
-            _allAlgorithms[index] = loadedInfo;
-            // If this algorithm is currently selected, update the current info too
-            if (selectedAlgorithmGuid == algorithmGuid) {
-              _currentAlgoInfo = loadedInfo;
-              specValues = loadedInfo.specifications
-                  .map((s) => s.defaultValue)
-                  .toList();
-            }
+            _currentAlgoInfo = loadedInfo;
+            specValues = loadedInfo.specifications
+                .map((s) => s.defaultValue)
+                .toList();
           });
         }
       } else if (mounted) {


### PR DESCRIPTION
Remove manual local state updates that conflicted with cubit state management.
The cubit.loadPlugin() method already properly updates the global state,
so the build method's automatic state synchronization is sufficient.

This fixes the double-button-press issue by ensuring _currentAlgoInfo
stays consistent with the global state after plugin loading.

Fixes #86

Generated with [Claude Code](https://claude.ai/code)