### PR TITLE
feat: display beta firmware date in UI

### DIFF
--- a/lib/cubit/disting_cubit_connection_delegate.dart
+++ b/lib/cubit/disting_cubit_connection_delegate.dart
@@ -233,9 +233,14 @@ class _ConnectionDelegate {
 
         _emitSyncProgress('Reading firmware version...', progress: 0.15);
 
-        final distingVersion =
+        final versionResponse =
             await distingManager.requestVersionString() ?? "";
-        final firmwareVersion = FirmwareVersion(distingVersion);
+        final versionParts = versionResponse.split('\n');
+        final distingVersion = versionParts[0];
+        final firmwareDate =
+            versionParts.length > 1 ? versionParts[1] : null;
+        final firmwareVersion =
+            FirmwareVersion(distingVersion, date: firmwareDate);
         _cubit._lastKnownFirmwareVersion = firmwareVersion;
         // Set the parameter unit scheme based on firmware version
         ParameterEditorRegistry.setFirmwareVersion(firmwareVersion);

--- a/lib/domain/sysex/responses/message_response.dart
+++ b/lib/domain/sysex/responses/message_response.dart
@@ -6,6 +6,13 @@ class MessageResponse extends SysexResponse {
 
   @override
   String parse() {
-    return decodeNullTerminatedAscii(data, 0).value;
+    final first = decodeNullTerminatedAscii(data, 0);
+    if (first.nextOffset < data.length) {
+      final second = decodeNullTerminatedAscii(data, first.nextOffset);
+      if (second.value.isNotEmpty) {
+        return '${first.value}\n${second.value}';
+      }
+    }
+    return first.value;
   }
 }

--- a/lib/models/firmware_version.dart
+++ b/lib/models/firmware_version.dart
@@ -1,11 +1,12 @@
 class FirmwareVersion {
   final String versionString;
+  final String? date;
   late final int major;
   late final int minor;
   late final int patch;
   late final List<int> _parts;
 
-  FirmwareVersion(this.versionString) {
+  FirmwareVersion(this.versionString, {this.date}) {
     try {
       final matches = RegExp(r'\d+').allMatches(versionString);
       _parts = matches.map((m) => int.tryParse(m.group(0)!) ?? 0).toList();

--- a/lib/ui/synchronized_screen.dart
+++ b/lib/ui/synchronized_screen.dart
@@ -1491,6 +1491,7 @@ class _SynchronizedScreenState extends State<SynchronizedScreen>
                     DistingVersion(
                       distingVersion: widget.distingVersion,
                       requiredVersion: Constants.requiredDistingVersion,
+                      firmwareDate: widget.firmwareVersion.date,
                       onTap: isDesktop
                           ? () {
                               final distingCubit = context.read<DistingCubit>();

--- a/lib/ui/widgets/disting_version.dart
+++ b/lib/ui/widgets/disting_version.dart
@@ -6,12 +6,14 @@ class DistingVersion extends StatelessWidget {
     super.key,
     required this.distingVersion,
     required this.requiredVersion,
+    this.firmwareDate,
     this.onTap,
     this.onHelpTextChanged,
   });
 
   final String distingVersion;
   final String requiredVersion;
+  final String? firmwareDate;
   final VoidCallback? onTap;
   final ValueChanged<String?>? onHelpTextChanged;
 
@@ -23,14 +25,17 @@ class DistingVersion extends StatelessWidget {
       distingVersion,
     ).isSupported(requiredVersion);
 
-    final text = Text(
-      distingVersion,
-      style: Theme.of(context).textTheme.labelSmall?.copyWith(
-        color: isNotSupported
-            ? Theme.of(context).colorScheme.error
-            : Theme.of(context).colorScheme.onSurfaceVariant,
-      ),
+    final versionStyle = Theme.of(context).textTheme.labelSmall?.copyWith(
+      color: isNotSupported
+          ? Theme.of(context).colorScheme.error
+          : Theme.of(context).colorScheme.onSurfaceVariant,
     );
+
+    final displayText = firmwareDate != null
+        ? '$distingVersion ($firmwareDate)'
+        : distingVersion;
+
+    final text = Text(displayText, style: versionStyle);
 
     // Only show tooltip if contextual help is not available
     final showTooltip = onHelpTextChanged == null;
@@ -45,10 +50,11 @@ class DistingVersion extends StatelessWidget {
       content = Tooltip(message: tooltipMessage, child: text);
     }
 
+    final dateLabel = firmwareDate != null ? ', date $firmwareDate' : '';
     final wrappedContent = Semantics(
       label: isNotSupported
-          ? 'Firmware version $distingVersion - update required, minimum $requiredVersion'
-          : 'Firmware version $distingVersion',
+          ? 'Firmware version $distingVersion$dateLabel - update required, minimum $requiredVersion'
+          : 'Firmware version $distingVersion$dateLabel',
       button: onTap != null,
       hint: onTap != null ? 'Tap to manage firmware updates' : null,
       excludeSemantics: true,


### PR DESCRIPTION
## Summary
- Parse optional second null-terminated string from firmware version SysEx response (contains build date)
- Display firmware date next to version in bottom bar, e.g., `1.15.0 (Mar 15 2026)`
- Gracefully handles older firmware that doesn't include a date (displays version only)

## Test plan
- [x] `flutter analyze` clean — zero warnings
- [x] Full test suite passes (2171 tests)
- [ ] Manual: connect to beta firmware that includes date and verify it displays
- [ ] Manual: connect to release firmware (no date) and verify version-only display

Fixes backlog story #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)