### PR TITLE
Fix plugin loading double-press bug

### DIFF
--- a/lib/ui/add_algorithm_screen.dart
+++ b/lib/ui/add_algorithm_screen.dart
@@ -348,6 +348,8 @@ class _AddAlgorithmScreenState extends State<AddAlgorithmScreen> {
                   .toList();
             }
           });
+          // Trigger filtering to update the display
+          _filterAlgorithms();
         }
       } else if (mounted) {
         ScaffoldMessenger.of(context).hideCurrentSnackBar();
@@ -389,6 +391,23 @@ class _AddAlgorithmScreenState extends State<AddAlgorithmScreen> {
         _allAlgorithms = List<AlgorithmInfo>.from(
           algorithms,
         )..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+        
+        // If we have a currently selected algorithm, update it to reflect the latest state
+        if (selectedAlgorithmGuid != null) {
+          final updatedAlgo = _allAlgorithms.firstWhereOrNull(
+            (a) => a.guid == selectedAlgorithmGuid,
+          );
+          if (updatedAlgo != null && _currentAlgoInfo != null) {
+            _currentAlgoInfo = updatedAlgo;
+            // Update specValues if the number of specifications changed
+            if (_currentAlgoInfo!.specifications.length != (specValues?.length ?? 0)) {
+              specValues = _currentAlgoInfo!.specifications
+                  .map((s) => s.defaultValue)
+                  .toList();
+            }
+          }
+        }
+        
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (mounted) {
             _filterAlgorithms();


### PR DESCRIPTION
Fix issue where loading a plugin required two button presses instead of one.

The problem occurred because after successful plugin loading, the widget would rebuild and overwrite _allAlgorithms with fresh DistingCubit state, causing _currentAlgoInfo to become stale with the old isLoaded=false state.

Solution:
- Added automatic _currentAlgoInfo refresh when _allAlgorithms updates from cubit
- Added _filterAlgorithms() call after plugin loading to update display
- Ensures button properly shows 'Add to Preset' after single plugin load

Fixes #86

Generated with [Claude Code](https://claude.ai/code)