### PR TITLE
feat: enable firmware flashing in macOS sandbox (TestFlight)

### DIFF
--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -532,9 +532,36 @@ jobs:
       - name: Build macOS
         run: flutter build macos
 
+      - name: Download and bundle nt-flash for sandboxed builds
+        run: |
+          # Get latest nt-flash release
+          NT_FLASH_VERSION=$(curl -s https://api.github.com/repos/thorinside/nt-flash/releases/latest | jq -r .tag_name)
+          echo "Bundling nt-flash $NT_FLASH_VERSION"
+          
+          # Download macOS release
+          curl -L "https://github.com/thorinside/nt-flash/releases/download/$NT_FLASH_VERSION/nt-flash-$NT_FLASH_VERSION-macos.zip" -o /tmp/nt-flash.zip
+          
+          # Extract and place in app bundle's MacOS directory
+          unzip -o /tmp/nt-flash.zip -d /tmp/nt-flash-extract
+          NT_FLASH_BIN=$(find /tmp/nt-flash-extract -name "nt-flash" -type f | head -1)
+          
+          # Copy to app bundle
+          cp "$NT_FLASH_BIN" build/macos/Build/Products/Release/nt_helper.app/Contents/MacOS/nt-flash
+          chmod +x build/macos/Build/Products/Release/nt_helper.app/Contents/MacOS/nt-flash
+          
+          echo "nt-flash binary info:"
+          file build/macos/Build/Products/Release/nt_helper.app/Contents/MacOS/nt-flash
+
       - name: Embed provisioning profile in app bundle
         run: |
           cp mac_appstore.provisionprofile build/macos/Build/Products/Release/nt_helper.app/Contents/embedded.provisionprofile
+
+      - name: Codesign nt-flash helper for sandbox
+        run: |
+          codesign --force --verbose --options runtime \
+            --sign "Apple Distribution: Neal Sanche (KN424RZG26)" \
+            --entitlements macos/Runner/nt-flash.entitlements \
+            build/macos/Build/Products/Release/nt_helper.app/Contents/MacOS/nt-flash
 
       - name: Codesign the macOS App for App Store
         run: |

--- a/lib/cubit/firmware_update_cubit.dart
+++ b/lib/cubit/firmware_update_cubit.dart
@@ -263,7 +263,9 @@ class FirmwareUpdateCubit extends Cubit<FirmwareUpdateState> {
             emit(
               FirmwareUpdateState.error(
                 message: progress.message,
-                errorType: _getErrorTypeForStage(currentStage),
+                errorType: progress.isSandboxError
+                    ? FirmwareErrorType.sandboxRestriction
+                    : _getErrorTypeForStage(currentStage),
                 failedStage: currentStage,
                 firmwarePath: currentState.firmwarePath,
                 targetVersion: currentState.targetVersion,

--- a/lib/cubit/firmware_update_state.dart
+++ b/lib/cubit/firmware_update_state.dart
@@ -19,6 +19,10 @@ enum FirmwareErrorType {
   /// Linux udev rules missing - need to install for USB access
   udevMissing,
 
+  /// macOS sandbox restriction - can't execute flash tool
+  /// This occurs when the bundled binary is missing or improperly signed
+  sandboxRestriction,
+
   /// General/unknown error
   general,
 }

--- a/lib/models/flash_progress.dart
+++ b/lib/models/flash_progress.dart
@@ -11,6 +11,7 @@ sealed class FlashProgress with _$FlashProgress {
     required int percent,
     required String message,
     @Default(false) bool isError,
+    @Default(false) bool isSandboxError,
   }) = _FlashProgress;
 
   factory FlashProgress.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/flash_progress.freezed.dart
+++ b/lib/models/flash_progress.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$FlashProgress {
 
- FlashStage get stage; int get percent; String get message; bool get isError;
+ FlashStage get stage; int get percent; String get message; bool get isError; bool get isSandboxError;
 /// Create a copy of FlashProgress
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $FlashProgressCopyWith<FlashProgress> get copyWith => _$FlashProgressCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is FlashProgress&&(identical(other.stage, stage) || other.stage == stage)&&(identical(other.percent, percent) || other.percent == percent)&&(identical(other.message, message) || other.message == message)&&(identical(other.isError, isError) || other.isError == isError));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FlashProgress&&(identical(other.stage, stage) || other.stage == stage)&&(identical(other.percent, percent) || other.percent == percent)&&(identical(other.message, message) || other.message == message)&&(identical(other.isError, isError) || other.isError == isError)&&(identical(other.isSandboxError, isSandboxError) || other.isSandboxError == isSandboxError));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,stage,percent,message,isError);
+int get hashCode => Object.hash(runtimeType,stage,percent,message,isError,isSandboxError);
 
 @override
 String toString() {
-  return 'FlashProgress(stage: $stage, percent: $percent, message: $message, isError: $isError)';
+  return 'FlashProgress(stage: $stage, percent: $percent, message: $message, isError: $isError, isSandboxError: $isSandboxError)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $FlashProgressCopyWith<$Res>  {
   factory $FlashProgressCopyWith(FlashProgress value, $Res Function(FlashProgress) _then) = _$FlashProgressCopyWithImpl;
 @useResult
 $Res call({
- FlashStage stage, int percent, String message, bool isError
+ FlashStage stage, int percent, String message, bool isError, bool isSandboxError
 });
 
 
@@ -65,12 +65,13 @@ class _$FlashProgressCopyWithImpl<$Res>
 
 /// Create a copy of FlashProgress
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? stage = null,Object? percent = null,Object? message = null,Object? isError = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? stage = null,Object? percent = null,Object? message = null,Object? isError = null,Object? isSandboxError = null,}) {
   return _then(_self.copyWith(
 stage: null == stage ? _self.stage : stage // ignore: cast_nullable_to_non_nullable
 as FlashStage,percent: null == percent ? _self.percent : percent // ignore: cast_nullable_to_non_nullable
 as int,message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
 as String,isError: null == isError ? _self.isError : isError // ignore: cast_nullable_to_non_nullable
+as bool,isSandboxError: null == isSandboxError ? _self.isSandboxError : isSandboxError // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -153,10 +154,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( FlashStage stage,  int percent,  String message,  bool isError)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( FlashStage stage,  int percent,  String message,  bool isError,  bool isSandboxError)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _FlashProgress() when $default != null:
-return $default(_that.stage,_that.percent,_that.message,_that.isError);case _:
+return $default(_that.stage,_that.percent,_that.message,_that.isError,_that.isSandboxError);case _:
   return orElse();
 
 }
@@ -174,10 +175,10 @@ return $default(_that.stage,_that.percent,_that.message,_that.isError);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( FlashStage stage,  int percent,  String message,  bool isError)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( FlashStage stage,  int percent,  String message,  bool isError,  bool isSandboxError)  $default,) {final _that = this;
 switch (_that) {
 case _FlashProgress():
-return $default(_that.stage,_that.percent,_that.message,_that.isError);}
+return $default(_that.stage,_that.percent,_that.message,_that.isError,_that.isSandboxError);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -191,10 +192,10 @@ return $default(_that.stage,_that.percent,_that.message,_that.isError);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( FlashStage stage,  int percent,  String message,  bool isError)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( FlashStage stage,  int percent,  String message,  bool isError,  bool isSandboxError)?  $default,) {final _that = this;
 switch (_that) {
 case _FlashProgress() when $default != null:
-return $default(_that.stage,_that.percent,_that.message,_that.isError);case _:
+return $default(_that.stage,_that.percent,_that.message,_that.isError,_that.isSandboxError);case _:
   return null;
 
 }
@@ -206,13 +207,14 @@ return $default(_that.stage,_that.percent,_that.message,_that.isError);case _:
 @JsonSerializable()
 
 class _FlashProgress implements FlashProgress {
-  const _FlashProgress({required this.stage, required this.percent, required this.message, this.isError = false});
+  const _FlashProgress({required this.stage, required this.percent, required this.message, this.isError = false, this.isSandboxError = false});
   factory _FlashProgress.fromJson(Map<String, dynamic> json) => _$FlashProgressFromJson(json);
 
 @override final  FlashStage stage;
 @override final  int percent;
 @override final  String message;
 @override@JsonKey() final  bool isError;
+@override@JsonKey() final  bool isSandboxError;
 
 /// Create a copy of FlashProgress
 /// with the given fields replaced by the non-null parameter values.
@@ -227,16 +229,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FlashProgress&&(identical(other.stage, stage) || other.stage == stage)&&(identical(other.percent, percent) || other.percent == percent)&&(identical(other.message, message) || other.message == message)&&(identical(other.isError, isError) || other.isError == isError));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FlashProgress&&(identical(other.stage, stage) || other.stage == stage)&&(identical(other.percent, percent) || other.percent == percent)&&(identical(other.message, message) || other.message == message)&&(identical(other.isError, isError) || other.isError == isError)&&(identical(other.isSandboxError, isSandboxError) || other.isSandboxError == isSandboxError));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,stage,percent,message,isError);
+int get hashCode => Object.hash(runtimeType,stage,percent,message,isError,isSandboxError);
 
 @override
 String toString() {
-  return 'FlashProgress(stage: $stage, percent: $percent, message: $message, isError: $isError)';
+  return 'FlashProgress(stage: $stage, percent: $percent, message: $message, isError: $isError, isSandboxError: $isSandboxError)';
 }
 
 
@@ -247,7 +249,7 @@ abstract mixin class _$FlashProgressCopyWith<$Res> implements $FlashProgressCopy
   factory _$FlashProgressCopyWith(_FlashProgress value, $Res Function(_FlashProgress) _then) = __$FlashProgressCopyWithImpl;
 @override @useResult
 $Res call({
- FlashStage stage, int percent, String message, bool isError
+ FlashStage stage, int percent, String message, bool isError, bool isSandboxError
 });
 
 
@@ -264,12 +266,13 @@ class __$FlashProgressCopyWithImpl<$Res>
 
 /// Create a copy of FlashProgress
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? stage = null,Object? percent = null,Object? message = null,Object? isError = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? stage = null,Object? percent = null,Object? message = null,Object? isError = null,Object? isSandboxError = null,}) {
   return _then(_FlashProgress(
 stage: null == stage ? _self.stage : stage // ignore: cast_nullable_to_non_nullable
 as FlashStage,percent: null == percent ? _self.percent : percent // ignore: cast_nullable_to_non_nullable
 as int,message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
 as String,isError: null == isError ? _self.isError : isError // ignore: cast_nullable_to_non_nullable
+as bool,isSandboxError: null == isSandboxError ? _self.isSandboxError : isSandboxError // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/lib/models/flash_progress.g.dart
+++ b/lib/models/flash_progress.g.dart
@@ -12,6 +12,7 @@ _FlashProgress _$FlashProgressFromJson(Map<String, dynamic> json) =>
       percent: (json['percent'] as num).toInt(),
       message: json['message'] as String,
       isError: json['isError'] as bool? ?? false,
+      isSandboxError: json['isSandboxError'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$FlashProgressToJson(_FlashProgress instance) =>
@@ -20,6 +21,7 @@ Map<String, dynamic> _$FlashProgressToJson(_FlashProgress instance) =>
       'percent': instance.percent,
       'message': instance.message,
       'isError': instance.isError,
+      'isSandboxError': instance.isSandboxError,
     };
 
 const _$FlashStageEnumMap = {

--- a/lib/ui/firmware/firmware_error_widget.dart
+++ b/lib/ui/firmware/firmware_error_widget.dart
@@ -66,6 +66,12 @@ class FirmwareErrorWidget extends StatelessWidget {
             const SizedBox(height: 16),
           ],
 
+          // Show sandbox restriction message for macOS
+          if (state.errorType == FirmwareErrorType.sandboxRestriction) ...[
+            const _SandboxInstructionsSection(),
+            const SizedBox(height: 16),
+          ],
+
           // Copy diagnostics button
           OutlinedButton.icon(
             onPressed: () => _copyDiagnostics(context),
@@ -126,9 +132,20 @@ class FirmwareErrorWidget extends StatelessWidget {
           return ('Install USB Rules', Icons.security, onInstallUdevRules!);
         }
         return ('Retry After Installing Rules', Icons.refresh, onRetryFlash);
+      case FirmwareErrorType.sandboxRestriction:
+        return ('Download Direct Version', Icons.download, _openGitHubReleases);
       case FirmwareErrorType.download:
       case FirmwareErrorType.general:
         return ('Try Again', Icons.refresh, onTryAgain);
+    }
+  }
+
+  void _openGitHubReleases() async {
+    final uri = Uri.parse(
+      'https://github.com/thorinside/nt_helper/releases/latest',
+    );
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
     }
   }
 
@@ -264,6 +281,58 @@ class _UdevInstructionsSection extends StatelessWidget {
             const SizedBox(height: 8),
             Text(
               'You will be prompted for your password to authorize the installation.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Information card explaining sandbox restrictions on macOS TestFlight/App Store
+class _SandboxInstructionsSection extends StatelessWidget {
+  const _SandboxInstructionsSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.security, color: theme.colorScheme.primary),
+                const SizedBox(width: 8),
+                Text(
+                  'macOS Sandbox Restriction',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Firmware updates are not available in the TestFlight/App Store version '
+              'due to macOS sandbox restrictions.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'To update your Disting NT firmware, please download the direct version '
+              'from GitHub Releases. All other features work normally in this version.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Click "Download Direct Version" above to get the unrestricted version.',
               style: theme.textTheme.bodySmall?.copyWith(
                 fontStyle: FontStyle.italic,
               ),

--- a/lib/utils/sandbox_utils.dart
+++ b/lib/utils/sandbox_utils.dart
@@ -1,0 +1,13 @@
+import 'dart:io';
+
+/// Utility class for detecting macOS App Sandbox environment
+class SandboxUtils {
+  /// Detects if the app is running in macOS App Sandbox
+  ///
+  /// The APP_SANDBOX_CONTAINER_ID environment variable is set by macOS
+  /// when an app is running inside the App Sandbox (TestFlight/App Store builds).
+  static bool get isSandboxed {
+    if (!Platform.isMacOS) return false;
+    return Platform.environment.containsKey('APP_SANDBOX_CONTAINER_ID');
+  }
+}

--- a/macos/Runner/AppStore.entitlements
+++ b/macos/Runner/AppStore.entitlements
@@ -16,5 +16,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.device.usb</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/nt-flash.entitlements
+++ b/macos/Runner/nt-flash.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.inherit</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Fixes the app crash when attempting firmware updates in TestFlight/App Store builds by bundling the `nt-flash` binary and properly configuring sandbox entitlements.

## Problem

The TestFlight build crashed when attempting firmware flashing because:
1. macOS App Sandbox blocks execution of binaries downloaded at runtime
2. The `nt-flash` tool was being downloaded to Application Support, which the sandbox prevents from executing
3. No graceful error handling existed for sandbox-related process failures

## Solution

### Bundled Binary Approach
- Bundle `nt-flash` binary in the app bundle during TestFlight CI build
- Sign the helper with `com.apple.security.inherit` entitlement to inherit parent sandbox profile
- Add `com.apple.security.device.usb` entitlement for USB device access

### Hybrid Path Resolution  
- **Sandboxed builds**: Use bundled binary from `Contents/MacOS/nt-flash`
- **Direct downloads**: Continue downloading on-demand to Application Support (existing behavior)

### Graceful Fallback
- Added `isSandboxError` flag to `FlashProgress` model
- Added `sandboxRestriction` error type with helpful UI
- Error widget guides users to download direct version from GitHub Releases if bundled binary fails

## Changes

| File | Change |
|------|--------|
| `macos/Runner/AppStore.entitlements` | Added USB device entitlement |
| `macos/Runner/nt-flash.entitlements` | New: helper entitlements with sandbox inherit |
| `lib/utils/sandbox_utils.dart` | New: detects macOS sandbox environment |
| `lib/services/flash_tool_manager.dart` | Hybrid path resolution based on sandbox state |
| `lib/services/flash_tool_bridge.dart` | Graceful ProcessException handling |
| `lib/models/flash_progress.dart` | Added `isSandboxError` field |
| `lib/cubit/firmware_update_state.dart` | Added `sandboxRestriction` error type |
| `lib/ui/firmware/firmware_error_widget.dart` | Sandbox-specific error UI with GitHub link |
| `.github/workflows/tag-build.yml` | Downloads, bundles, and codesigns nt-flash |

## Testing Notes

1. **TestFlight build**: CI will now download `nt-flash` from GitHub releases, bundle it in the app, and codesign with inherit entitlements
2. **Direct download build**: Unchanged - still downloads nt-flash on demand
3. **Fallback**: If bundled binary fails, user sees helpful error directing to GitHub Releases

## Risk Assessment

- **App Review**: USB entitlement is standard for MIDI/firmware apps; may need to provide video demo
- **Binary signing**: Explicit codesign step before main app signing should ensure proper chain