### PR TITLE
Fix wavetable selectors for firmware 1.13

### DIFF
--- a/lib/ui/parameter_editor_registry.dart
+++ b/lib/ui/parameter_editor_registry.dart
@@ -35,6 +35,9 @@ enum ParameterUnitScheme {
 
 /// Unit constants for each firmware scheme
 class ParameterUnits {
+  // Common across all firmware versions
+  static const int enum_ = 1; // kNT_unitEnum - enumStrings must also be provided
+
   // Legacy firmware (≤1.12)
   static const int legacyFilePath = 13;
   static const int legacyFileFolder = 14;
@@ -444,21 +447,39 @@ class ParameterEditorRegistry {
       description: 'Three Pot program selection',
     ),
 
-    // Wavetable
+    // Wavetable - unit 16 (kNT_unitHasStrings)
     ParameterEditorRule(
       algorithmGuid: 'vcot',
       parameterNamePattern: r'.*[Ww]avetable.*',
       unit: ParameterUnits.modernHasStrings,
       baseDirectory: '/wavetables',
       mode: FileSelectionMode.folderOnly,
-      description: 'VCO Wavetable folder selection',
+      description: 'VCO Wavetable folder selection (hasStrings)',
     ),
     ParameterEditorRule(
       parameterNamePattern: r'.*[Ww]avetable.*',
       unit: ParameterUnits.modernHasStrings,
       baseDirectory: '/wavetables',
       mode: FileSelectionMode.folderOnly,
-      description: 'Wavetable folder selection',
+      description: 'Wavetable folder selection (hasStrings)',
+    ),
+
+    // Wavetable - unit 1 (kNT_unitEnum)
+    // Some algorithms (e.g., Dream Machine) use enum unit for wavetables
+    ParameterEditorRule(
+      algorithmGuid: 'vcot',
+      parameterNamePattern: r'.*[Ww]avetable.*',
+      unit: ParameterUnits.enum_,
+      baseDirectory: '/wavetables',
+      mode: FileSelectionMode.folderOnly,
+      description: 'VCO Wavetable folder selection (enum)',
+    ),
+    ParameterEditorRule(
+      parameterNamePattern: r'.*[Ww]avetable.*',
+      unit: ParameterUnits.enum_,
+      baseDirectory: '/wavetables',
+      mode: FileSelectionMode.folderOnly,
+      description: 'Wavetable folder selection (enum)',
     ),
 
     // Multisample


### PR DESCRIPTION
Add support for wavetable parameters using unit=1 (kNT_unitEnum) in addition
to existing unit=16 (kNT_unitHasStrings) support. Some algorithms like Dream
Machine use enum unit type for wavetable selection in firmware 1.13.

Changes:
- Add ParameterUnits.enum_ constant (value 1) for kNT_unitEnum
- Add two new ParameterEditorRule entries for wavetable parameters with unit=1
- Update existing wavetable rule descriptions to clarify unit type
- Ensures FileParameterEditor is used for wavetable selection regardless of
  whether the firmware reports unit=1 or unit=16

This allows wavetable selectors to properly browse /wavetables directory
via SD card file listing instead of falling back to broken enum dropdowns.

Fixes issue reported by Dream Machine user on firmware 1.13 where wavetable
selectors were not working.