### PR TITLE
feat: display firmware version and date on separate lines

### DIFF
--- a/lib/ui/widgets/disting_version.dart
+++ b/lib/ui/widgets/disting_version.dart
@@ -31,11 +31,16 @@ class DistingVersion extends StatelessWidget {
           : Theme.of(context).colorScheme.onSurfaceVariant,
     );
 
-    final displayText = firmwareDate != null
-        ? '$distingVersion ($firmwareDate)'
-        : distingVersion;
-
-    final text = Text(displayText, style: versionStyle);
+    final Widget text = firmwareDate != null
+        ? Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(distingVersion, style: versionStyle),
+              Text(firmwareDate!, style: versionStyle),
+            ],
+          )
+        : Text(distingVersion, style: versionStyle);
 
     // Only show tooltip if contextual help is not available
     final showTooltip = onHelpTextChanged == null;


### PR DESCRIPTION
## Summary
- Split firmware version display in the bottom bar into two right-aligned lines: version on top, date (without parentheses) below
- Only affects display when firmware date is available; version-only display unchanged

## Test plan
- [x] `flutter analyze` passes with zero issues
- [x] All 2190 tests pass
- [ ] Visual verification: bottom bar shows version on first line, date on second line
- [ ] Verify date has no parentheses
- [ ] Verify alignment is right-aligned in the bottom bar

Closes story #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)