### PR TITLE
refactor: bus-assignment model with PortRole enum

### DIFF
--- a/lib/core/routing/connection_discovery_service.dart
+++ b/lib/core/routing/connection_discovery_service.dart
@@ -30,11 +30,15 @@ class ConnectionDiscoveryService {
       final routing = routings[i];
       final algorithmId = _extractAlgorithmId(routing);
 
-      // Register input ports
-      _registerPorts(routing.inputPorts, algorithmId, i, false, busRegistry);
+      // Register input ports (bus readers)
+      _registerPorts(
+        routing.inputPorts, algorithmId, i, PortRole.busReader, busRegistry,
+      );
 
-      // Register output ports
-      _registerPorts(routing.outputPorts, algorithmId, i, true, busRegistry);
+      // Register output ports (bus writers)
+      _registerPorts(
+        routing.outputPorts, algorithmId, i, PortRole.busWriter, busRegistry,
+      );
     }
 
     // Debug: Print bus registry summary
@@ -196,7 +200,7 @@ class ConnectionDiscoveryService {
     List<Port> ports,
     String algorithmId,
     int algorithmIndex,
-    bool isOutput,
+    PortRole role,
     Map<int, List<_PortAssignment>> busRegistry,
   ) {
     for (final port in ports) {
@@ -212,7 +216,7 @@ class ConnectionDiscoveryService {
                 portName: port.name,
                 parameterName: port.busParam ?? '',
                 parameterNumber: port.parameterNumber ?? 0,
-                isOutput: isOutput,
+                role: role,
                 portType: port.type,
                 busValue: busValue,
                 outputMode: port.outputMode,
@@ -586,7 +590,7 @@ class _PortAssignment {
   final String portName;
   final String parameterName;
   final int parameterNumber;
-  final bool isOutput;
+  final PortRole role;
   final PortType portType;
   final int busValue;
   final OutputMode? outputMode;
@@ -598,9 +602,12 @@ class _PortAssignment {
     required this.portName,
     required this.parameterName,
     required this.parameterNumber,
-    required this.isOutput,
+    required this.role,
     required this.portType,
     required this.busValue,
     this.outputMode,
   });
+
+  /// Whether this port writes to the bus (legacy compatibility).
+  bool get isOutput => role == PortRole.busWriter;
 }

--- a/lib/core/routing/models/es5_hardware_node.dart
+++ b/lib/core/routing/models/es5_hardware_node.dart
@@ -54,8 +54,8 @@ class ES5HardwareNode {
         direction: PortDirection.input,
         description: 'ES-5 Left (Silent Way)',
         busValue: leftAudioBus,
-        isPhysical: true,
         nodeId: id,
+        role: PortRole.es5Bus,
       ),
     );
 
@@ -68,8 +68,8 @@ class ES5HardwareNode {
         direction: PortDirection.input,
         description: 'ES-5 Right (Silent Way)',
         busValue: rightAudioBus,
-        isPhysical: true,
         nodeId: id,
+        role: PortRole.es5Bus,
       ),
     );
 
@@ -82,8 +82,8 @@ class ES5HardwareNode {
           type: PortType.cv, // All gate/trigger signals are CV (Story 7.5)
           direction: PortDirection.input,
           description: 'ES-5 Output $i',
-          isPhysical: true,
           nodeId: id,
+          role: PortRole.es5Bus,
         ),
       );
     }
@@ -115,8 +115,8 @@ class ES5HardwareNode {
       direction: PortDirection.input,
       description: 'ES-5 Left (Silent Way)',
       busValue: leftAudioBus,
-      isPhysical: true,
       nodeId: id,
+      role: PortRole.es5Bus,
     );
   }
 
@@ -129,8 +129,8 @@ class ES5HardwareNode {
       direction: PortDirection.input,
       description: 'ES-5 Right (Silent Way)',
       busValue: rightAudioBus,
-      isPhysical: true,
       nodeId: id,
+      role: PortRole.es5Bus,
     );
   }
 
@@ -151,8 +151,8 @@ class ES5HardwareNode {
       type: PortType.cv, // All gate/trigger signals are CV (Story 7.5)
       direction: PortDirection.input,
       description: 'ES-5 Output $portNumber',
-      isPhysical: true,
       nodeId: id,
+      role: PortRole.es5Bus,
     );
   }
 }

--- a/lib/core/routing/models/port.freezed.dart
+++ b/lib/core/routing/models/port.freezed.dart
@@ -43,7 +43,9 @@ mixin _$Port {
  bool get isPhysical;/// The hardware index for physical ports (1-based)
  int? get hardwareIndex;/// The jack type for physical ports ('input' or 'output')
  String? get jackType;/// The node identifier for grouping related ports
- String? get nodeId;
+ String? get nodeId;/// The role this port plays in the bus-assignment routing model.
+/// If not set, derived from [direction], [isPhysical], and port ID conventions.
+ PortRole? get role;
 /// Create a copy of Port
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -56,16 +58,16 @@ $PortCopyWith<Port> get copyWith => _$PortCopyWithImpl<Port>(this as Port, _$ide
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Port&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.direction, direction) || other.direction == direction)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other.constraints, constraints)&&(identical(other.isActive, isActive) || other.isActive == isActive)&&(identical(other.outputMode, outputMode) || other.outputMode == outputMode)&&(identical(other.isPolyVoice, isPolyVoice) || other.isPolyVoice == isPolyVoice)&&(identical(other.voiceNumber, voiceNumber) || other.voiceNumber == voiceNumber)&&(identical(other.isVirtualCV, isVirtualCV) || other.isVirtualCV == isVirtualCV)&&(identical(other.isMultiChannel, isMultiChannel) || other.isMultiChannel == isMultiChannel)&&(identical(other.channelNumber, channelNumber) || other.channelNumber == channelNumber)&&(identical(other.isStereoChannel, isStereoChannel) || other.isStereoChannel == isStereoChannel)&&(identical(other.stereoSide, stereoSide) || other.stereoSide == stereoSide)&&(identical(other.isMasterMix, isMasterMix) || other.isMasterMix == isMasterMix)&&(identical(other.busValue, busValue) || other.busValue == busValue)&&(identical(other.busParam, busParam) || other.busParam == busParam)&&(identical(other.parameterNumber, parameterNumber) || other.parameterNumber == parameterNumber)&&(identical(other.modeParameterNumber, modeParameterNumber) || other.modeParameterNumber == modeParameterNumber)&&(identical(other.isPhysical, isPhysical) || other.isPhysical == isPhysical)&&(identical(other.hardwareIndex, hardwareIndex) || other.hardwareIndex == hardwareIndex)&&(identical(other.jackType, jackType) || other.jackType == jackType)&&(identical(other.nodeId, nodeId) || other.nodeId == nodeId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Port&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.direction, direction) || other.direction == direction)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other.constraints, constraints)&&(identical(other.isActive, isActive) || other.isActive == isActive)&&(identical(other.outputMode, outputMode) || other.outputMode == outputMode)&&(identical(other.isPolyVoice, isPolyVoice) || other.isPolyVoice == isPolyVoice)&&(identical(other.voiceNumber, voiceNumber) || other.voiceNumber == voiceNumber)&&(identical(other.isVirtualCV, isVirtualCV) || other.isVirtualCV == isVirtualCV)&&(identical(other.isMultiChannel, isMultiChannel) || other.isMultiChannel == isMultiChannel)&&(identical(other.channelNumber, channelNumber) || other.channelNumber == channelNumber)&&(identical(other.isStereoChannel, isStereoChannel) || other.isStereoChannel == isStereoChannel)&&(identical(other.stereoSide, stereoSide) || other.stereoSide == stereoSide)&&(identical(other.isMasterMix, isMasterMix) || other.isMasterMix == isMasterMix)&&(identical(other.busValue, busValue) || other.busValue == busValue)&&(identical(other.busParam, busParam) || other.busParam == busParam)&&(identical(other.parameterNumber, parameterNumber) || other.parameterNumber == parameterNumber)&&(identical(other.modeParameterNumber, modeParameterNumber) || other.modeParameterNumber == modeParameterNumber)&&(identical(other.isPhysical, isPhysical) || other.isPhysical == isPhysical)&&(identical(other.hardwareIndex, hardwareIndex) || other.hardwareIndex == hardwareIndex)&&(identical(other.jackType, jackType) || other.jackType == jackType)&&(identical(other.nodeId, nodeId) || other.nodeId == nodeId)&&(identical(other.role, role) || other.role == role));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,name,type,direction,description,const DeepCollectionEquality().hash(constraints),isActive,outputMode,isPolyVoice,voiceNumber,isVirtualCV,isMultiChannel,channelNumber,isStereoChannel,stereoSide,isMasterMix,busValue,busParam,parameterNumber,modeParameterNumber,isPhysical,hardwareIndex,jackType,nodeId]);
+int get hashCode => Object.hashAll([runtimeType,id,name,type,direction,description,const DeepCollectionEquality().hash(constraints),isActive,outputMode,isPolyVoice,voiceNumber,isVirtualCV,isMultiChannel,channelNumber,isStereoChannel,stereoSide,isMasterMix,busValue,busParam,parameterNumber,modeParameterNumber,isPhysical,hardwareIndex,jackType,nodeId,role]);
 
 @override
 String toString() {
-  return 'Port(id: $id, name: $name, type: $type, direction: $direction, description: $description, constraints: $constraints, isActive: $isActive, outputMode: $outputMode, isPolyVoice: $isPolyVoice, voiceNumber: $voiceNumber, isVirtualCV: $isVirtualCV, isMultiChannel: $isMultiChannel, channelNumber: $channelNumber, isStereoChannel: $isStereoChannel, stereoSide: $stereoSide, isMasterMix: $isMasterMix, busValue: $busValue, busParam: $busParam, parameterNumber: $parameterNumber, modeParameterNumber: $modeParameterNumber, isPhysical: $isPhysical, hardwareIndex: $hardwareIndex, jackType: $jackType, nodeId: $nodeId)';
+  return 'Port(id: $id, name: $name, type: $type, direction: $direction, description: $description, constraints: $constraints, isActive: $isActive, outputMode: $outputMode, isPolyVoice: $isPolyVoice, voiceNumber: $voiceNumber, isVirtualCV: $isVirtualCV, isMultiChannel: $isMultiChannel, channelNumber: $channelNumber, isStereoChannel: $isStereoChannel, stereoSide: $stereoSide, isMasterMix: $isMasterMix, busValue: $busValue, busParam: $busParam, parameterNumber: $parameterNumber, modeParameterNumber: $modeParameterNumber, isPhysical: $isPhysical, hardwareIndex: $hardwareIndex, jackType: $jackType, nodeId: $nodeId, role: $role)';
 }
 
 
@@ -76,7 +78,7 @@ abstract mixin class $PortCopyWith<$Res>  {
   factory $PortCopyWith(Port value, $Res Function(Port) _then) = _$PortCopyWithImpl;
 @useResult
 $Res call({
- String id, String name, PortType type, PortDirection direction, String? description, Map<String, dynamic>? constraints, bool isActive, OutputMode? outputMode, bool isPolyVoice, int? voiceNumber, bool isVirtualCV, bool isMultiChannel, int? channelNumber, bool isStereoChannel, String? stereoSide, bool isMasterMix, int? busValue, String? busParam, int? parameterNumber, int? modeParameterNumber, bool isPhysical, int? hardwareIndex, String? jackType, String? nodeId
+ String id, String name, PortType type, PortDirection direction, String? description, Map<String, dynamic>? constraints, bool isActive, OutputMode? outputMode, bool isPolyVoice, int? voiceNumber, bool isVirtualCV, bool isMultiChannel, int? channelNumber, bool isStereoChannel, String? stereoSide, bool isMasterMix, int? busValue, String? busParam, int? parameterNumber, int? modeParameterNumber, bool isPhysical, int? hardwareIndex, String? jackType, String? nodeId, PortRole? role
 });
 
 
@@ -93,7 +95,7 @@ class _$PortCopyWithImpl<$Res>
 
 /// Create a copy of Port
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? direction = null,Object? description = freezed,Object? constraints = freezed,Object? isActive = null,Object? outputMode = freezed,Object? isPolyVoice = null,Object? voiceNumber = freezed,Object? isVirtualCV = null,Object? isMultiChannel = null,Object? channelNumber = freezed,Object? isStereoChannel = null,Object? stereoSide = freezed,Object? isMasterMix = null,Object? busValue = freezed,Object? busParam = freezed,Object? parameterNumber = freezed,Object? modeParameterNumber = freezed,Object? isPhysical = null,Object? hardwareIndex = freezed,Object? jackType = freezed,Object? nodeId = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? direction = null,Object? description = freezed,Object? constraints = freezed,Object? isActive = null,Object? outputMode = freezed,Object? isPolyVoice = null,Object? voiceNumber = freezed,Object? isVirtualCV = null,Object? isMultiChannel = null,Object? channelNumber = freezed,Object? isStereoChannel = null,Object? stereoSide = freezed,Object? isMasterMix = null,Object? busValue = freezed,Object? busParam = freezed,Object? parameterNumber = freezed,Object? modeParameterNumber = freezed,Object? isPhysical = null,Object? hardwareIndex = freezed,Object? jackType = freezed,Object? nodeId = freezed,Object? role = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -119,7 +121,8 @@ as int?,isPhysical: null == isPhysical ? _self.isPhysical : isPhysical // ignore
 as bool,hardwareIndex: freezed == hardwareIndex ? _self.hardwareIndex : hardwareIndex // ignore: cast_nullable_to_non_nullable
 as int?,jackType: freezed == jackType ? _self.jackType : jackType // ignore: cast_nullable_to_non_nullable
 as String?,nodeId: freezed == nodeId ? _self.nodeId : nodeId // ignore: cast_nullable_to_non_nullable
-as String?,
+as String?,role: freezed == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
+as PortRole?,
   ));
 }
 
@@ -201,10 +204,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  PortType type,  PortDirection direction,  String? description,  Map<String, dynamic>? constraints,  bool isActive,  OutputMode? outputMode,  bool isPolyVoice,  int? voiceNumber,  bool isVirtualCV,  bool isMultiChannel,  int? channelNumber,  bool isStereoChannel,  String? stereoSide,  bool isMasterMix,  int? busValue,  String? busParam,  int? parameterNumber,  int? modeParameterNumber,  bool isPhysical,  int? hardwareIndex,  String? jackType,  String? nodeId)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  PortType type,  PortDirection direction,  String? description,  Map<String, dynamic>? constraints,  bool isActive,  OutputMode? outputMode,  bool isPolyVoice,  int? voiceNumber,  bool isVirtualCV,  bool isMultiChannel,  int? channelNumber,  bool isStereoChannel,  String? stereoSide,  bool isMasterMix,  int? busValue,  String? busParam,  int? parameterNumber,  int? modeParameterNumber,  bool isPhysical,  int? hardwareIndex,  String? jackType,  String? nodeId,  PortRole? role)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Port() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.direction,_that.description,_that.constraints,_that.isActive,_that.outputMode,_that.isPolyVoice,_that.voiceNumber,_that.isVirtualCV,_that.isMultiChannel,_that.channelNumber,_that.isStereoChannel,_that.stereoSide,_that.isMasterMix,_that.busValue,_that.busParam,_that.parameterNumber,_that.modeParameterNumber,_that.isPhysical,_that.hardwareIndex,_that.jackType,_that.nodeId);case _:
+return $default(_that.id,_that.name,_that.type,_that.direction,_that.description,_that.constraints,_that.isActive,_that.outputMode,_that.isPolyVoice,_that.voiceNumber,_that.isVirtualCV,_that.isMultiChannel,_that.channelNumber,_that.isStereoChannel,_that.stereoSide,_that.isMasterMix,_that.busValue,_that.busParam,_that.parameterNumber,_that.modeParameterNumber,_that.isPhysical,_that.hardwareIndex,_that.jackType,_that.nodeId,_that.role);case _:
   return orElse();
 
 }
@@ -222,10 +225,10 @@ return $default(_that.id,_that.name,_that.type,_that.direction,_that.description
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  PortType type,  PortDirection direction,  String? description,  Map<String, dynamic>? constraints,  bool isActive,  OutputMode? outputMode,  bool isPolyVoice,  int? voiceNumber,  bool isVirtualCV,  bool isMultiChannel,  int? channelNumber,  bool isStereoChannel,  String? stereoSide,  bool isMasterMix,  int? busValue,  String? busParam,  int? parameterNumber,  int? modeParameterNumber,  bool isPhysical,  int? hardwareIndex,  String? jackType,  String? nodeId)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  PortType type,  PortDirection direction,  String? description,  Map<String, dynamic>? constraints,  bool isActive,  OutputMode? outputMode,  bool isPolyVoice,  int? voiceNumber,  bool isVirtualCV,  bool isMultiChannel,  int? channelNumber,  bool isStereoChannel,  String? stereoSide,  bool isMasterMix,  int? busValue,  String? busParam,  int? parameterNumber,  int? modeParameterNumber,  bool isPhysical,  int? hardwareIndex,  String? jackType,  String? nodeId,  PortRole? role)  $default,) {final _that = this;
 switch (_that) {
 case _Port():
-return $default(_that.id,_that.name,_that.type,_that.direction,_that.description,_that.constraints,_that.isActive,_that.outputMode,_that.isPolyVoice,_that.voiceNumber,_that.isVirtualCV,_that.isMultiChannel,_that.channelNumber,_that.isStereoChannel,_that.stereoSide,_that.isMasterMix,_that.busValue,_that.busParam,_that.parameterNumber,_that.modeParameterNumber,_that.isPhysical,_that.hardwareIndex,_that.jackType,_that.nodeId);}
+return $default(_that.id,_that.name,_that.type,_that.direction,_that.description,_that.constraints,_that.isActive,_that.outputMode,_that.isPolyVoice,_that.voiceNumber,_that.isVirtualCV,_that.isMultiChannel,_that.channelNumber,_that.isStereoChannel,_that.stereoSide,_that.isMasterMix,_that.busValue,_that.busParam,_that.parameterNumber,_that.modeParameterNumber,_that.isPhysical,_that.hardwareIndex,_that.jackType,_that.nodeId,_that.role);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -239,10 +242,10 @@ return $default(_that.id,_that.name,_that.type,_that.direction,_that.description
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  PortType type,  PortDirection direction,  String? description,  Map<String, dynamic>? constraints,  bool isActive,  OutputMode? outputMode,  bool isPolyVoice,  int? voiceNumber,  bool isVirtualCV,  bool isMultiChannel,  int? channelNumber,  bool isStereoChannel,  String? stereoSide,  bool isMasterMix,  int? busValue,  String? busParam,  int? parameterNumber,  int? modeParameterNumber,  bool isPhysical,  int? hardwareIndex,  String? jackType,  String? nodeId)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  PortType type,  PortDirection direction,  String? description,  Map<String, dynamic>? constraints,  bool isActive,  OutputMode? outputMode,  bool isPolyVoice,  int? voiceNumber,  bool isVirtualCV,  bool isMultiChannel,  int? channelNumber,  bool isStereoChannel,  String? stereoSide,  bool isMasterMix,  int? busValue,  String? busParam,  int? parameterNumber,  int? modeParameterNumber,  bool isPhysical,  int? hardwareIndex,  String? jackType,  String? nodeId,  PortRole? role)?  $default,) {final _that = this;
 switch (_that) {
 case _Port() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.direction,_that.description,_that.constraints,_that.isActive,_that.outputMode,_that.isPolyVoice,_that.voiceNumber,_that.isVirtualCV,_that.isMultiChannel,_that.channelNumber,_that.isStereoChannel,_that.stereoSide,_that.isMasterMix,_that.busValue,_that.busParam,_that.parameterNumber,_that.modeParameterNumber,_that.isPhysical,_that.hardwareIndex,_that.jackType,_that.nodeId);case _:
+return $default(_that.id,_that.name,_that.type,_that.direction,_that.description,_that.constraints,_that.isActive,_that.outputMode,_that.isPolyVoice,_that.voiceNumber,_that.isVirtualCV,_that.isMultiChannel,_that.channelNumber,_that.isStereoChannel,_that.stereoSide,_that.isMasterMix,_that.busValue,_that.busParam,_that.parameterNumber,_that.modeParameterNumber,_that.isPhysical,_that.hardwareIndex,_that.jackType,_that.nodeId,_that.role);case _:
   return null;
 
 }
@@ -254,7 +257,7 @@ return $default(_that.id,_that.name,_that.type,_that.direction,_that.description
 @JsonSerializable()
 
 class _Port extends Port {
-  const _Port({required this.id, required this.name, required this.type, required this.direction, this.description, final  Map<String, dynamic>? constraints, this.isActive = true, this.outputMode, this.isPolyVoice = false, this.voiceNumber, this.isVirtualCV = false, this.isMultiChannel = false, this.channelNumber, this.isStereoChannel = false, this.stereoSide, this.isMasterMix = false, this.busValue, this.busParam, this.parameterNumber, this.modeParameterNumber, this.isPhysical = false, this.hardwareIndex, this.jackType, this.nodeId}): _constraints = constraints,super._();
+  const _Port({required this.id, required this.name, required this.type, required this.direction, this.description, final  Map<String, dynamic>? constraints, this.isActive = true, this.outputMode, this.isPolyVoice = false, this.voiceNumber, this.isVirtualCV = false, this.isMultiChannel = false, this.channelNumber, this.isStereoChannel = false, this.stereoSide, this.isMasterMix = false, this.busValue, this.busParam, this.parameterNumber, this.modeParameterNumber, this.isPhysical = false, this.hardwareIndex, this.jackType, this.nodeId, this.role}): _constraints = constraints,super._();
   factory _Port.fromJson(Map<String, dynamic> json) => _$PortFromJson(json);
 
 /// Unique identifier for this port
@@ -318,6 +321,9 @@ class _Port extends Port {
 @override final  String? jackType;
 /// The node identifier for grouping related ports
 @override final  String? nodeId;
+/// The role this port plays in the bus-assignment routing model.
+/// If not set, derived from [direction], [isPhysical], and port ID conventions.
+@override final  PortRole? role;
 
 /// Create a copy of Port
 /// with the given fields replaced by the non-null parameter values.
@@ -332,16 +338,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Port&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.direction, direction) || other.direction == direction)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other._constraints, _constraints)&&(identical(other.isActive, isActive) || other.isActive == isActive)&&(identical(other.outputMode, outputMode) || other.outputMode == outputMode)&&(identical(other.isPolyVoice, isPolyVoice) || other.isPolyVoice == isPolyVoice)&&(identical(other.voiceNumber, voiceNumber) || other.voiceNumber == voiceNumber)&&(identical(other.isVirtualCV, isVirtualCV) || other.isVirtualCV == isVirtualCV)&&(identical(other.isMultiChannel, isMultiChannel) || other.isMultiChannel == isMultiChannel)&&(identical(other.channelNumber, channelNumber) || other.channelNumber == channelNumber)&&(identical(other.isStereoChannel, isStereoChannel) || other.isStereoChannel == isStereoChannel)&&(identical(other.stereoSide, stereoSide) || other.stereoSide == stereoSide)&&(identical(other.isMasterMix, isMasterMix) || other.isMasterMix == isMasterMix)&&(identical(other.busValue, busValue) || other.busValue == busValue)&&(identical(other.busParam, busParam) || other.busParam == busParam)&&(identical(other.parameterNumber, parameterNumber) || other.parameterNumber == parameterNumber)&&(identical(other.modeParameterNumber, modeParameterNumber) || other.modeParameterNumber == modeParameterNumber)&&(identical(other.isPhysical, isPhysical) || other.isPhysical == isPhysical)&&(identical(other.hardwareIndex, hardwareIndex) || other.hardwareIndex == hardwareIndex)&&(identical(other.jackType, jackType) || other.jackType == jackType)&&(identical(other.nodeId, nodeId) || other.nodeId == nodeId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Port&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.direction, direction) || other.direction == direction)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other._constraints, _constraints)&&(identical(other.isActive, isActive) || other.isActive == isActive)&&(identical(other.outputMode, outputMode) || other.outputMode == outputMode)&&(identical(other.isPolyVoice, isPolyVoice) || other.isPolyVoice == isPolyVoice)&&(identical(other.voiceNumber, voiceNumber) || other.voiceNumber == voiceNumber)&&(identical(other.isVirtualCV, isVirtualCV) || other.isVirtualCV == isVirtualCV)&&(identical(other.isMultiChannel, isMultiChannel) || other.isMultiChannel == isMultiChannel)&&(identical(other.channelNumber, channelNumber) || other.channelNumber == channelNumber)&&(identical(other.isStereoChannel, isStereoChannel) || other.isStereoChannel == isStereoChannel)&&(identical(other.stereoSide, stereoSide) || other.stereoSide == stereoSide)&&(identical(other.isMasterMix, isMasterMix) || other.isMasterMix == isMasterMix)&&(identical(other.busValue, busValue) || other.busValue == busValue)&&(identical(other.busParam, busParam) || other.busParam == busParam)&&(identical(other.parameterNumber, parameterNumber) || other.parameterNumber == parameterNumber)&&(identical(other.modeParameterNumber, modeParameterNumber) || other.modeParameterNumber == modeParameterNumber)&&(identical(other.isPhysical, isPhysical) || other.isPhysical == isPhysical)&&(identical(other.hardwareIndex, hardwareIndex) || other.hardwareIndex == hardwareIndex)&&(identical(other.jackType, jackType) || other.jackType == jackType)&&(identical(other.nodeId, nodeId) || other.nodeId == nodeId)&&(identical(other.role, role) || other.role == role));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,name,type,direction,description,const DeepCollectionEquality().hash(_constraints),isActive,outputMode,isPolyVoice,voiceNumber,isVirtualCV,isMultiChannel,channelNumber,isStereoChannel,stereoSide,isMasterMix,busValue,busParam,parameterNumber,modeParameterNumber,isPhysical,hardwareIndex,jackType,nodeId]);
+int get hashCode => Object.hashAll([runtimeType,id,name,type,direction,description,const DeepCollectionEquality().hash(_constraints),isActive,outputMode,isPolyVoice,voiceNumber,isVirtualCV,isMultiChannel,channelNumber,isStereoChannel,stereoSide,isMasterMix,busValue,busParam,parameterNumber,modeParameterNumber,isPhysical,hardwareIndex,jackType,nodeId,role]);
 
 @override
 String toString() {
-  return 'Port(id: $id, name: $name, type: $type, direction: $direction, description: $description, constraints: $constraints, isActive: $isActive, outputMode: $outputMode, isPolyVoice: $isPolyVoice, voiceNumber: $voiceNumber, isVirtualCV: $isVirtualCV, isMultiChannel: $isMultiChannel, channelNumber: $channelNumber, isStereoChannel: $isStereoChannel, stereoSide: $stereoSide, isMasterMix: $isMasterMix, busValue: $busValue, busParam: $busParam, parameterNumber: $parameterNumber, modeParameterNumber: $modeParameterNumber, isPhysical: $isPhysical, hardwareIndex: $hardwareIndex, jackType: $jackType, nodeId: $nodeId)';
+  return 'Port(id: $id, name: $name, type: $type, direction: $direction, description: $description, constraints: $constraints, isActive: $isActive, outputMode: $outputMode, isPolyVoice: $isPolyVoice, voiceNumber: $voiceNumber, isVirtualCV: $isVirtualCV, isMultiChannel: $isMultiChannel, channelNumber: $channelNumber, isStereoChannel: $isStereoChannel, stereoSide: $stereoSide, isMasterMix: $isMasterMix, busValue: $busValue, busParam: $busParam, parameterNumber: $parameterNumber, modeParameterNumber: $modeParameterNumber, isPhysical: $isPhysical, hardwareIndex: $hardwareIndex, jackType: $jackType, nodeId: $nodeId, role: $role)';
 }
 
 
@@ -352,7 +358,7 @@ abstract mixin class _$PortCopyWith<$Res> implements $PortCopyWith<$Res> {
   factory _$PortCopyWith(_Port value, $Res Function(_Port) _then) = __$PortCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name, PortType type, PortDirection direction, String? description, Map<String, dynamic>? constraints, bool isActive, OutputMode? outputMode, bool isPolyVoice, int? voiceNumber, bool isVirtualCV, bool isMultiChannel, int? channelNumber, bool isStereoChannel, String? stereoSide, bool isMasterMix, int? busValue, String? busParam, int? parameterNumber, int? modeParameterNumber, bool isPhysical, int? hardwareIndex, String? jackType, String? nodeId
+ String id, String name, PortType type, PortDirection direction, String? description, Map<String, dynamic>? constraints, bool isActive, OutputMode? outputMode, bool isPolyVoice, int? voiceNumber, bool isVirtualCV, bool isMultiChannel, int? channelNumber, bool isStereoChannel, String? stereoSide, bool isMasterMix, int? busValue, String? busParam, int? parameterNumber, int? modeParameterNumber, bool isPhysical, int? hardwareIndex, String? jackType, String? nodeId, PortRole? role
 });
 
 
@@ -369,7 +375,7 @@ class __$PortCopyWithImpl<$Res>
 
 /// Create a copy of Port
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? direction = null,Object? description = freezed,Object? constraints = freezed,Object? isActive = null,Object? outputMode = freezed,Object? isPolyVoice = null,Object? voiceNumber = freezed,Object? isVirtualCV = null,Object? isMultiChannel = null,Object? channelNumber = freezed,Object? isStereoChannel = null,Object? stereoSide = freezed,Object? isMasterMix = null,Object? busValue = freezed,Object? busParam = freezed,Object? parameterNumber = freezed,Object? modeParameterNumber = freezed,Object? isPhysical = null,Object? hardwareIndex = freezed,Object? jackType = freezed,Object? nodeId = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? direction = null,Object? description = freezed,Object? constraints = freezed,Object? isActive = null,Object? outputMode = freezed,Object? isPolyVoice = null,Object? voiceNumber = freezed,Object? isVirtualCV = null,Object? isMultiChannel = null,Object? channelNumber = freezed,Object? isStereoChannel = null,Object? stereoSide = freezed,Object? isMasterMix = null,Object? busValue = freezed,Object? busParam = freezed,Object? parameterNumber = freezed,Object? modeParameterNumber = freezed,Object? isPhysical = null,Object? hardwareIndex = freezed,Object? jackType = freezed,Object? nodeId = freezed,Object? role = freezed,}) {
   return _then(_Port(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -395,7 +401,8 @@ as int?,isPhysical: null == isPhysical ? _self.isPhysical : isPhysical // ignore
 as bool,hardwareIndex: freezed == hardwareIndex ? _self.hardwareIndex : hardwareIndex // ignore: cast_nullable_to_non_nullable
 as int?,jackType: freezed == jackType ? _self.jackType : jackType // ignore: cast_nullable_to_non_nullable
 as String?,nodeId: freezed == nodeId ? _self.nodeId : nodeId // ignore: cast_nullable_to_non_nullable
-as String?,
+as String?,role: freezed == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
+as PortRole?,
   ));
 }
 

--- a/lib/core/routing/models/port.freezed.dart
+++ b/lib/core/routing/models/port.freezed.dart
@@ -38,13 +38,12 @@ mixin _$Port {
  int? get busValue;/// The parameter name associated with this port's bus assignment
  String? get busParam;/// The parameter number associated with this port
  int? get parameterNumber;/// The mode parameter number for this port's output mode (Add/Replace)
- int? get modeParameterNumber;// Direct properties for physical ports
-/// Whether this port represents a physical hardware port
- bool get isPhysical;/// The hardware index for physical ports (1-based)
- int? get hardwareIndex;/// The jack type for physical ports ('input' or 'output')
- String? get jackType;/// The node identifier for grouping related ports
+ int? get modeParameterNumber;/// The hardware index for physical/ES-5 ports (1-based).
+/// For physical ports this equals the bus number for inputs (1-12)
+/// or the jack number for outputs (1-8, mapped to buses 13-20).
+ int? get hardwareIndex;/// The node identifier for grouping related ports
  String? get nodeId;/// The role this port plays in the bus-assignment routing model.
-/// If not set, derived from [direction], [isPhysical], and port ID conventions.
+/// If not set, derived from [direction] and port ID conventions.
  PortRole? get role;
 /// Create a copy of Port
 /// with the given fields replaced by the non-null parameter values.
@@ -58,16 +57,16 @@ $PortCopyWith<Port> get copyWith => _$PortCopyWithImpl<Port>(this as Port, _$ide
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Port&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.direction, direction) || other.direction == direction)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other.constraints, constraints)&&(identical(other.isActive, isActive) || other.isActive == isActive)&&(identical(other.outputMode, outputMode) || other.outputMode == outputMode)&&(identical(other.isPolyVoice, isPolyVoice) || other.isPolyVoice == isPolyVoice)&&(identical(other.voiceNumber, voiceNumber) || other.voiceNumber == voiceNumber)&&(identical(other.isVirtualCV, isVirtualCV) || other.isVirtualCV == isVirtualCV)&&(identical(other.isMultiChannel, isMultiChannel) || other.isMultiChannel == isMultiChannel)&&(identical(other.channelNumber, channelNumber) || other.channelNumber == channelNumber)&&(identical(other.isStereoChannel, isStereoChannel) || other.isStereoChannel == isStereoChannel)&&(identical(other.stereoSide, stereoSide) || other.stereoSide == stereoSide)&&(identical(other.isMasterMix, isMasterMix) || other.isMasterMix == isMasterMix)&&(identical(other.busValue, busValue) || other.busValue == busValue)&&(identical(other.busParam, busParam) || other.busParam == busParam)&&(identical(other.parameterNumber, parameterNumber) || other.parameterNumber == parameterNumber)&&(identical(other.modeParameterNumber, modeParameterNumber) || other.modeParameterNumber == modeParameterNumber)&&(identical(other.isPhysical, isPhysical) || other.isPhysical == isPhysical)&&(identical(other.hardwareIndex, hardwareIndex) || other.hardwareIndex == hardwareIndex)&&(identical(other.jackType, jackType) || other.jackType == jackType)&&(identical(other.nodeId, nodeId) || other.nodeId == nodeId)&&(identical(other.role, role) || other.role == role));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Port&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.direction, direction) || other.direction == direction)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other.constraints, constraints)&&(identical(other.isActive, isActive) || other.isActive == isActive)&&(identical(other.outputMode, outputMode) || other.outputMode == outputMode)&&(identical(other.isPolyVoice, isPolyVoice) || other.isPolyVoice == isPolyVoice)&&(identical(other.voiceNumber, voiceNumber) || other.voiceNumber == voiceNumber)&&(identical(other.isVirtualCV, isVirtualCV) || other.isVirtualCV == isVirtualCV)&&(identical(other.isMultiChannel, isMultiChannel) || other.isMultiChannel == isMultiChannel)&&(identical(other.channelNumber, channelNumber) || other.channelNumber == channelNumber)&&(identical(other.isStereoChannel, isStereoChannel) || other.isStereoChannel == isStereoChannel)&&(identical(other.stereoSide, stereoSide) || other.stereoSide == stereoSide)&&(identical(other.isMasterMix, isMasterMix) || other.isMasterMix == isMasterMix)&&(identical(other.busValue, busValue) || other.busValue == busValue)&&(identical(other.busParam, busParam) || other.busParam == busParam)&&(identical(other.parameterNumber, parameterNumber) || other.parameterNumber == parameterNumber)&&(identical(other.modeParameterNumber, modeParameterNumber) || other.modeParameterNumber == modeParameterNumber)&&(identical(other.hardwareIndex, hardwareIndex) || other.hardwareIndex == hardwareIndex)&&(identical(other.nodeId, nodeId) || other.nodeId == nodeId)&&(identical(other.role, role) || other.role == role));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,name,type,direction,description,const DeepCollectionEquality().hash(constraints),isActive,outputMode,isPolyVoice,voiceNumber,isVirtualCV,isMultiChannel,channelNumber,isStereoChannel,stereoSide,isMasterMix,busValue,busParam,parameterNumber,modeParameterNumber,isPhysical,hardwareIndex,jackType,nodeId,role]);
+int get hashCode => Object.hashAll([runtimeType,id,name,type,direction,description,const DeepCollectionEquality().hash(constraints),isActive,outputMode,isPolyVoice,voiceNumber,isVirtualCV,isMultiChannel,channelNumber,isStereoChannel,stereoSide,isMasterMix,busValue,busParam,parameterNumber,modeParameterNumber,hardwareIndex,nodeId,role]);
 
 @override
 String toString() {
-  return 'Port(id: $id, name: $name, type: $type, direction: $direction, description: $description, constraints: $constraints, isActive: $isActive, outputMode: $outputMode, isPolyVoice: $isPolyVoice, voiceNumber: $voiceNumber, isVirtualCV: $isVirtualCV, isMultiChannel: $isMultiChannel, channelNumber: $channelNumber, isStereoChannel: $isStereoChannel, stereoSide: $stereoSide, isMasterMix: $isMasterMix, busValue: $busValue, busParam: $busParam, parameterNumber: $parameterNumber, modeParameterNumber: $modeParameterNumber, isPhysical: $isPhysical, hardwareIndex: $hardwareIndex, jackType: $jackType, nodeId: $nodeId, role: $role)';
+  return 'Port(id: $id, name: $name, type: $type, direction: $direction, description: $description, constraints: $constraints, isActive: $isActive, outputMode: $outputMode, isPolyVoice: $isPolyVoice, voiceNumber: $voiceNumber, isVirtualCV: $isVirtualCV, isMultiChannel: $isMultiChannel, channelNumber: $channelNumber, isStereoChannel: $isStereoChannel, stereoSide: $stereoSide, isMasterMix: $isMasterMix, busValue: $busValue, busParam: $busParam, parameterNumber: $parameterNumber, modeParameterNumber: $modeParameterNumber, hardwareIndex: $hardwareIndex, nodeId: $nodeId, role: $role)';
 }
 
 
@@ -78,7 +77,7 @@ abstract mixin class $PortCopyWith<$Res>  {
   factory $PortCopyWith(Port value, $Res Function(Port) _then) = _$PortCopyWithImpl;
 @useResult
 $Res call({
- String id, String name, PortType type, PortDirection direction, String? description, Map<String, dynamic>? constraints, bool isActive, OutputMode? outputMode, bool isPolyVoice, int? voiceNumber, bool isVirtualCV, bool isMultiChannel, int? channelNumber, bool isStereoChannel, String? stereoSide, bool isMasterMix, int? busValue, String? busParam, int? parameterNumber, int? modeParameterNumber, bool isPhysical, int? hardwareIndex, String? jackType, String? nodeId, PortRole? role
+ String id, String name, PortType type, PortDirection direction, String? description, Map<String, dynamic>? constraints, bool isActive, OutputMode? outputMode, bool isPolyVoice, int? voiceNumber, bool isVirtualCV, bool isMultiChannel, int? channelNumber, bool isStereoChannel, String? stereoSide, bool isMasterMix, int? busValue, String? busParam, int? parameterNumber, int? modeParameterNumber, int? hardwareIndex, String? nodeId, PortRole? role
 });
 
 
@@ -95,7 +94,7 @@ class _$PortCopyWithImpl<$Res>
 
 /// Create a copy of Port
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? direction = null,Object? description = freezed,Object? constraints = freezed,Object? isActive = null,Object? outputMode = freezed,Object? isPolyVoice = null,Object? voiceNumber = freezed,Object? isVirtualCV = null,Object? isMultiChannel = null,Object? channelNumber = freezed,Object? isStereoChannel = null,Object? stereoSide = freezed,Object? isMasterMix = null,Object? busValue = freezed,Object? busParam = freezed,Object? parameterNumber = freezed,Object? modeParameterNumber = freezed,Object? isPhysical = null,Object? hardwareIndex = freezed,Object? jackType = freezed,Object? nodeId = freezed,Object? role = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? direction = null,Object? description = freezed,Object? constraints = freezed,Object? isActive = null,Object? outputMode = freezed,Object? isPolyVoice = null,Object? voiceNumber = freezed,Object? isVirtualCV = null,Object? isMultiChannel = null,Object? channelNumber = freezed,Object? isStereoChannel = null,Object? stereoSide = freezed,Object? isMasterMix = null,Object? busValue = freezed,Object? busParam = freezed,Object? parameterNumber = freezed,Object? modeParameterNumber = freezed,Object? hardwareIndex = freezed,Object? nodeId = freezed,Object? role = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -117,10 +116,8 @@ as bool,busValue: freezed == busValue ? _self.busValue : busValue // ignore: cas
 as int?,busParam: freezed == busParam ? _self.busParam : busParam // ignore: cast_nullable_to_non_nullable
 as String?,parameterNumber: freezed == parameterNumber ? _self.parameterNumber : parameterNumber // ignore: cast_nullable_to_non_nullable
 as int?,modeParameterNumber: freezed == modeParameterNumber ? _self.modeParameterNumber : modeParameterNumber // ignore: cast_nullable_to_non_nullable
-as int?,isPhysical: null == isPhysical ? _self.isPhysical : isPhysical // ignore: cast_nullable_to_non_nullable
-as bool,hardwareIndex: freezed == hardwareIndex ? _self.hardwareIndex : hardwareIndex // ignore: cast_nullable_to_non_nullable
-as int?,jackType: freezed == jackType ? _self.jackType : jackType // ignore: cast_nullable_to_non_nullable
-as String?,nodeId: freezed == nodeId ? _self.nodeId : nodeId // ignore: cast_nullable_to_non_nullable
+as int?,hardwareIndex: freezed == hardwareIndex ? _self.hardwareIndex : hardwareIndex // ignore: cast_nullable_to_non_nullable
+as int?,nodeId: freezed == nodeId ? _self.nodeId : nodeId // ignore: cast_nullable_to_non_nullable
 as String?,role: freezed == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
 as PortRole?,
   ));
@@ -204,10 +201,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  PortType type,  PortDirection direction,  String? description,  Map<String, dynamic>? constraints,  bool isActive,  OutputMode? outputMode,  bool isPolyVoice,  int? voiceNumber,  bool isVirtualCV,  bool isMultiChannel,  int? channelNumber,  bool isStereoChannel,  String? stereoSide,  bool isMasterMix,  int? busValue,  String? busParam,  int? parameterNumber,  int? modeParameterNumber,  bool isPhysical,  int? hardwareIndex,  String? jackType,  String? nodeId,  PortRole? role)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  PortType type,  PortDirection direction,  String? description,  Map<String, dynamic>? constraints,  bool isActive,  OutputMode? outputMode,  bool isPolyVoice,  int? voiceNumber,  bool isVirtualCV,  bool isMultiChannel,  int? channelNumber,  bool isStereoChannel,  String? stereoSide,  bool isMasterMix,  int? busValue,  String? busParam,  int? parameterNumber,  int? modeParameterNumber,  int? hardwareIndex,  String? nodeId,  PortRole? role)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Port() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.direction,_that.description,_that.constraints,_that.isActive,_that.outputMode,_that.isPolyVoice,_that.voiceNumber,_that.isVirtualCV,_that.isMultiChannel,_that.channelNumber,_that.isStereoChannel,_that.stereoSide,_that.isMasterMix,_that.busValue,_that.busParam,_that.parameterNumber,_that.modeParameterNumber,_that.isPhysical,_that.hardwareIndex,_that.jackType,_that.nodeId,_that.role);case _:
+return $default(_that.id,_that.name,_that.type,_that.direction,_that.description,_that.constraints,_that.isActive,_that.outputMode,_that.isPolyVoice,_that.voiceNumber,_that.isVirtualCV,_that.isMultiChannel,_that.channelNumber,_that.isStereoChannel,_that.stereoSide,_that.isMasterMix,_that.busValue,_that.busParam,_that.parameterNumber,_that.modeParameterNumber,_that.hardwareIndex,_that.nodeId,_that.role);case _:
   return orElse();
 
 }
@@ -225,10 +222,10 @@ return $default(_that.id,_that.name,_that.type,_that.direction,_that.description
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  PortType type,  PortDirection direction,  String? description,  Map<String, dynamic>? constraints,  bool isActive,  OutputMode? outputMode,  bool isPolyVoice,  int? voiceNumber,  bool isVirtualCV,  bool isMultiChannel,  int? channelNumber,  bool isStereoChannel,  String? stereoSide,  bool isMasterMix,  int? busValue,  String? busParam,  int? parameterNumber,  int? modeParameterNumber,  bool isPhysical,  int? hardwareIndex,  String? jackType,  String? nodeId,  PortRole? role)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  PortType type,  PortDirection direction,  String? description,  Map<String, dynamic>? constraints,  bool isActive,  OutputMode? outputMode,  bool isPolyVoice,  int? voiceNumber,  bool isVirtualCV,  bool isMultiChannel,  int? channelNumber,  bool isStereoChannel,  String? stereoSide,  bool isMasterMix,  int? busValue,  String? busParam,  int? parameterNumber,  int? modeParameterNumber,  int? hardwareIndex,  String? nodeId,  PortRole? role)  $default,) {final _that = this;
 switch (_that) {
 case _Port():
-return $default(_that.id,_that.name,_that.type,_that.direction,_that.description,_that.constraints,_that.isActive,_that.outputMode,_that.isPolyVoice,_that.voiceNumber,_that.isVirtualCV,_that.isMultiChannel,_that.channelNumber,_that.isStereoChannel,_that.stereoSide,_that.isMasterMix,_that.busValue,_that.busParam,_that.parameterNumber,_that.modeParameterNumber,_that.isPhysical,_that.hardwareIndex,_that.jackType,_that.nodeId,_that.role);}
+return $default(_that.id,_that.name,_that.type,_that.direction,_that.description,_that.constraints,_that.isActive,_that.outputMode,_that.isPolyVoice,_that.voiceNumber,_that.isVirtualCV,_that.isMultiChannel,_that.channelNumber,_that.isStereoChannel,_that.stereoSide,_that.isMasterMix,_that.busValue,_that.busParam,_that.parameterNumber,_that.modeParameterNumber,_that.hardwareIndex,_that.nodeId,_that.role);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -242,10 +239,10 @@ return $default(_that.id,_that.name,_that.type,_that.direction,_that.description
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  PortType type,  PortDirection direction,  String? description,  Map<String, dynamic>? constraints,  bool isActive,  OutputMode? outputMode,  bool isPolyVoice,  int? voiceNumber,  bool isVirtualCV,  bool isMultiChannel,  int? channelNumber,  bool isStereoChannel,  String? stereoSide,  bool isMasterMix,  int? busValue,  String? busParam,  int? parameterNumber,  int? modeParameterNumber,  bool isPhysical,  int? hardwareIndex,  String? jackType,  String? nodeId,  PortRole? role)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  PortType type,  PortDirection direction,  String? description,  Map<String, dynamic>? constraints,  bool isActive,  OutputMode? outputMode,  bool isPolyVoice,  int? voiceNumber,  bool isVirtualCV,  bool isMultiChannel,  int? channelNumber,  bool isStereoChannel,  String? stereoSide,  bool isMasterMix,  int? busValue,  String? busParam,  int? parameterNumber,  int? modeParameterNumber,  int? hardwareIndex,  String? nodeId,  PortRole? role)?  $default,) {final _that = this;
 switch (_that) {
 case _Port() when $default != null:
-return $default(_that.id,_that.name,_that.type,_that.direction,_that.description,_that.constraints,_that.isActive,_that.outputMode,_that.isPolyVoice,_that.voiceNumber,_that.isVirtualCV,_that.isMultiChannel,_that.channelNumber,_that.isStereoChannel,_that.stereoSide,_that.isMasterMix,_that.busValue,_that.busParam,_that.parameterNumber,_that.modeParameterNumber,_that.isPhysical,_that.hardwareIndex,_that.jackType,_that.nodeId,_that.role);case _:
+return $default(_that.id,_that.name,_that.type,_that.direction,_that.description,_that.constraints,_that.isActive,_that.outputMode,_that.isPolyVoice,_that.voiceNumber,_that.isVirtualCV,_that.isMultiChannel,_that.channelNumber,_that.isStereoChannel,_that.stereoSide,_that.isMasterMix,_that.busValue,_that.busParam,_that.parameterNumber,_that.modeParameterNumber,_that.hardwareIndex,_that.nodeId,_that.role);case _:
   return null;
 
 }
@@ -257,7 +254,7 @@ return $default(_that.id,_that.name,_that.type,_that.direction,_that.description
 @JsonSerializable()
 
 class _Port extends Port {
-  const _Port({required this.id, required this.name, required this.type, required this.direction, this.description, final  Map<String, dynamic>? constraints, this.isActive = true, this.outputMode, this.isPolyVoice = false, this.voiceNumber, this.isVirtualCV = false, this.isMultiChannel = false, this.channelNumber, this.isStereoChannel = false, this.stereoSide, this.isMasterMix = false, this.busValue, this.busParam, this.parameterNumber, this.modeParameterNumber, this.isPhysical = false, this.hardwareIndex, this.jackType, this.nodeId, this.role}): _constraints = constraints,super._();
+  const _Port({required this.id, required this.name, required this.type, required this.direction, this.description, final  Map<String, dynamic>? constraints, this.isActive = true, this.outputMode, this.isPolyVoice = false, this.voiceNumber, this.isVirtualCV = false, this.isMultiChannel = false, this.channelNumber, this.isStereoChannel = false, this.stereoSide, this.isMasterMix = false, this.busValue, this.busParam, this.parameterNumber, this.modeParameterNumber, this.hardwareIndex, this.nodeId, this.role}): _constraints = constraints,super._();
   factory _Port.fromJson(Map<String, dynamic> json) => _$PortFromJson(json);
 
 /// Unique identifier for this port
@@ -312,17 +309,14 @@ class _Port extends Port {
 @override final  int? parameterNumber;
 /// The mode parameter number for this port's output mode (Add/Replace)
 @override final  int? modeParameterNumber;
-// Direct properties for physical ports
-/// Whether this port represents a physical hardware port
-@override@JsonKey() final  bool isPhysical;
-/// The hardware index for physical ports (1-based)
+/// The hardware index for physical/ES-5 ports (1-based).
+/// For physical ports this equals the bus number for inputs (1-12)
+/// or the jack number for outputs (1-8, mapped to buses 13-20).
 @override final  int? hardwareIndex;
-/// The jack type for physical ports ('input' or 'output')
-@override final  String? jackType;
 /// The node identifier for grouping related ports
 @override final  String? nodeId;
 /// The role this port plays in the bus-assignment routing model.
-/// If not set, derived from [direction], [isPhysical], and port ID conventions.
+/// If not set, derived from [direction] and port ID conventions.
 @override final  PortRole? role;
 
 /// Create a copy of Port
@@ -338,16 +332,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Port&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.direction, direction) || other.direction == direction)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other._constraints, _constraints)&&(identical(other.isActive, isActive) || other.isActive == isActive)&&(identical(other.outputMode, outputMode) || other.outputMode == outputMode)&&(identical(other.isPolyVoice, isPolyVoice) || other.isPolyVoice == isPolyVoice)&&(identical(other.voiceNumber, voiceNumber) || other.voiceNumber == voiceNumber)&&(identical(other.isVirtualCV, isVirtualCV) || other.isVirtualCV == isVirtualCV)&&(identical(other.isMultiChannel, isMultiChannel) || other.isMultiChannel == isMultiChannel)&&(identical(other.channelNumber, channelNumber) || other.channelNumber == channelNumber)&&(identical(other.isStereoChannel, isStereoChannel) || other.isStereoChannel == isStereoChannel)&&(identical(other.stereoSide, stereoSide) || other.stereoSide == stereoSide)&&(identical(other.isMasterMix, isMasterMix) || other.isMasterMix == isMasterMix)&&(identical(other.busValue, busValue) || other.busValue == busValue)&&(identical(other.busParam, busParam) || other.busParam == busParam)&&(identical(other.parameterNumber, parameterNumber) || other.parameterNumber == parameterNumber)&&(identical(other.modeParameterNumber, modeParameterNumber) || other.modeParameterNumber == modeParameterNumber)&&(identical(other.isPhysical, isPhysical) || other.isPhysical == isPhysical)&&(identical(other.hardwareIndex, hardwareIndex) || other.hardwareIndex == hardwareIndex)&&(identical(other.jackType, jackType) || other.jackType == jackType)&&(identical(other.nodeId, nodeId) || other.nodeId == nodeId)&&(identical(other.role, role) || other.role == role));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Port&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.direction, direction) || other.direction == direction)&&(identical(other.description, description) || other.description == description)&&const DeepCollectionEquality().equals(other._constraints, _constraints)&&(identical(other.isActive, isActive) || other.isActive == isActive)&&(identical(other.outputMode, outputMode) || other.outputMode == outputMode)&&(identical(other.isPolyVoice, isPolyVoice) || other.isPolyVoice == isPolyVoice)&&(identical(other.voiceNumber, voiceNumber) || other.voiceNumber == voiceNumber)&&(identical(other.isVirtualCV, isVirtualCV) || other.isVirtualCV == isVirtualCV)&&(identical(other.isMultiChannel, isMultiChannel) || other.isMultiChannel == isMultiChannel)&&(identical(other.channelNumber, channelNumber) || other.channelNumber == channelNumber)&&(identical(other.isStereoChannel, isStereoChannel) || other.isStereoChannel == isStereoChannel)&&(identical(other.stereoSide, stereoSide) || other.stereoSide == stereoSide)&&(identical(other.isMasterMix, isMasterMix) || other.isMasterMix == isMasterMix)&&(identical(other.busValue, busValue) || other.busValue == busValue)&&(identical(other.busParam, busParam) || other.busParam == busParam)&&(identical(other.parameterNumber, parameterNumber) || other.parameterNumber == parameterNumber)&&(identical(other.modeParameterNumber, modeParameterNumber) || other.modeParameterNumber == modeParameterNumber)&&(identical(other.hardwareIndex, hardwareIndex) || other.hardwareIndex == hardwareIndex)&&(identical(other.nodeId, nodeId) || other.nodeId == nodeId)&&(identical(other.role, role) || other.role == role));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hashAll([runtimeType,id,name,type,direction,description,const DeepCollectionEquality().hash(_constraints),isActive,outputMode,isPolyVoice,voiceNumber,isVirtualCV,isMultiChannel,channelNumber,isStereoChannel,stereoSide,isMasterMix,busValue,busParam,parameterNumber,modeParameterNumber,isPhysical,hardwareIndex,jackType,nodeId,role]);
+int get hashCode => Object.hashAll([runtimeType,id,name,type,direction,description,const DeepCollectionEquality().hash(_constraints),isActive,outputMode,isPolyVoice,voiceNumber,isVirtualCV,isMultiChannel,channelNumber,isStereoChannel,stereoSide,isMasterMix,busValue,busParam,parameterNumber,modeParameterNumber,hardwareIndex,nodeId,role]);
 
 @override
 String toString() {
-  return 'Port(id: $id, name: $name, type: $type, direction: $direction, description: $description, constraints: $constraints, isActive: $isActive, outputMode: $outputMode, isPolyVoice: $isPolyVoice, voiceNumber: $voiceNumber, isVirtualCV: $isVirtualCV, isMultiChannel: $isMultiChannel, channelNumber: $channelNumber, isStereoChannel: $isStereoChannel, stereoSide: $stereoSide, isMasterMix: $isMasterMix, busValue: $busValue, busParam: $busParam, parameterNumber: $parameterNumber, modeParameterNumber: $modeParameterNumber, isPhysical: $isPhysical, hardwareIndex: $hardwareIndex, jackType: $jackType, nodeId: $nodeId, role: $role)';
+  return 'Port(id: $id, name: $name, type: $type, direction: $direction, description: $description, constraints: $constraints, isActive: $isActive, outputMode: $outputMode, isPolyVoice: $isPolyVoice, voiceNumber: $voiceNumber, isVirtualCV: $isVirtualCV, isMultiChannel: $isMultiChannel, channelNumber: $channelNumber, isStereoChannel: $isStereoChannel, stereoSide: $stereoSide, isMasterMix: $isMasterMix, busValue: $busValue, busParam: $busParam, parameterNumber: $parameterNumber, modeParameterNumber: $modeParameterNumber, hardwareIndex: $hardwareIndex, nodeId: $nodeId, role: $role)';
 }
 
 
@@ -358,7 +352,7 @@ abstract mixin class _$PortCopyWith<$Res> implements $PortCopyWith<$Res> {
   factory _$PortCopyWith(_Port value, $Res Function(_Port) _then) = __$PortCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name, PortType type, PortDirection direction, String? description, Map<String, dynamic>? constraints, bool isActive, OutputMode? outputMode, bool isPolyVoice, int? voiceNumber, bool isVirtualCV, bool isMultiChannel, int? channelNumber, bool isStereoChannel, String? stereoSide, bool isMasterMix, int? busValue, String? busParam, int? parameterNumber, int? modeParameterNumber, bool isPhysical, int? hardwareIndex, String? jackType, String? nodeId, PortRole? role
+ String id, String name, PortType type, PortDirection direction, String? description, Map<String, dynamic>? constraints, bool isActive, OutputMode? outputMode, bool isPolyVoice, int? voiceNumber, bool isVirtualCV, bool isMultiChannel, int? channelNumber, bool isStereoChannel, String? stereoSide, bool isMasterMix, int? busValue, String? busParam, int? parameterNumber, int? modeParameterNumber, int? hardwareIndex, String? nodeId, PortRole? role
 });
 
 
@@ -375,7 +369,7 @@ class __$PortCopyWithImpl<$Res>
 
 /// Create a copy of Port
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? direction = null,Object? description = freezed,Object? constraints = freezed,Object? isActive = null,Object? outputMode = freezed,Object? isPolyVoice = null,Object? voiceNumber = freezed,Object? isVirtualCV = null,Object? isMultiChannel = null,Object? channelNumber = freezed,Object? isStereoChannel = null,Object? stereoSide = freezed,Object? isMasterMix = null,Object? busValue = freezed,Object? busParam = freezed,Object? parameterNumber = freezed,Object? modeParameterNumber = freezed,Object? isPhysical = null,Object? hardwareIndex = freezed,Object? jackType = freezed,Object? nodeId = freezed,Object? role = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? direction = null,Object? description = freezed,Object? constraints = freezed,Object? isActive = null,Object? outputMode = freezed,Object? isPolyVoice = null,Object? voiceNumber = freezed,Object? isVirtualCV = null,Object? isMultiChannel = null,Object? channelNumber = freezed,Object? isStereoChannel = null,Object? stereoSide = freezed,Object? isMasterMix = null,Object? busValue = freezed,Object? busParam = freezed,Object? parameterNumber = freezed,Object? modeParameterNumber = freezed,Object? hardwareIndex = freezed,Object? nodeId = freezed,Object? role = freezed,}) {
   return _then(_Port(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -397,10 +391,8 @@ as bool,busValue: freezed == busValue ? _self.busValue : busValue // ignore: cas
 as int?,busParam: freezed == busParam ? _self.busParam : busParam // ignore: cast_nullable_to_non_nullable
 as String?,parameterNumber: freezed == parameterNumber ? _self.parameterNumber : parameterNumber // ignore: cast_nullable_to_non_nullable
 as int?,modeParameterNumber: freezed == modeParameterNumber ? _self.modeParameterNumber : modeParameterNumber // ignore: cast_nullable_to_non_nullable
-as int?,isPhysical: null == isPhysical ? _self.isPhysical : isPhysical // ignore: cast_nullable_to_non_nullable
-as bool,hardwareIndex: freezed == hardwareIndex ? _self.hardwareIndex : hardwareIndex // ignore: cast_nullable_to_non_nullable
-as int?,jackType: freezed == jackType ? _self.jackType : jackType // ignore: cast_nullable_to_non_nullable
-as String?,nodeId: freezed == nodeId ? _self.nodeId : nodeId // ignore: cast_nullable_to_non_nullable
+as int?,hardwareIndex: freezed == hardwareIndex ? _self.hardwareIndex : hardwareIndex // ignore: cast_nullable_to_non_nullable
+as int?,nodeId: freezed == nodeId ? _self.nodeId : nodeId // ignore: cast_nullable_to_non_nullable
 as String?,role: freezed == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
 as PortRole?,
   ));

--- a/lib/core/routing/models/port.g.dart
+++ b/lib/core/routing/models/port.g.dart
@@ -31,6 +31,7 @@ _Port _$PortFromJson(Map<String, dynamic> json) => _Port(
   hardwareIndex: (json['hardwareIndex'] as num?)?.toInt(),
   jackType: json['jackType'] as String?,
   nodeId: json['nodeId'] as String?,
+  role: $enumDecodeNullable(_$PortRoleEnumMap, json['role']),
 );
 
 Map<String, dynamic> _$PortToJson(_Port instance) => <String, dynamic>{
@@ -58,6 +59,7 @@ Map<String, dynamic> _$PortToJson(_Port instance) => <String, dynamic>{
   'hardwareIndex': instance.hardwareIndex,
   'jackType': instance.jackType,
   'nodeId': instance.nodeId,
+  'role': _$PortRoleEnumMap[instance.role],
 };
 
 const _$PortTypeEnumMap = {PortType.audio: 'audio', PortType.cv: 'cv'};
@@ -71,4 +73,11 @@ const _$PortDirectionEnumMap = {
 const _$OutputModeEnumMap = {
   OutputMode.add: 'add',
   OutputMode.replace: 'replace',
+};
+
+const _$PortRoleEnumMap = {
+  PortRole.busReader: 'busReader',
+  PortRole.busWriter: 'busWriter',
+  PortRole.physicalBus: 'physicalBus',
+  PortRole.es5Bus: 'es5Bus',
 };

--- a/lib/core/routing/models/port.g.dart
+++ b/lib/core/routing/models/port.g.dart
@@ -27,9 +27,7 @@ _Port _$PortFromJson(Map<String, dynamic> json) => _Port(
   busParam: json['busParam'] as String?,
   parameterNumber: (json['parameterNumber'] as num?)?.toInt(),
   modeParameterNumber: (json['modeParameterNumber'] as num?)?.toInt(),
-  isPhysical: json['isPhysical'] as bool? ?? false,
   hardwareIndex: (json['hardwareIndex'] as num?)?.toInt(),
-  jackType: json['jackType'] as String?,
   nodeId: json['nodeId'] as String?,
   role: $enumDecodeNullable(_$PortRoleEnumMap, json['role']),
 );
@@ -55,9 +53,7 @@ Map<String, dynamic> _$PortToJson(_Port instance) => <String, dynamic>{
   'busParam': instance.busParam,
   'parameterNumber': instance.parameterNumber,
   'modeParameterNumber': instance.modeParameterNumber,
-  'isPhysical': instance.isPhysical,
   'hardwareIndex': instance.hardwareIndex,
-  'jackType': instance.jackType,
   'nodeId': instance.nodeId,
   'role': _$PortRoleEnumMap[instance.role],
 };
@@ -78,6 +74,7 @@ const _$OutputModeEnumMap = {
 const _$PortRoleEnumMap = {
   PortRole.busReader: 'busReader',
   PortRole.busWriter: 'busWriter',
-  PortRole.physicalBus: 'physicalBus',
+  PortRole.physicalInputBus: 'physicalInputBus',
+  PortRole.physicalOutputBus: 'physicalOutputBus',
   PortRole.es5Bus: 'es5Bus',
 };

--- a/lib/cubit/routing_editor_cubit.dart
+++ b/lib/cubit/routing_editor_cubit.dart
@@ -309,9 +309,8 @@ class RoutingEditorCubit extends Cubit<RoutingEditorState> {
         name: 'I$n',
         type: PortType.cv,
         direction: PortDirection.output,
-        isPhysical: true,
         hardwareIndex: n,
-        jackType: 'input',
+        role: PortRole.physicalInputBus,
       );
     });
   }
@@ -325,9 +324,8 @@ class RoutingEditorCubit extends Cubit<RoutingEditorState> {
         name: 'O$n',
         type: PortType.audio,
         direction: PortDirection.input,
-        isPhysical: true,
         hardwareIndex: n,
-        jackType: 'output',
+        role: PortRole.physicalOutputBus,
       );
     });
   }
@@ -391,17 +389,13 @@ class RoutingEditorCubit extends Cubit<RoutingEditorState> {
 
       if (sourcePort.isBus && targetPort.isBusReader) {
         // Bus -> algorithm input: assign bus number to the reader
-        if (sourceRole == PortRole.physicalBus &&
-            sourcePort.jackType == 'input') {
-          // Physical input jack (bus 1-12) -> algorithm input
+        if (sourceRole == PortRole.physicalInputBus) {
           busNumber = await _assignBusForHardwareInput(
             sourcePortId,
             targetPort,
             currentState,
           );
-        } else if (sourceRole == PortRole.physicalBus &&
-            sourcePort.jackType == 'output') {
-          // Physical output jack (bus 13-20) -> algorithm input
+        } else if (sourceRole == PortRole.physicalOutputBus) {
           busNumber = await _assignBusForPhysicalOutputToAlgorithmInput(
             sourcePortId,
             targetPort,
@@ -453,17 +447,13 @@ class RoutingEditorCubit extends Cubit<RoutingEditorState> {
         }
       } else if (targetPort.isBus && sourcePort.isBusReader) {
         // Algorithm input -> bus: assign bus number to the reader
-        if (targetRole == PortRole.physicalBus &&
-            targetPort.jackType == 'input') {
-          // Algorithm input -> physical input jack (bus 1-12)
+        if (targetRole == PortRole.physicalInputBus) {
           busNumber = await _assignBusForHardwareInput(
             targetPortId,
             sourcePort,
             currentState,
           );
-        } else if (targetRole == PortRole.physicalBus &&
-            targetPort.jackType == 'output') {
-          // Algorithm input -> physical output jack (bus 13-20)
+        } else if (targetRole == PortRole.physicalOutputBus) {
           busNumber = await _assignBusForPhysicalOutputToAlgorithmInput(
             targetPortId,
             sourcePort,

--- a/lib/ui/widgets/routing/accessible_routing_list_view.dart
+++ b/lib/ui/widgets/routing/accessible_routing_list_view.dart
@@ -77,7 +77,7 @@ class AccessibleRoutingListView extends StatelessWidget {
         ),
         const SizedBox(height: 8),
         ...algorithms.map(
-          (algo) => _buildAlgorithmTile(context, algo, connections),
+          (algo) => _buildAlgorithmTile(context, algo, connections, algorithms),
         ),
 
         const Divider(height: 32),
@@ -113,6 +113,7 @@ class AccessibleRoutingListView extends StatelessWidget {
     BuildContext context,
     RoutingAlgorithm algo,
     List<Connection> connections,
+    List<RoutingAlgorithm> algorithms,
   ) {
     final theme = Theme.of(context);
     final inputCount = algo.inputPorts.length;
@@ -132,6 +133,8 @@ class AccessibleRoutingListView extends StatelessWidget {
             '$inputCount inputs, $outputCount outputs, '
             '$connectedPorts active connections',
         child: ExpansionTile(
+          shape: const Border(),
+          collapsedShape: const Border(),
           leading: CircleAvatar(
             backgroundColor: theme.colorScheme.primaryContainer,
             child: Text(
@@ -153,7 +156,8 @@ class AccessibleRoutingListView extends StatelessWidget {
                 ),
               ),
               ...algo.inputPorts.map(
-                (port) => _buildPortListItem(context, port, connections, true),
+                (port) => _buildPortListItem(
+                    context, port, connections, true, algorithms),
               ),
             ],
             if (algo.outputPorts.isNotEmpty) ...[
@@ -165,7 +169,8 @@ class AccessibleRoutingListView extends StatelessWidget {
                 ),
               ),
               ...algo.outputPorts.map(
-                (port) => _buildPortListItem(context, port, connections, false),
+                (port) => _buildPortListItem(
+                    context, port, connections, false, algorithms),
               ),
             ],
             const SizedBox(height: 8),
@@ -180,6 +185,7 @@ class AccessibleRoutingListView extends StatelessWidget {
     Port port,
     List<Connection> connections,
     bool isInput,
+    List<RoutingAlgorithm> algorithms,
   ) {
     final connectedTo = connections.where(
       (c) =>
@@ -187,9 +193,17 @@ class AccessibleRoutingListView extends StatelessWidget {
           (!isInput && c.sourcePortId == port.id),
     );
 
-    final connectionInfo = connectedTo.isEmpty
-        ? 'Not connected'
-        : 'Connected to ${connectedTo.length} port${connectedTo.length > 1 ? 's' : ''}';
+    String connectionInfo;
+    if (connectedTo.isEmpty) {
+      connectionInfo = 'Not connected';
+    } else {
+      final names = connectedTo.map((c) {
+        final otherPortId =
+            isInput ? c.sourcePortId : c.destinationPortId;
+        return _findPortName(otherPortId, algorithms);
+      });
+      connectionInfo = names.join(', ');
+    }
 
     return ListTile(
       dense: true,

--- a/lib/ui/widgets/routing/connection_painter.dart
+++ b/lib/ui/widgets/routing/connection_painter.dart
@@ -118,7 +118,6 @@ class ConnectionPainter extends CustomPainter {
     final invalidConnections = <ConnectionData>[];
     final selectedConnections = <ConnectionData>[];
     final partialConnections = <ConnectionData>[];
-
     for (final conn in connections) {
       if (conn.isSelected) {
         selectedConnections.add(conn);
@@ -133,7 +132,7 @@ class ConnectionPainter extends CustomPainter {
       }
     }
 
-    // Draw in order: regular -> ghost -> invalid -> partial -> selected (for proper layering)
+    // Draw in order: regular -> ghost -> invalid -> partial -> backward partial -> selected
     _drawConnectionBatch(
       canvas,
       regularConnections,
@@ -373,11 +372,11 @@ class ConnectionPainter extends CustomPainter {
     ConnectionData conn,
     ConnectionVisualType type,
   ) {
-    // Handle invalid connections with error color
+    // Handle backward connections (wrong slot order) with tertiary color
     if (type == ConnectionVisualType.invalid) {
       paint
         ..strokeWidth = 2.0
-        ..color = theme.colorScheme.error;
+        ..color = theme.colorScheme.tertiary;
       return;
     }
 

--- a/lib/ui/widgets/routing/connection_validator.dart
+++ b/lib/ui/widgets/routing/connection_validator.dart
@@ -79,11 +79,7 @@ class ConnectionValidator {
 
   static bool _isWriterToPhysicalInput(Port writer, Port bus) {
     if (writer.effectiveRole != PortRole.busWriter) return false;
-    if (bus.effectiveRole != PortRole.physicalBus) return false;
-    // Physical input jacks are buses 1-12
-    final index = bus.hardwareIndex;
-    if (index == null) return false;
-    return bus.jackType == 'input' && index <= 12;
+    return bus.isPhysicalInput;
   }
 
   /// Given two valid ports, determines which is the "writer" (source) and

--- a/lib/ui/widgets/routing/connection_validator.dart
+++ b/lib/ui/widgets/routing/connection_validator.dart
@@ -88,6 +88,17 @@ class ConnectionValidator {
       return true;
     }
 
+    // Valid: Physical Output → Algorithm Input
+    // Algorithm reads from the output bus (13-20)
+    // Note: Physical outputs have PortDirection.input because they are sinks
+    if (sourceIsPhysical &&
+        targetIsAlgorithm &&
+        source.direction == PortDirection.input &&
+        target.direction == PortDirection.input &&
+        source.jackType == 'output') {
+      return true;
+    }
+
     // Invalid: Physical to Physical connections
     if (sourceIsPhysical && targetIsPhysical) {
       return false;
@@ -111,6 +122,15 @@ class ConnectionValidator {
         target.direction == PortDirection.output &&
         target.isPhysical &&
         target.jackType == 'input') {
+      return true;
+    }
+
+    // Physical output to algorithm input special case
+    // Physical outputs have input direction (they are sinks)
+    if (source.direction == PortDirection.input &&
+        target.direction == PortDirection.input &&
+        source.isPhysical &&
+        source.jackType == 'output') {
       return true;
     }
 

--- a/lib/ui/widgets/routing/physical_port_generator.dart
+++ b/lib/ui/widgets/routing/physical_port_generator.dart
@@ -25,12 +25,11 @@ class PhysicalPortGenerator {
         id: 'hw_in_$portNumber',
         name: 'Input $portNumber',
         type: _getPortTypeForInput(portNumber),
-        direction: PortDirection.output, // Physical inputs are sources
+        direction: PortDirection.output,
         description: 'Hardware input jack $portNumber',
-        isPhysical: true,
         hardwareIndex: portNumber,
-        jackType: 'input',
         nodeId: 'hw_inputs',
+        role: PortRole.physicalInputBus,
       );
     });
   }
@@ -49,12 +48,11 @@ class PhysicalPortGenerator {
         id: 'hw_out_$portNumber',
         name: 'O$portNumber',
         type: _getPortTypeForOutput(portNumber),
-        direction: PortDirection.input, // Physical outputs are targets
+        direction: PortDirection.input,
         description: 'Hardware output jack $portNumber',
-        isPhysical: true,
         hardwareIndex: portNumber,
-        jackType: 'output',
         nodeId: 'hw_outputs',
+        role: PortRole.physicalOutputBus,
       );
     });
   }
@@ -74,12 +72,11 @@ class PhysicalPortGenerator {
       id: 'hw_in_$index',
       name: 'Input $index',
       type: _getPortTypeForInput(index),
-      direction: PortDirection.output, // Physical inputs are sources
+      direction: PortDirection.output,
       description: 'Hardware input jack $index',
-      isPhysical: true,
       hardwareIndex: index,
-      jackType: 'input',
       nodeId: 'hw_inputs',
+      role: PortRole.physicalInputBus,
     );
   }
 
@@ -98,12 +95,11 @@ class PhysicalPortGenerator {
       id: 'hw_out_$index',
       name: 'O$index',
       type: _getPortTypeForOutput(index),
-      direction: PortDirection.input, // Physical outputs are targets
+      direction: PortDirection.input,
       description: 'Hardware output jack $index',
-      isPhysical: true,
       hardwareIndex: index,
-      jackType: 'output',
       nodeId: 'hw_outputs',
+      role: PortRole.physicalOutputBus,
     );
   }
 
@@ -142,23 +138,14 @@ class PhysicalPortGenerator {
   }
 
   /// Validates that a port is a physical input port.
-  static bool isPhysicalInputPort(Port port) {
-    return port.isPhysical &&
-        port.jackType == 'input' &&
-        port.direction == PortDirection.output;
-  }
+  static bool isPhysicalInputPort(Port port) => port.isPhysicalInput;
 
   /// Validates that a port is a physical output port.
-  static bool isPhysicalOutputPort(Port port) {
-    return port.isPhysical &&
-        port.jackType == 'output' &&
-        port.direction == PortDirection.input;
-  }
+  static bool isPhysicalOutputPort(Port port) => port.isPhysicalOutput;
 
   /// Validates that a port is any physical port (input or output).
-  static bool isPhysicalPort(Port port) {
-    return port.isPhysical;
-  }
+  static bool isPhysicalPort(Port port) =>
+      port.isPhysicalInput || port.isPhysicalOutput;
 
   /// Gets the hardware index from a physical port.
   ///
@@ -173,9 +160,9 @@ class PhysicalPortGenerator {
     final index = getHardwareIndex(port);
     if (index == null) return port.name;
 
-    if (isPhysicalInputPort(port)) {
+    if (port.isPhysicalInput) {
       return 'I$index';
-    } else if (isPhysicalOutputPort(port)) {
+    } else if (port.isPhysicalOutput) {
       return 'O$index';
     }
 

--- a/lib/ui/widgets/routing/routing_editor_widget.dart
+++ b/lib/ui/widgets/routing/routing_editor_widget.dart
@@ -4267,6 +4267,25 @@ class _RoutingEditorWidgetState extends State<RoutingEditorWidget>
         }
       }
     }
+
+    // For partial bus-to-input connections, the destination is the input port
+    if (connection.connectionType == ConnectionType.partialBusToInput) {
+      final destPortId = connection.destinationPortId;
+
+      for (final algorithm in routingState.algorithms) {
+        for (final port in algorithm.inputPorts) {
+          if (port.id == destPortId && port.parameterNumber != null) {
+            context.read<DistingCubit>().updateParameterValue(
+              algorithmIndex: algorithm.index,
+              parameterNumber: port.parameterNumber!,
+              value: 0,
+              userIsChangingTheValue: true,
+            );
+            return;
+          }
+        }
+      }
+    }
   }
 
   void _toggleConnectionOutputMode(String connectionId) {

--- a/test/core/routing/models/es5_hardware_node_test.dart
+++ b/test/core/routing/models/es5_hardware_node_test.dart
@@ -45,7 +45,7 @@ void main() {
         expect(lPort.direction, equals(PortDirection.input));
         expect(lPort.description, equals('ES-5 Left (Silent Way)'));
         expect(lPort.busValue, equals(29));
-        expect(lPort.isPhysical, isTrue);
+        expect(lPort.isBus, isTrue);
         expect(lPort.nodeId, equals('es5_hardware_node'));
       });
 
@@ -56,7 +56,7 @@ void main() {
         expect(rPort.direction, equals(PortDirection.input));
         expect(rPort.description, equals('ES-5 Right (Silent Way)'));
         expect(rPort.busValue, equals(30));
-        expect(rPort.isPhysical, isTrue);
+        expect(rPort.isBus, isTrue);
         expect(rPort.nodeId, equals('es5_hardware_node'));
       });
 
@@ -68,7 +68,7 @@ void main() {
           expect(port.direction, equals(PortDirection.input));
           expect(port.description, equals('ES-5 Output $i'));
           expect(port.busValue, isNull);
-          expect(port.isPhysical, isTrue);
+          expect(port.isBus, isTrue);
           expect(port.nodeId, equals('es5_hardware_node'));
         }
       });
@@ -87,7 +87,7 @@ void main() {
       });
 
       test('all ports are physical', () {
-        expect(ports.every((p) => p.isPhysical), isTrue);
+        expect(ports.every((p) => p.isBus), isTrue);
       });
 
       test('all ports are inputs', () {
@@ -148,7 +148,7 @@ void main() {
         expect(port.type, equals(PortType.audio));
         expect(port.direction, equals(PortDirection.input));
         expect(port.busValue, equals(29));
-        expect(port.isPhysical, isTrue);
+        expect(port.isBus, isTrue);
       });
     });
 
@@ -160,7 +160,7 @@ void main() {
         expect(port.type, equals(PortType.audio));
         expect(port.direction, equals(PortDirection.input));
         expect(port.busValue, equals(30));
-        expect(port.isPhysical, isTrue);
+        expect(port.isBus, isTrue);
       });
     });
 
@@ -173,7 +173,7 @@ void main() {
           expect(port.type, equals(PortType.cv));
           expect(port.direction, equals(PortDirection.input));
           expect(port.busValue, isNull);
-          expect(port.isPhysical, isTrue);
+          expect(port.isBus, isTrue);
         }
       });
 

--- a/test/core/routing/models/port_test.dart
+++ b/test/core/routing/models/port_test.dart
@@ -600,10 +600,11 @@ void main() {
 
   group('PortRole Tests', () {
     test('PortRole enum has expected values', () {
-      expect(PortRole.values, hasLength(4));
+      expect(PortRole.values, hasLength(5));
       expect(PortRole.values, contains(PortRole.busReader));
       expect(PortRole.values, contains(PortRole.busWriter));
-      expect(PortRole.values, contains(PortRole.physicalBus));
+      expect(PortRole.values, contains(PortRole.physicalInputBus));
+      expect(PortRole.values, contains(PortRole.physicalOutputBus));
       expect(PortRole.values, contains(PortRole.es5Bus));
     });
 
@@ -628,30 +629,28 @@ void main() {
         expect(port.effectiveRole, PortRole.busWriter);
       });
 
-      test('physical input derives to physicalBus', () {
+      test('physical input derives to physicalInputBus', () {
         const port = Port(
           id: 'hw_in_1',
           name: 'I1',
           type: PortType.cv,
           direction: PortDirection.output,
-          isPhysical: true,
           hardwareIndex: 1,
-          jackType: 'input',
+          role: PortRole.physicalInputBus,
         );
-        expect(port.effectiveRole, PortRole.physicalBus);
+        expect(port.effectiveRole, PortRole.physicalInputBus);
       });
 
-      test('physical output derives to physicalBus', () {
+      test('physical output derives to physicalOutputBus', () {
         const port = Port(
           id: 'hw_out_1',
           name: 'O1',
           type: PortType.audio,
           direction: PortDirection.input,
-          isPhysical: true,
           hardwareIndex: 1,
-          jackType: 'output',
+          role: PortRole.physicalOutputBus,
         );
-        expect(port.effectiveRole, PortRole.physicalBus);
+        expect(port.effectiveRole, PortRole.physicalOutputBus);
       });
 
       test('ES-5 port derives to es5Bus', () {
@@ -689,13 +688,13 @@ void main() {
     });
 
     group('role-based convenience getters', () {
-      test('isBus is true for physicalBus', () {
+      test('isBus is true for physicalInputBus', () {
         const port = Port(
           id: 'hw_in_1',
           name: 'I1',
           type: PortType.cv,
           direction: PortDirection.output,
-          isPhysical: true,
+          role: PortRole.physicalInputBus,
         );
         expect(port.isBus, isTrue);
         expect(port.isBusReader, isFalse);
@@ -744,13 +743,13 @@ void main() {
           name: 'Test',
           type: PortType.cv,
           direction: PortDirection.input,
-          role: PortRole.physicalBus,
+          role: PortRole.physicalInputBus,
         );
 
         final json = port.toJson();
         final deserialized = Port.fromJson(json);
-        expect(deserialized.role, PortRole.physicalBus);
-        expect(deserialized.effectiveRole, PortRole.physicalBus);
+        expect(deserialized.role, PortRole.physicalInputBus);
+        expect(deserialized.effectiveRole, PortRole.physicalInputBus);
       });
 
       test('null role round-trips through JSON', () {

--- a/test/core/routing/models/port_test.dart
+++ b/test/core/routing/models/port_test.dart
@@ -597,4 +597,175 @@ void main() {
       });
     });
   });
+
+  group('PortRole Tests', () {
+    test('PortRole enum has expected values', () {
+      expect(PortRole.values, hasLength(4));
+      expect(PortRole.values, contains(PortRole.busReader));
+      expect(PortRole.values, contains(PortRole.busWriter));
+      expect(PortRole.values, contains(PortRole.physicalBus));
+      expect(PortRole.values, contains(PortRole.es5Bus));
+    });
+
+    group('effectiveRole derivation from legacy fields', () {
+      test('algorithm input derives to busReader', () {
+        const port = Port(
+          id: 'node_1_in_1',
+          name: 'Input 1',
+          type: PortType.cv,
+          direction: PortDirection.input,
+        );
+        expect(port.effectiveRole, PortRole.busReader);
+      });
+
+      test('algorithm output derives to busWriter', () {
+        const port = Port(
+          id: 'node_1_out_1',
+          name: 'Output 1',
+          type: PortType.cv,
+          direction: PortDirection.output,
+        );
+        expect(port.effectiveRole, PortRole.busWriter);
+      });
+
+      test('physical input derives to physicalBus', () {
+        const port = Port(
+          id: 'hw_in_1',
+          name: 'I1',
+          type: PortType.cv,
+          direction: PortDirection.output,
+          isPhysical: true,
+          hardwareIndex: 1,
+          jackType: 'input',
+        );
+        expect(port.effectiveRole, PortRole.physicalBus);
+      });
+
+      test('physical output derives to physicalBus', () {
+        const port = Port(
+          id: 'hw_out_1',
+          name: 'O1',
+          type: PortType.audio,
+          direction: PortDirection.input,
+          isPhysical: true,
+          hardwareIndex: 1,
+          jackType: 'output',
+        );
+        expect(port.effectiveRole, PortRole.physicalBus);
+      });
+
+      test('ES-5 port derives to es5Bus', () {
+        const port = Port(
+          id: 'es5_L',
+          name: 'ES-5 L',
+          type: PortType.audio,
+          direction: PortDirection.input,
+        );
+        expect(port.effectiveRole, PortRole.es5Bus);
+      });
+
+      test('bidirectional derives to busWriter', () {
+        const port = Port(
+          id: 'node_1_out_1',
+          name: 'Bidir',
+          type: PortType.cv,
+          direction: PortDirection.bidirectional,
+        );
+        expect(port.effectiveRole, PortRole.busWriter);
+      });
+    });
+
+    group('explicit role overrides derivation', () {
+      test('explicit role takes precedence over direction', () {
+        const port = Port(
+          id: 'node_1_in_1',
+          name: 'Input 1',
+          type: PortType.cv,
+          direction: PortDirection.input,
+          role: PortRole.busWriter,
+        );
+        expect(port.effectiveRole, PortRole.busWriter);
+      });
+    });
+
+    group('role-based convenience getters', () {
+      test('isBus is true for physicalBus', () {
+        const port = Port(
+          id: 'hw_in_1',
+          name: 'I1',
+          type: PortType.cv,
+          direction: PortDirection.output,
+          isPhysical: true,
+        );
+        expect(port.isBus, isTrue);
+        expect(port.isBusReader, isFalse);
+        expect(port.isBusWriter, isFalse);
+      });
+
+      test('isBus is true for es5Bus', () {
+        const port = Port(
+          id: 'es5_L',
+          name: 'ES-5 L',
+          type: PortType.audio,
+          direction: PortDirection.input,
+        );
+        expect(port.isBus, isTrue);
+      });
+
+      test('isBusReader for algorithm input', () {
+        const port = Port(
+          id: 'node_1_in_1',
+          name: 'Input 1',
+          type: PortType.cv,
+          direction: PortDirection.input,
+        );
+        expect(port.isBusReader, isTrue);
+        expect(port.isBusWriter, isFalse);
+        expect(port.isBus, isFalse);
+      });
+
+      test('isBusWriter for algorithm output', () {
+        const port = Port(
+          id: 'node_1_out_1',
+          name: 'Output 1',
+          type: PortType.cv,
+          direction: PortDirection.output,
+        );
+        expect(port.isBusWriter, isTrue);
+        expect(port.isBusReader, isFalse);
+        expect(port.isBus, isFalse);
+      });
+    });
+
+    group('PortRole serialization', () {
+      test('explicit role round-trips through JSON', () {
+        const port = Port(
+          id: 'test',
+          name: 'Test',
+          type: PortType.cv,
+          direction: PortDirection.input,
+          role: PortRole.physicalBus,
+        );
+
+        final json = port.toJson();
+        final deserialized = Port.fromJson(json);
+        expect(deserialized.role, PortRole.physicalBus);
+        expect(deserialized.effectiveRole, PortRole.physicalBus);
+      });
+
+      test('null role round-trips through JSON', () {
+        const port = Port(
+          id: 'test',
+          name: 'Test',
+          type: PortType.cv,
+          direction: PortDirection.input,
+        );
+
+        final json = port.toJson();
+        final deserialized = Port.fromJson(json);
+        expect(deserialized.role, isNull);
+        expect(deserialized.effectiveRole, PortRole.busReader);
+      });
+    });
+  });
 }

--- a/test/ui/widgets/routing/connection_validator_test.dart
+++ b/test/ui/widgets/routing/connection_validator_test.dart
@@ -10,9 +10,8 @@ void main() {
       name: 'Input 1',
       type: PortType.cv,
       direction: PortDirection.output,
-      isPhysical: true,
       hardwareIndex: 1,
-      jackType: 'input',
+      role: PortRole.physicalInputBus,
     );
 
     // Physical output ports have PortDirection.input because they are signal sinks
@@ -21,9 +20,8 @@ void main() {
       name: 'Output 1',
       type: PortType.cv,
       direction: PortDirection.input,
-      isPhysical: true,
       hardwareIndex: 1,
-      jackType: 'output',
+      role: PortRole.physicalOutputBus,
     );
 
     final algorithmInput = Port(
@@ -122,9 +120,8 @@ void main() {
       name: 'Input 1',
       type: PortType.cv,
       direction: PortDirection.output,
-      isPhysical: true,
       hardwareIndex: 1,
-      jackType: 'input',
+      role: PortRole.physicalInputBus,
     );
 
     final physicalOutput = Port(
@@ -132,9 +129,8 @@ void main() {
       name: 'Output 1',
       type: PortType.cv,
       direction: PortDirection.input,
-      isPhysical: true,
       hardwareIndex: 1,
-      jackType: 'output',
+      role: PortRole.physicalOutputBus,
     );
 
     final algorithmInput = Port(

--- a/test/ui/widgets/routing/connection_validator_test.dart
+++ b/test/ui/widgets/routing/connection_validator_test.dart
@@ -1,0 +1,227 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/core/routing/models/port.dart';
+import 'package:nt_helper/ui/widgets/routing/connection_validator.dart';
+
+void main() {
+  group('ConnectionValidator physical port bi-directionality', () {
+    // Physical input ports have PortDirection.output because they are signal sources
+    final physicalInput = Port(
+      id: 'hw_in_1',
+      name: 'Input 1',
+      type: PortType.cv,
+      direction: PortDirection.output,
+      isPhysical: true,
+      hardwareIndex: 1,
+      jackType: 'input',
+    );
+
+    // Physical output ports have PortDirection.input because they are signal sinks
+    final physicalOutput = Port(
+      id: 'hw_out_1',
+      name: 'Output 1',
+      type: PortType.cv,
+      direction: PortDirection.input,
+      isPhysical: true,
+      hardwareIndex: 1,
+      jackType: 'output',
+    );
+
+    final algorithmInput = Port(
+      id: 'node_1_in_1',
+      name: 'Algo Input 1',
+      type: PortType.cv,
+      direction: PortDirection.input,
+    );
+
+    final algorithmOutput = Port(
+      id: 'node_2_out_1',
+      name: 'Algo Output 1',
+      type: PortType.cv,
+      direction: PortDirection.output,
+    );
+
+    test('physical input -> algorithm input is valid', () {
+      expect(
+        ConnectionValidator.isValidConnection(physicalInput, algorithmInput),
+        isTrue,
+      );
+    });
+
+    test('algorithm output -> physical output is valid', () {
+      expect(
+        ConnectionValidator.isValidConnection(algorithmOutput, physicalOutput),
+        isTrue,
+      );
+    });
+
+    test('algorithm output -> physical input (ghost connection) is valid', () {
+      expect(
+        ConnectionValidator.isValidConnection(algorithmOutput, physicalInput),
+        isTrue,
+      );
+    });
+
+    test('algorithm output -> algorithm input is valid', () {
+      expect(
+        ConnectionValidator.isValidConnection(algorithmOutput, algorithmInput),
+        isTrue,
+      );
+    });
+
+    test('physical input -> physical output is invalid', () {
+      expect(
+        ConnectionValidator.isValidConnection(physicalInput, physicalOutput),
+        isFalse,
+      );
+    });
+
+    test('physical output -> physical input is invalid', () {
+      expect(
+        ConnectionValidator.isValidConnection(physicalOutput, physicalInput),
+        isFalse,
+      );
+    });
+
+    test('physical output -> algorithm input is valid', () {
+      expect(
+        ConnectionValidator.isValidConnection(physicalOutput, algorithmInput),
+        isTrue,
+      );
+    });
+
+    test('algorithm input -> algorithm output is invalid', () {
+      expect(
+        ConnectionValidator.isValidConnection(algorithmInput, algorithmOutput),
+        isFalse,
+      );
+    });
+
+    test('ghost connection is correctly identified', () {
+      expect(
+        ConnectionValidator.isGhostConnection(algorithmOutput, physicalInput),
+        isTrue,
+      );
+    });
+
+    test('algorithm output -> physical output is not a ghost connection', () {
+      expect(
+        ConnectionValidator.isGhostConnection(algorithmOutput, physicalOutput),
+        isFalse,
+      );
+    });
+  });
+
+  group('ConnectionValidator drag direction resolution', () {
+    // These tests verify that for any valid connection, at least one of
+    // isValidConnection(a, b) or isValidConnection(b, a) returns true,
+    // which is what the drag handlers rely on to resolve direction.
+
+    final physicalInput = Port(
+      id: 'hw_in_1',
+      name: 'Input 1',
+      type: PortType.cv,
+      direction: PortDirection.output,
+      isPhysical: true,
+      hardwareIndex: 1,
+      jackType: 'input',
+    );
+
+    final physicalOutput = Port(
+      id: 'hw_out_1',
+      name: 'Output 1',
+      type: PortType.cv,
+      direction: PortDirection.input,
+      isPhysical: true,
+      hardwareIndex: 1,
+      jackType: 'output',
+    );
+
+    final algorithmInput = Port(
+      id: 'node_1_in_1',
+      name: 'Algo Input 1',
+      type: PortType.cv,
+      direction: PortDirection.input,
+    );
+
+    final algorithmOutput = Port(
+      id: 'node_2_out_1',
+      name: 'Algo Output 1',
+      type: PortType.cv,
+      direction: PortDirection.output,
+    );
+
+    test('dragging from algorithm output to physical input resolves', () {
+      final forward = ConnectionValidator.isValidConnection(
+        algorithmOutput,
+        physicalInput,
+      );
+      final reverse = ConnectionValidator.isValidConnection(
+        physicalInput,
+        algorithmOutput,
+      );
+      expect(forward || reverse, isTrue,
+          reason: 'Ghost connection should be valid in at least one direction');
+      expect(forward, isTrue,
+          reason: 'Algorithm output should be the source');
+    });
+
+    test('dragging from physical input to algorithm output resolves', () {
+      // User drags from physical input to algorithm output — reverse ordering
+      // should be valid (algorithm output as source)
+      final forward = ConnectionValidator.isValidConnection(
+        physicalInput,
+        algorithmOutput,
+      );
+      final reverse = ConnectionValidator.isValidConnection(
+        algorithmOutput,
+        physicalInput,
+      );
+      expect(forward || reverse, isTrue,
+          reason: 'Should resolve via reverse ordering');
+    });
+
+    test('dragging from physical output to algorithm input resolves', () {
+      final forward = ConnectionValidator.isValidConnection(
+        physicalOutput,
+        algorithmInput,
+      );
+      final reverse = ConnectionValidator.isValidConnection(
+        algorithmInput,
+        physicalOutput,
+      );
+      expect(forward || reverse, isTrue,
+          reason: 'Physical output -> algorithm input is valid');
+      expect(forward, isTrue,
+          reason: 'Physical output should be the source');
+    });
+
+    test('dragging from algorithm input to physical output resolves', () {
+      // User drags from algorithm input to physical output — reverse ordering
+      // should be valid (physical output as source)
+      final forward = ConnectionValidator.isValidConnection(
+        algorithmInput,
+        physicalOutput,
+      );
+      final reverse = ConnectionValidator.isValidConnection(
+        physicalOutput,
+        algorithmInput,
+      );
+      expect(forward || reverse, isTrue,
+          reason: 'Should resolve via reverse ordering');
+    });
+
+    test('dragging from algorithm output to physical output resolves', () {
+      final forward = ConnectionValidator.isValidConnection(
+        algorithmOutput,
+        physicalOutput,
+      );
+      final reverse = ConnectionValidator.isValidConnection(
+        physicalOutput,
+        algorithmOutput,
+      );
+      expect(forward || reverse, isTrue,
+          reason: 'Algorithm output -> physical output is valid');
+      expect(forward, isTrue);
+    });
+  });
+}

--- a/test/ui/widgets/routing/connection_validator_test.dart
+++ b/test/ui/widgets/routing/connection_validator_test.dart
@@ -89,10 +89,11 @@ void main() {
       );
     });
 
-    test('algorithm input -> algorithm output is invalid', () {
+    test('algorithm input -> algorithm output is valid (busReader + busWriter)',
+        () {
       expect(
         ConnectionValidator.isValidConnection(algorithmInput, algorithmOutput),
-        isFalse,
+        isTrue,
       );
     });
 

--- a/test/ui/widgets/routing/integration_validation_test.dart
+++ b/test/ui/widgets/routing/integration_validation_test.dart
@@ -17,7 +17,7 @@ List<Port> _createTestInputPorts() {
       type: PortType.audio,
       direction:
           PortDirection.output, // Physical inputs act as outputs to algorithms
-      isPhysical: true,
+      role: PortRole.physicalInputBus,
       busValue: portNum,
     );
   });
@@ -33,7 +33,7 @@ List<Port> _createTestOutputPorts() {
       type: PortType.audio,
       direction:
           PortDirection.input, // Physical outputs act as inputs from algorithms
-      isPhysical: true,
+      role: PortRole.physicalOutputBus,
       busValue: portNum + 12,
     );
   });
@@ -215,14 +215,14 @@ void main() {
         final port = inputPorts[i];
         expect(port.id, equals('hw_in_${i + 1}'));
         expect(port.direction, equals(PortDirection.output));
-        expect(port.isPhysical, isTrue);
+        expect(port.isPhysicalInput, isTrue);
       }
 
       for (int i = 0; i < outputPorts.length; i++) {
         final port = outputPorts[i];
         expect(port.id, equals('hw_out_${i + 1}'));
         expect(port.direction, equals(PortDirection.input));
-        expect(port.isPhysical, isTrue);
+        expect(port.isPhysicalOutput, isTrue);
       }
 
       // Test the ports work in actual widgets

--- a/test/ui/widgets/routing/performance_test.dart
+++ b/test/ui/widgets/routing/performance_test.dart
@@ -14,7 +14,7 @@ List<Port> _createTestInputPorts() {
       type: PortType.audio,
       direction:
           PortDirection.output, // Physical inputs act as outputs to algorithms
-      isPhysical: true,
+      role: PortRole.physicalInputBus,
       busValue: portNum,
     );
   });
@@ -30,7 +30,7 @@ List<Port> _createTestOutputPorts() {
       type: PortType.audio,
       direction:
           PortDirection.input, // Physical outputs act as inputs from algorithms
-      isPhysical: true,
+      role: PortRole.physicalOutputBus,
       busValue: portNum + 12,
     );
   });

--- a/test/ui/widgets/routing/physical_io_movement_test.dart
+++ b/test/ui/widgets/routing/physical_io_movement_test.dart
@@ -14,7 +14,7 @@ List<Port> _createTestInputPorts() {
       type: PortType.audio,
       direction:
           PortDirection.output, // Physical inputs act as outputs to algorithms
-      isPhysical: true,
+      role: PortRole.physicalInputBus,
       busValue: portNum,
     );
   });
@@ -30,7 +30,7 @@ List<Port> _createTestOutputPorts() {
       type: PortType.audio,
       direction:
           PortDirection.input, // Physical outputs act as inputs from algorithms
-      isPhysical: true,
+      role: PortRole.physicalOutputBus,
       busValue: portNum + 12,
     );
   });

--- a/test/ui/widgets/routing/universal_port_widget_integration_test.dart
+++ b/test/ui/widgets/routing/universal_port_widget_integration_test.dart
@@ -17,7 +17,7 @@ List<core_port.Port> _createTestInputPorts() {
       direction: core_port
           .PortDirection
           .output, // Physical inputs act as outputs to algorithms
-      isPhysical: true,
+      role: core_port.PortRole.physicalInputBus,
       busValue: portNum,
     );
   });
@@ -34,7 +34,7 @@ List<core_port.Port> _createTestOutputPorts() {
       direction: core_port
           .PortDirection
           .input, // Physical outputs act as inputs from algorithms
-      isPhysical: true,
+      role: core_port.PortRole.physicalOutputBus,
       busValue: portNum + 12,
     );
   });


### PR DESCRIPTION
## Summary
- Introduces `PortRole` enum (`busReader`, `busWriter`, `physicalInputBus`, `physicalOutputBus`, `es5Bus`) replacing `isPhysical`/`jackType` fields on Port
- Rewrites `ConnectionValidator` and drag handlers to symmetric role-based model
- Backward connections (reader in lower slot than writer) shown in tertiary color as real connections
- Connection deletion now clears both sides to prevent leftover partial connections
- Accessible routing view: human-readable port/bus names, specific connection targets, cleaner cards

## Phases
1. Add PortRole enum to Port model
2. Migrate ConnectionDiscoveryService to PortRole
3. Rewrite ConnectionValidator and drag handlers to symmetric model
4. Remove `isPhysical`/`jackType`, split `physicalBus` into `physicalInputBus`/`physicalOutputBus`

## Test plan
- [x] All 2065 tests pass
- [x] `flutter analyze` clean
- [x] Manual testing of connection creation, deletion, backward connections, partial connections
- [x] Accessible routing view verified with human-readable names

🤖 Generated with [Claude Code](https://claude.com/claude-code)