### PR TITLE
Auto-save preset on rename

### DIFF
--- a/docs/plans/auto-save-on-preset-rename_plan.md
+++ b/docs/plans/auto-save-on-preset-rename_plan.md
@@ -1,0 +1,149 @@
+# Plan: Auto-save preset on rename
+
+## Goal
+
+When the user renames the current preset to a non-empty value, the preset is saved to the device immediately — the user no longer has to invoke the manual "Save Preset" action separately. Renames to empty/whitespace-only strings are already rejected by existing validation and must NOT trigger a save.
+
+## Current behavior (verified)
+
+### Rename flow
+
+| Step | Location |
+|---|---|
+| User taps "Preset:" label | `lib/ui/synchronized_screen.dart:2123` (`InkWell.onTap`) |
+| Rename dialog opens | `lib/ui/widgets/rename_preset_dialog.dart:38-55` (TextField + OK/Cancel buttons; submit on Enter or OK) |
+| Dialog returns trimmed name (or `null` on cancel) | `rename_preset_dialog.dart:33-36` |
+| UI guards empty / unchanged | `synchronized_screen.dart:2133-2137` (`newName != null && newName.isNotEmpty && newName != widget.presetName`) |
+| Cubit facade | `lib/cubit/disting_cubit.dart:422-424` (`renamePreset()` → `renamePresetImpl()`) |
+| Cubit impl | `lib/cubit/disting_cubit_preset_ops.dart:32-77` (optimistic UI emit, async `requestSetPresetName`, deferred verification read-back) |
+
+`renamePresetImpl()` already trims and re-checks emptiness: line 35-36 short-circuits when `trimmed.isEmpty || trimmed == currentState.presetName`.
+
+### Manual save flow (the path we must reuse)
+
+The manual save calls `IDistingMidiManager.requestSavePreset()` directly — there is no cubit-level wrapper today. Three call sites:
+
+- `synchronized_screen.dart:503` — keyboard shortcut handler.
+- `synchronized_screen.dart:1828` — "save first, then new preset" branch.
+- `synchronized_screen.dart:1851` — "Save Preset" popup menu item.
+
+Plus one external call site:
+
+- `lib/services/disting_controller_impl.dart:329` — `DistingController.savePreset()` (used by MCP).
+
+All four invoke `manager.requestSavePreset()` (with no option arg) on the active manager. Implementations:
+
+- `lib/domain/disting_midi_manager.dart:664` — sends SysEx `SavePresetMessage` with option=2 to the live device.
+- `lib/domain/offline_disting_midi_manager.dart:528` — persists to the local Drift database via `presetsDao.saveFullPreset()`.
+- `lib/domain/mock_disting_midi_manager.dart:1069` — no-op (demo mode).
+
+The interface declares `Future<void> requestSavePreset({int option})` (`lib/domain/i_disting_midi_manager.dart:77`). The mock signature uses `int? option`, but every caller invokes it with no argument, so default-arg behaviour is what matters and it is consistent (option=2 on hardware, ignored offline/mock).
+
+The device handles SysEx commands sequentially (comment at `synchronized_screen.dart:1829-1831`), so chaining `requestSetPresetName` and `requestSavePreset` is already safe — that is precisely how the existing "save before new preset" branch works.
+
+## Design
+
+### Trigger point
+
+Inside `renamePresetImpl()` in `lib/cubit/disting_cubit_preset_ops.dart`, **after** the existing empty-name guard and **after** the optimistic UI emit + the `requestSetPresetName` background send. Calling save from inside the cubit (rather than the UI) means *all* rename entry points get auto-save:
+
+- The rename dialog (`synchronized_screen.dart:2136`).
+- The MCP `setPresetName` controller (`disting_controller_impl.dart:96`, which calls `cubit.renamePreset()`).
+
+Both should auto-save — that matches the spirit of the feature ("renaming a preset persists it").
+
+### Empty-name guard
+
+The existing line 35-36 already short-circuits empty/whitespace-only renames AND no-op renames (where the trimmed name equals the current preset name). Auto-save must run only on the path past that guard, so it inherits the same protection for free. No new validation needed.
+
+### Reuse the manual-save path
+
+The rename impl has access to `disting` (line 42, the active manager). Calling `disting.requestSavePreset()` from there hits the same interface method as every other save call site — no parallel save logic, no new cubit method. This satisfies the "same code path" acceptance criterion.
+
+### Sequencing
+
+`disting.requestSetPresetName(trimmed)` is fired without `await` today (line 43 — the future is chained with `.catchError`). Auto-save must follow the rename SysEx, not race it. Two viable ordering strategies:
+
+1. **Await the rename, then save.** Change `disting.requestSetPresetName(trimmed).catchError(...)` to `await` it, save on success, skip save on failure. Most correct, but converts the rename from fire-and-forget to await — slight behavior change for callers that don't await `renamePreset()` (the UI doesn't, MCP does via `Future.value()`).
+2. **Fire-and-forget save after rename, relying on the device's sequential command processing.** Simply call `disting.requestSavePreset()` immediately after the `requestSetPresetName(...)` line. Matches what `synchronized_screen.dart:1828` already does for the "save first, then new preset" branch.
+
+**Choice: strategy 1 (await rename, then save).** Rationale: the offline manager's `requestSetPresetName` writes to the database synchronously (via `await`); strategy 2 would still work there, but strategy 1 also lets us skip the save when the rename failed — which matches the existing verification-fallback that re-reads the device truth. Skipping the save on failure avoids persisting a stale UI name. The catch handler stays in place to schedule the verification read-back.
+
+### Last-write-wins on rapid renames
+
+Multiple rename calls in quick succession: each `renamePresetImpl` call emits its own optimistic UI update and fires its own `requestSetPresetName` + `requestSavePreset`. The device processes SysEx sequentially, so the last name wins on the device side. The verification operation is already cancelled-and-replaced on each call (`_renamePresetVerificationOperation?.cancel()` at lines 45 and 61), which keeps the last verification authoritative. No new debounce is needed — the existing semantics (last write wins) carry through to the auto-save.
+
+### What does NOT change
+
+- `renamePreset()` facade signature (still `void renamePreset(String newName)`).
+- The rename dialog UI.
+- The manual save call sites (keyboard shortcut, menu, "save first new", MCP `savePreset()`).
+- The `requestSavePreset` interface and all implementations.
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `lib/cubit/disting_cubit_preset_ops.dart` | After awaiting `requestSetPresetName(trimmed)` succeeds, call `disting.requestSavePreset()`. On error, fall through to existing verification path and do NOT save. |
+| `test/cubit/disting_cubit_preset_rename_test.dart` (NEW) | New test file. Cases: (a) renaming to non-empty value calls `requestSetPresetName` then `requestSavePreset` exactly once, (b) renaming to whitespace-only does NOT call either, (c) renaming to the same name does NOT save, (d) two rapid renames result in two saves with the latest name being the final SysEx call. |
+
+No UI file changes. No interface changes. No new cubit method.
+
+## Acceptance criteria — how each is met
+
+| Criterion | How |
+|---|---|
+| Rename to non-empty persists immediately | `disting.requestSavePreset()` runs after `requestSetPresetName` succeeds, inside `renamePresetImpl`. |
+| Rename to empty/whitespace does NOT save | Existing `trimmed.isEmpty` guard at `disting_cubit_preset_ops.dart:36` short-circuits before any SysEx is sent — auto-save is below the guard. |
+| Manual save still works | No change to any of the four manual-save call sites. |
+| Same code path as manual save | Auto-save calls `disting.requestSavePreset()` — the exact method every manual save call site uses. |
+| Rapid renames → latest wins | Existing rename impl already emits last-write-wins semantics; auto-save follows the same ordering on the device. |
+| `flutter analyze` clean | No new warnings introduced. |
+| Tests pass | New test file added; existing tests untouched. |
+| New test covers the change | New `disting_cubit_preset_rename_test.dart` covers the four cases above. |
+
+## Gaps integrated
+
+### G1 — Behavior change for MCP `setPresetName` callers
+
+`lib/services/disting_controller_impl.dart:96` (`DistingController.setPresetName`) routes to `cubit.renamePreset()`. After this change, the MCP tool `disting_tools.dart:setPresetName` (line 955) will auto-save as a side effect. Two MCP tools chain `setPresetName` with subsequent work that ends in an explicit `savePreset()`:
+
+- `buildPresetFromJson` (line 1935) — sets name first, then loads slots; later returns without an explicit save.
+- `editPreset` (line 4221) — applies diff then sets name in step 6, then explicitly saves at line 2823.
+
+**Resolution:** This is acceptable, not a bug. The device handles SysEx commands sequentially, so an extra save SysEx during a complex MCP flow is idempotent and harmless. `editPreset`'s explicit `savePreset()` at line 2823 still runs and remains the authoritative save. `buildPresetFromJson` previously did not save at all (relied on user to save manually); auto-save now persists the name change earlier, but the slot operations that follow still require a final save (out of scope for this feature). No MCP test changes needed — existing tests mock `DistingController`, not the cubit, so they are unaffected.
+
+### G2 — Failure of `requestSetPresetName` must skip the save
+
+The plan's strategy 1 (await rename, save on success) is correct, but the implementation must be precise:
+
+- Wrap `await disting.requestSetPresetName(trimmed)` in a try/catch.
+- On success: call `disting.requestSavePreset()` (do not await — keep cubit responsive).
+- On error: schedule the existing 250ms verification read-back (preserve the current `.catchError` behavior). Do NOT call save.
+- The unconditional 500ms verification read at lines 61-75 is preserved as-is — it remains useful regardless of save success/failure.
+
+### G3 — No cubit BuildContext for semantics announcement (accept)
+
+The keyboard-shortcut manual save (`synchronized_screen.dart:503`) emits `SemanticsService.sendAnnouncement('Preset saved')` after `requestSavePreset()`. The popup-menu manual save and the MCP save path do **not**. Auto-save runs inside the cubit which has no `BuildContext`, so it cannot emit a semantics announcement.
+
+**Resolution:** Accept the gap. The screen reader already hears the rename event (the preset name in the UI updates optimistically). Adding a save announcement would require a UI-layer listener and is out of scope. The keyboard-shortcut announcement is preserved as-is.
+
+### G4 — Test cases expanded
+
+The original test list is upgraded to:
+
+1. **Rename to non-empty name** calls `requestSetPresetName(trimmed)` and `requestSavePreset()` exactly once each, **in that order** (verified via Mocktail `verifyInOrder`).
+2. **Rename to empty string** does NOT call either method.
+3. **Rename to whitespace-only** ('   ', '\t\n') does NOT call either method (Dart `String.trim()` strips all Unicode whitespace).
+4. **Rename to the same name** as the current preset does NOT call either method.
+5. **Rename when state is not `DistingStateSynchronized`** does NOT call either method.
+6. **`requestSetPresetName` throws** → `requestSavePreset` is NOT called (regression guard for G2).
+7. **Two rapid renames** result in `requestSetPresetName` then `requestSavePreset` being called twice in total, with the SECOND name being the last `requestSetPresetName` argument (last-write-wins).
+
+### G5 — Offline mode behaviour
+
+The offline manager's `requestSavePreset` writes to the local Drift database (`lib/domain/offline_disting_midi_manager.dart:528`). When `_loadedPresetId == null`, it creates a new preset entry (id=-1 path). This is a pre-existing behavior of the manual-save call, NOT introduced by this feature — and the existing rename guard (`if (currentState is DistingStateSynchronized)`) already requires a synchronized state, which means a preset is loaded. No additional guard required. Tests use `MockDistingMidiManager` and verify the call, not the offline-specific branch behavior.
+
+### G6 — `requestSavePreset` is not awaited
+
+To keep the cubit responsive (no UI freeze waiting for save round-trip), the auto-save call is **fire-and-forget** with a `.catchError` to swallow errors. The rename await is kept for sequencing (so we know the rename succeeded before asking for a save). This mirrors the existing manual-save call sites which also do not await.

--- a/docs/plans/auto_center_setting_plan.md
+++ b/docs/plans/auto_center_setting_plan.md
@@ -1,0 +1,118 @@
+# Plan: Auto-center on algorithm selection setting
+
+## Goal
+
+Add a user preference "Auto-center on algorithm selection" (default `true`) that gates the existing behavior where the routing canvas auto-scrolls/centers on an algorithm node when that algorithm becomes the sole focused selection.
+
+## Current behavior (verified)
+
+The auto-centering is mediated by `RoutingEditorState.cascadeScrollTarget`. The trigger pipeline is:
+
+1. User selects an algorithm via one of these paths:
+   - Plain tap on a node in the routing canvas — `routing_editor_widget.dart:3209` calls `cubit.setFocusedAlgorithm(nodeId)`.
+   - Cross-screen sync when the algorithm list changes selection — `synchronized_screen.dart:392` calls `_routingEditorCubit?.setFocusedAlgorithmBySlotIndex(slotIndex)`, which delegates to `setFocusedAlgorithm()`.
+2. `setFocusedAlgorithm()` (`routing_editor_cubit.dart:3314-3327`) emits a state with `cascadeScrollTarget` set to the node's centroid.
+3. `RoutingEditorWidget.build`'s `BlocConsumer.listener` (`routing_editor_widget.dart:1042-1064`) detects the new `cascadeScrollTarget` and animates the scroll controllers via `_scrollToPosition()`. After the animation it calls `clearCascadeScrollTarget()`.
+
+Two other paths emit a `cascadeScrollTarget` but are NOT selection events and must keep working:
+
+- `_applyCascadeLayout()` (`routing_editor_cubit.dart:3079`) emits a centroid scroll target after running the layout algorithm. The user explicitly invoked layout — that is not an algorithm-selection event, so this scroll must stay unconditional.
+- `toggleAlgorithmFocus()` (`routing_editor_cubit.dart:3299`, used for shift-click multi-select) intentionally does NOT set `cascadeScrollTarget` today. No change needed there.
+
+## Setting design
+
+Mirror the existing `cpuMonitorEnabled` boolean setting in `lib/services/settings_service.dart`:
+
+| Aspect | Value |
+|---|---|
+| Setting key constant | `_autoCenterOnSelectionKey = 'auto_center_on_selection'` |
+| Default constant | `defaultAutoCenterOnSelection = true` |
+| Public getter | `bool get autoCenterOnSelection` |
+| Public setter | `Future<bool> setAutoCenterOnSelection(bool value)` |
+| Persistence | `SharedPreferences.setBool` (existing infrastructure, already initialized in `main.dart`) |
+| ValueNotifier | Not required — the value is read at the moment a selection happens, not bound reactively, and the UI for toggling rebuilds itself locally inside `_SettingsDialogState`. |
+
+## Gating point
+
+Single point of control: `RoutingEditorCubit.setFocusedAlgorithm()`.
+
+```dart
+void setFocusedAlgorithm(String algorithmId) {
+  final currentState = state;
+  if (currentState is! RoutingEditorStateLoaded) return;
+
+  final shouldAutoCenter = SettingsService().autoCenterOnSelection;
+  Offset? scrollTarget;
+  if (shouldAutoCenter) {
+    final nodePos = currentState.nodePositions[algorithmId];
+    scrollTarget = nodePos != null
+        ? Offset(nodePos.x + nodePos.width / 2,
+                 nodePos.y + nodePos.height / 2)
+        : null;
+  }
+
+  emit(currentState.copyWith(
+    focusedAlgorithmIds: {algorithmId},
+    cascadeScrollTarget: scrollTarget,
+  ));
+}
+```
+
+Rationale for gating here, not in the widget listener:
+- `setFocusedAlgorithmBySlotIndex()` already delegates to `setFocusedAlgorithm()`, so a single change covers both selection paths.
+- `_applyCascadeLayout()` continues to set `cascadeScrollTarget` independently — its scroll is preserved without conditional logic.
+- The widget listener stays generic ("if there is a target, scroll to it"), so future producers of `cascadeScrollTarget` aren't accidentally gated.
+
+## Settings UI placement
+
+Add a new `SwitchListTile` in `lib/services/settings_service.dart` `_SettingsDialogState.build()`, immediately after the "Show Contextual Help Hints" tile (around current line 810), before the `SizedBox(height: 24)` that precedes the Gallery URL section. Mirror the haptics/CPU-monitor toggle pattern.
+
+- **Title:** `"Auto-Center on Algorithm Selection"` — chosen as a noun phrase that names the behavior. Neighboring tiles use a mix of imperative ("Enable…", "Show…", "Allow…") and noun-phrase ("Collapse Algorithm Pages by Default") forms; either fits.
+- **Subtitle:** `"Automatically scroll the routing canvas to the selected algorithm"` (present-tense action, matches "Provide tactile feedback…", "Show CPU usage…", "Display helpful hints…").
+
+Wire-up checklist (mirrors CPU monitor):
+- Add `late bool _autoCenterOnSelection;` to `_SettingsDialogState`.
+- Initialize in `_loadSettings()` (`settings.autoCenterOnSelection`).
+- Persist in `_saveSettings()` (`await settings.setAutoCenterOnSelection(_autoCenterOnSelection);`).
+- Reset in `SettingsService.resetToDefaults()` (`await setAutoCenterOnSelection(defaultAutoCenterOnSelection);`).
+
+## Files changed
+
+| File | Why |
+|---|---|
+| `lib/services/settings_service.dart` | Add key, default, getter, setter, dialog state field, load/save/reset wiring, toggle UI. |
+| `lib/cubit/routing_editor_cubit.dart` | Gate `cascadeScrollTarget` in `setFocusedAlgorithm()` based on `SettingsService().autoCenterOnSelection`. |
+| `docs/plans/auto_center_setting_plan.md` | This plan (already created). |
+| `test/cubit/routing_editor_cubit_auto_center_test.dart` (new) | Unit test that confirms `setFocusedAlgorithm()` sets `cascadeScrollTarget` when the setting is true and leaves it null when the setting is false. Stubs the singleton via `SharedPreferences.setMockInitialValues`. |
+
+## Tests
+
+A unit test under `test/cubit/` that follows the established pattern (see `test/cubit/routing_editor_cubit_layout_test.dart` for a reference, and `test/services/settings_service_ui_scale_test.dart:12` for the SettingsService init pattern):
+
+1. In `setUp()` for each test, call `SharedPreferences.setMockInitialValues({'auto_center_on_selection': <value>})` BEFORE calling `SettingsService().init()`. The `SettingsService` singleton persists across tests, so each `setUp` must reset the mock to the expected value and re-init so the getter sees the seeded value.
+2. Construct a `RoutingEditorCubit` with a minimal `RoutingEditorStateLoaded` (use the `MockDistingCubit` pattern from `routing_editor_cubit_layout_test.dart`) containing a single algorithm with a known `NodePosition`.
+3. Call `cubit.setFocusedAlgorithm('algo-id')`.
+4. Assert `cascadeScrollTarget` is `null` when setting is `false`, and equals the node centroid when setting is `true`.
+5. Assert `focusedAlgorithmIds` contains the id in both cases (focus is independent of scroll).
+
+If hooking the cubit into a fully-loaded state is too heavy, fall back to a focused widget test, or extract the centroid+gating logic behind a small testable method. Prefer the unit test.
+
+### Test isolation note
+
+Because `SettingsService` is a singleton, tests that toggle the setting must be ordered carefully. In each `setUp`, seed `setMockInitialValues` with the desired bool and re-call `init()` — do not rely on cross-test state.
+
+## Edge cases / open questions (for gap analysis)
+
+- Should the setting also gate the cascade-layout scroll? Current plan: NO, because that's a user-initiated layout action, not selection. The setting name says "on algorithm selection".
+- Toggling mid-session: setting is read at the next selection event, so changes take effect immediately without a restart.
+- First launch: default is `true`, so existing behavior is preserved on upgrade (no migration needed — `getBool` falls back to the default constant).
+- Multiple windows / split screen: SharedPreferences is process-wide; both panes see the same setting. No special handling.
+- Reset App Data: the new key is a simple bool, will be cleared along with everything else by the existing reset flow.
+- Demo / offline mode: setting lives in app preferences, unaffected by mode.
+- Accessibility: `accessible_routing_list_view.dart` destructures `cascadeScrollTarget` from the state but does not consume it (no scroll-to-target in list mode). a11y mode is unaffected — confirmed.
+- Init-order safety: `SettingsService().init()` is awaited in `lib/main.dart:121` before `runApp`, well before any `RoutingEditorCubit` is constructed by the provider tree. The getter also falls back to the constant default if `_prefs` is null. No race.
+- Localization: this codebase has no `.arb`/`l10n` setup. Strings live inline. No translation step required.
+
+## Out of scope (noted but not addressed)
+
+During audit, a pre-existing bug was identified: `SettingsService.resetToDefaults()` (line 428-447) is missing several settings (e.g. `chatEnabled`, `chatPanelWidth`, `dismissedUpdateVersion`, etc.). The new `autoCenterOnSelection` reset call WILL be added per this plan; existing missing resets are out of scope and will not be fixed here.

--- a/lib/cubit/disting_cubit_preset_ops.dart
+++ b/lib/cubit/disting_cubit_preset_ops.dart
@@ -40,7 +40,10 @@ mixin _DistingCubitPresetOps on _DistingCubitBase {
 
       // 2) Send request in background (works for online + offline managers)
       final disting = currentState.disting;
-      disting.requestSetPresetName(trimmed).catchError((e, s) {
+      disting.requestSetPresetName(trimmed).then((_) {
+        // Auto-save via the same path as the manual "Save Preset" action.
+        disting.requestSavePreset().catchError((_) {});
+      }, onError: (e, s) {
         // If rename fails, fall back to device truth via a lightweight read.
         _renamePresetVerificationOperation?.cancel();
         _renamePresetVerificationOperation = CancelableOperation.fromFuture(

--- a/lib/cubit/routing_editor_cubit.dart
+++ b/lib/cubit/routing_editor_cubit.dart
@@ -15,6 +15,7 @@ import 'package:nt_helper/core/routing/services/connection_validator.dart';
 import 'package:nt_helper/ui/widgets/routing/connection_validator.dart'
     as ui_validator;
 import 'package:nt_helper/core/routing/node_layout_algorithm.dart';
+import 'package:nt_helper/services/settings_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nt_helper/core/routing/models/es5_hardware_node.dart';
 import 'package:nt_helper/core/routing/bus_spec.dart';
@@ -3315,10 +3316,16 @@ class RoutingEditorCubit extends Cubit<RoutingEditorState> {
     final currentState = state;
     if (currentState is! RoutingEditorStateLoaded) return;
 
-    final nodePos = currentState.nodePositions[algorithmId];
-    final scrollTarget = nodePos != null
-        ? Offset(nodePos.x + nodePos.width / 2, nodePos.y + nodePos.height / 2)
-        : null;
+    Offset? scrollTarget;
+    if (SettingsService().autoCenterOnSelection) {
+      final nodePos = currentState.nodePositions[algorithmId];
+      scrollTarget = nodePos != null
+          ? Offset(
+              nodePos.x + nodePos.width / 2,
+              nodePos.y + nodePos.height / 2,
+            )
+          : null;
+    }
 
     emit(currentState.copyWith(
       focusedAlgorithmIds: {algorithmId},

--- a/lib/domain/disting_midi_manager.dart
+++ b/lib/domain/disting_midi_manager.dart
@@ -1061,9 +1061,12 @@ class DistingMidiManager implements IDistingMidiManager {
   @override
   Future<DirectoryListing?> requestDirectoryListing(String path) async {
     await _checkSdCardSupport();
+    // SD card operations require absolute paths (see installFileToPath
+    // in disting_cubit_plugin_delegate.dart for the same normalization).
+    final absolutePath = path.startsWith('/') ? path : '/$path';
     final message = RequestDirectoryListingMessage(
       sysExId: sysExId,
-      path: path,
+      path: absolutePath,
     );
     final packet = message.encode();
     return _scheduler.sendRequest<DirectoryListing>(
@@ -1097,21 +1100,45 @@ class DistingMidiManager implements IDistingMidiManager {
   @override
   Future<Uint8List?> requestFileDownload(String path) async {
     await _checkSdCardSupport();
-    final message = RequestFileDownloadMessage(sysExId: sysExId, path: path);
+    // SD card operations require absolute paths (see installFileToPath
+    // in disting_cubit_plugin_delegate.dart for the same normalization).
+    // Without a leading '/' the firmware can't locate the file and
+    // responds with a directory listing of the root, which surfaces as
+    // a type-mismatch error rather than useful file bytes.
+    final absolutePath = path.startsWith('/') ? path : '/$path';
+    final message = RequestFileDownloadMessage(
+      sysExId: sysExId,
+      path: absolutePath,
+    );
     final packet = message.encode();
 
-    // File downloads return the entire file in a single response
-    // According to Python reference, file downloads respond with 0x7A (same as directory listing)
-    final chunk = await _scheduler.sendRequest<FileChunk>(
-      packet,
-      RequestKey(
-        sysExId: sysExId,
-        messageType: DistingNTRespMessageType.respDirectoryListing, // 0x7A
-      ),
-      responseExpectation: ResponseExpectation.required,
-      timeout: const Duration(seconds: 10), // Longer timeout for large files
-    );
-    return chunk?.data;
+    // File downloads return the entire file in a single response.
+    // The NT reuses message type 0x7A for both directory listings and
+    // file download responses, differentiated by the operation byte
+    // (1 = listing, 2 = file chunk — see response_factory.dart).
+    //
+    // When the path doesn't resolve to a readable file the firmware can
+    // respond with a directory listing instead of a FileChunk; the
+    // scheduler's type-checked complete() rejects the DirectoryListing
+    // value and surfaces a StateError. Catch it here and treat it as a
+    // clean "file not found" (null), matching the contract documented
+    // on the interface.
+    try {
+      final chunk = await _scheduler.sendRequest<FileChunk>(
+        packet,
+        RequestKey(
+          sysExId: sysExId,
+          messageType: DistingNTRespMessageType.respDirectoryListing, // 0x7A
+        ),
+        responseExpectation: ResponseExpectation.required,
+        timeout: const Duration(seconds: 10), // Longer timeout for large files
+      );
+      return chunk?.data;
+    } on StateError {
+      // Firmware returned an unexpected shape (typically a directory
+      // listing for a missing/invalid file path). Treat as not found.
+      return null;
+    }
   }
 
   @override

--- a/lib/services/file_collector.dart
+++ b/lib/services/file_collector.dart
@@ -3,15 +3,12 @@ import 'package:nt_helper/models/preset_dependencies.dart';
 import 'package:nt_helper/models/collected_file.dart';
 import 'package:nt_helper/models/collection_result.dart';
 import 'package:nt_helper/models/package_config.dart';
-import 'package:nt_helper/util/extensions.dart';
-import 'package:nt_helper/db/database.dart';
 
 /// Collects dependency files from the file system
 class FileCollector {
   final PresetFileSystem fileSystem;
-  final AppDatabase database;
 
-  FileCollector(this.fileSystem, this.database);
+  FileCollector(this.fileSystem);
 
   /// 50 MB hard ceiling per file. Anything larger is skipped with a
   /// warning — a Disting NT preset is unlikely to need files this big,
@@ -113,21 +110,27 @@ class FileCollector {
       await _collectFile(midiPath, files, warnings, label: 'MIDI file');
     }
 
-    // Collect community plugin files (if enabled)
+    // Collect community plugin files (if enabled).
+    //
+    // Plugin paths come from live AlgorithmInfo records (see
+    // PresetAnalyzer.extractPluginPaths). The full library is passed in,
+    // so `pluginPaths` contains every plugin installed on the NT — we
+    // only package the subset that the preset actually references
+    // (dependencies.communityPlugins), otherwise every export would try
+    // to read every plugin.
+    //
+    // Matching is done on trimmed GUIDs since the preset JSON can store
+    // a trailing-space-padded 4-char GUID while AlgorithmInfo may return
+    // the trimmed form (or vice versa).
     if (config?.includeCommunityPlugins == true) {
-      // First, collect all plugin GUIDs that need paths
-      final allPluginGuids = <String>{
-        ...dependencies.communityPlugins,
-        ...dependencies.pluginPaths.keys,
+      final referenced = {
+        for (final g in dependencies.communityPlugins) g.trim(): g,
       };
+      final collectedRefs = <String>{};
 
-      // Track which GUIDs we've already collected to avoid duplicates
-      final collectedGuids = <String>{};
-
-      // Priority 1: Use direct paths from AlgorithmInfo (pluginPaths).
-      // These are more reliable as they come directly from the hardware.
       for (final entry in dependencies.pluginPaths.entries) {
-        final pluginGuid = entry.key;
+        final trimmed = entry.key.trim();
+        if (!referenced.containsKey(trimmed)) continue;
         final pluginPath = entry.value;
 
         try {
@@ -140,57 +143,37 @@ class FileCollector {
               );
             } else {
               files.add(CollectedFile(pluginPath, bytes));
-              collectedGuids.add(pluginGuid);
+              collectedRefs.add(trimmed);
             }
           } else {
             warnings.add(
               'Plugin file not found at path from hardware: $pluginPath '
-              '(GUID: $pluginGuid)',
+              '(GUID: ${entry.key})',
             );
           }
         } catch (e) {
           warnings.add(
-            'Error reading plugin $pluginGuid at $pluginPath: $e',
+            'Error reading plugin ${entry.key} at $pluginPath: $e',
           );
         }
       }
 
-      // Priority 2: Fall back to database lookup for remaining plugins
-      // (plugins identified by GUID but not in pluginPaths).
-      final remainingGuids = allPluginGuids.difference(collectedGuids).intersection(
-            dependencies.communityPlugins,
-          );
-
-      if (remainingGuids.isNotEmpty) {
-        final guidToPathMap = await database.metadataDao
-            .getPluginFilePathsByGuids(remainingGuids);
-
-        for (final pluginGuid in remainingGuids) {
-          final pluginPath = guidToPathMap[pluginGuid];
-          if (pluginPath != null) {
-            try {
-              (await fileSystem.readFile(pluginPath))?.let((bytes) {
-                if (bytes.length > maxFileSize) {
-                  warnings.add(
-                    'Skipping oversized plugin: $pluginPath '
-                    '(${_formatBytes(bytes.length)})',
-                  );
-                } else {
-                  files.add(CollectedFile(pluginPath, bytes));
-                }
-              });
-            } catch (e) {
-              warnings.add(
-                'Error reading community plugin $pluginGuid at $pluginPath: $e',
-              );
-            }
-          } else {
-            warnings.add(
-              'Community plugin $pluginGuid not found locally. '
-              'File path not available in database.',
-            );
-          }
+      // Warn about any community-plugin GUID referenced by the preset
+      // that we didn't package. Either the plugin isn't installed on
+      // the connected NT, or its filename path failed to resolve above.
+      for (final entry in referenced.entries) {
+        if (collectedRefs.contains(entry.key)) continue;
+        final originalGuid = entry.value;
+        // Skip if a "not found" warning already exists for this GUID
+        // (we'd have emitted one during the loop above).
+        if (dependencies.pluginPaths.keys
+            .any((k) => k.trim() == entry.key)) {
+          continue;
         }
+        warnings.add(
+          'Community plugin $originalGuid is not installed on the '
+          'connected Disting NT — cannot include it in the package.',
+        );
       }
     }
 

--- a/lib/services/package_creator.dart
+++ b/lib/services/package_creator.dart
@@ -5,7 +5,6 @@ import 'package:nt_helper/interfaces/preset_file_system.dart';
 import 'package:nt_helper/models/preset_dependencies.dart';
 import 'package:nt_helper/models/collected_file.dart';
 import 'package:nt_helper/models/package_config.dart';
-import 'package:nt_helper/db/database.dart';
 import 'preset_analyzer.dart';
 import 'file_collector.dart';
 
@@ -26,9 +25,8 @@ class PackageResult {
 /// Creates preset packages with all dependencies
 class PackageCreator {
   final PresetFileSystem fileSystem;
-  final AppDatabase database;
 
-  PackageCreator(this.fileSystem, this.database);
+  PackageCreator(this.fileSystem);
 
   Future<PackageResult> createPackage({
     required String presetFilePath, // e.g., "presets/MyPreset.json"
@@ -62,7 +60,7 @@ class PackageCreator {
       onProgress?.call('Collecting files...');
 
       // Collect dependency files
-      final fileCollector = FileCollector(fileSystem, database);
+      final fileCollector = FileCollector(fileSystem);
       final collection = await fileCollector.collectDependencies(
         dependencies,
         config: config,

--- a/lib/services/preset_analyzer.dart
+++ b/lib/services/preset_analyzer.dart
@@ -6,17 +6,39 @@ import '../domain/disting_nt_sysex.dart';
 class PresetAnalyzer {
   /// Extracts plugin file paths from AlgorithmInfo objects.
   /// Call this with live slot data to populate pluginPaths for direct SD card reads.
-  /// Returns a map of plugin GUID to SD card file path.
+  /// Returns a map of plugin GUID to SD card file path (normalized to include
+  /// the plugin directory prefix if the firmware returned a bare filename).
   static Map<String, String> extractPluginPaths(
     List<AlgorithmInfo> algorithmInfos,
   ) {
     final paths = <String, String>{};
     for (final info in algorithmInfos) {
       if (info.isPlugin && info.filename != null && info.filename!.isNotEmpty) {
-        paths[info.guid] = info.filename!;
+        paths[info.guid] = _normalizePluginPath(info.filename!);
       }
     }
     return paths;
+  }
+
+  /// Normalizes `AlgorithmInfo.filename` into a full SD-card-relative
+  /// path. The firmware strips the standard directory prefix
+  /// (`programs/plug-ins/`, `programs/lua/`, `programs/three_pot/`) from
+  /// the filename to save null-terminated-string bytes in the SysEx
+  /// payload, so we have to add it back. A filename may still contain
+  /// subfolder components (e.g. `corrupter/corrupter.o`), which we treat
+  /// as relative to the canonical plugin directory.
+  static String _normalizePluginPath(String filename) {
+    final lower = filename.toLowerCase();
+
+    // If the firmware did return a full path from the SD root, trust it.
+    if (lower.startsWith('programs/')) return filename;
+
+    if (lower.endsWith('.lua')) return 'programs/lua/$filename';
+    if (lower.endsWith('.3pot')) return 'programs/three_pot/$filename';
+    // Default: compiled C++ plugins (.o) and anything unknown live in
+    // /programs/plug-ins/. Subfolder paths like `corrupter/corrupter.o`
+    // are relative to plug-ins.
+    return 'programs/plug-ins/$filename';
   }
 
   static PresetDependencies analyzeDependencies(
@@ -38,6 +60,12 @@ class PresetAnalyzer {
   /// `/multisamples/`. All other algorithms with a `timbres[].folder`
   /// field reference a sample folder under `/samples/`.
   static const _multisampleGuids = <String>{'pyms'};
+
+  /// Algorithm GUIDs that use a top-level `folder` field to reference a
+  /// multisample folder under `/multisamples/`. `pymu` is the current
+  /// Poly Multisample (firmware >= 1.10); unlike `pyms` it has no
+  /// `timbres[]` array — just one folder per slot.
+  static const _topLevelMultisampleGuids = <String>{'pymu'};
 
   static void _analyzeSlot(Map<String, dynamic> slot, PresetDependencies deps) {
     final rawGuid = slot['guid']?.toString();
@@ -105,6 +133,16 @@ class PresetAnalyzer {
     // Granulator-style top-level sample reference (file under /samples/).
     if (slot['sample'] != null && slot['sample'].toString().trim().isNotEmpty) {
       deps.granulatorSamples.add(slot['sample']);
+    }
+
+    // Top-level `folder` field for algorithms that reference a single
+    // multisample folder per slot (e.g. `pymu` Poly Multisample).
+    // The `saveFolder` / `saveFilename` fields on the same slot are the
+    // *record destination*, not an existing dependency, so we skip them.
+    if (_topLevelMultisampleGuids.contains(guid) &&
+        slot['folder'] != null &&
+        slot['folder'].toString().trim().isNotEmpty) {
+      deps.multisampleFolders.add(slot['folder']);
     }
   }
 

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -485,6 +485,7 @@ class _SettingsDialogState extends State<SettingsDialog> {
   late bool _showDebugPanel;
   late bool _showContextualHelp;
   late bool _cpuMonitorEnabled;
+  late bool _autoCenterOnSelection;
   late double _uiScale;
 
   @override
@@ -507,6 +508,7 @@ class _SettingsDialogState extends State<SettingsDialog> {
       _showDebugPanel = settings.showDebugPanel;
       _showContextualHelp = settings.showContextualHelp;
       _cpuMonitorEnabled = settings.cpuMonitorEnabled;
+      _autoCenterOnSelection = settings.autoCenterOnSelection;
       _uiScale = settings.uiScale;
     });
   }
@@ -531,6 +533,7 @@ class _SettingsDialogState extends State<SettingsDialog> {
       await settings.setShowDebugPanel(_showDebugPanel);
       await settings.setShowContextualHelp(_showContextualHelp);
       await settings.setCpuMonitorEnabled(_cpuMonitorEnabled);
+      await settings.setAutoCenterOnSelection(_autoCenterOnSelection);
       await settings.setUiScale(_uiScale);
 
       if (mounted) {
@@ -817,6 +820,24 @@ class _SettingsDialogState extends State<SettingsDialog> {
                       onChanged: (value) {
                         setState(() {
                           _showContextualHelp = value;
+                        });
+                      },
+                      contentPadding: EdgeInsets.zero,
+                    ),
+
+                    // Auto-center on algorithm selection setting
+                    SwitchListTile(
+                      title: Text(
+                        'Auto-Center on Algorithm Selection',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      subtitle: const Text(
+                        'Automatically scroll the routing canvas to the selected algorithm',
+                      ),
+                      value: _autoCenterOnSelection,
+                      onChanged: (value) {
+                        setState(() {
+                          _autoCenterOnSelection = value;
                         });
                       },
                       contentPadding: EdgeInsets.zero,

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -63,6 +63,7 @@ class SettingsService {
   static const String _openaiModelKey = 'openai_model';
   static const String _openaiBaseUrlKey = 'openai_base_url';
   static const String _uiScaleKey = 'ui_scale';
+  static const String _autoCenterOnSelectionKey = 'auto_center_on_selection';
 
   // Default values
   static const int defaultRequestTimeout = 200;
@@ -94,6 +95,7 @@ class SettingsService {
   static const double minUiScale = 0.7;
   static const double maxUiScale = 1.5;
   static const double uiScaleStep = 0.1;
+  static const bool defaultAutoCenterOnSelection = true;
 
   /// Initialize the settings service
   Future<void> init() async {
@@ -281,6 +283,16 @@ class SettingsService {
     return await _prefs?.setInt(_algorithmCacheDaysKey, value) ?? false;
   }
 
+  /// Check if the routing canvas should auto-center on the selected algorithm
+  bool get autoCenterOnSelection =>
+      _prefs?.getBool(_autoCenterOnSelectionKey) ??
+      defaultAutoCenterOnSelection;
+
+  /// Set whether the routing canvas should auto-center on the selected algorithm
+  Future<bool> setAutoCenterOnSelection(bool value) async {
+    return await _prefs?.setBool(_autoCenterOnSelectionKey, value) ?? false;
+  }
+
   /// Check if CPU monitor is enabled
   bool get cpuMonitorEnabled =>
       _prefs?.getBool(_cpuMonitorEnabledKey) ?? defaultCpuMonitorEnabled;
@@ -444,6 +456,7 @@ class SettingsService {
     await setCpuMonitorEnabled(defaultCpuMonitorEnabled);
     await setSplitDividerPosition(defaultSplitDividerPosition);
     await setUiScale(defaultUiScale);
+    await setAutoCenterOnSelection(defaultAutoCenterOnSelection);
   }
 }
 

--- a/lib/ui/widgets/preset_browser_dialog.dart
+++ b/lib/ui/widgets/preset_browser_dialog.dart
@@ -256,15 +256,14 @@ class _PresetBrowserDialogState extends State<PresetBrowserDialog> {
                             Map<String, String>? pluginPaths;
                             final state = widget.distingCubit.state;
                             if (state is DistingStateSynchronized) {
-                              final slotAlgorithmIndices = state.slots
-                                  .map((s) => s.algorithm.algorithmIndex)
-                                  .toSet();
-                              final slotAlgorithms = state.algorithms
-                                  .where((a) =>
-                                      slotAlgorithmIndices.contains(a.algorithmIndex))
-                                  .toList();
-                              pluginPaths =
-                                  PresetAnalyzer.extractPluginPaths(slotAlgorithms);
+                              // Use the full algorithm library, not just the
+                              // currently-loaded slots. The preset being
+                              // exported may reference plugins that aren't
+                              // currently in any slot — those still need
+                              // their filenames resolved for packaging.
+                              pluginPaths = PresetAnalyzer.extractPluginPaths(
+                                state.algorithms,
+                              );
                             }
 
                             await showDialog<void>(
@@ -274,7 +273,6 @@ class _PresetBrowserDialogState extends State<PresetBrowserDialog> {
                                 fileSystem: PresetFileSystemImpl(
                                   widget.distingCubit.requireDisting(),
                                 ),
-                                database: widget.distingCubit.database,
                                 pluginPaths: pluginPaths,
                               ),
                             );

--- a/lib/ui/widgets/preset_package_dialog.dart
+++ b/lib/ui/widgets/preset_package_dialog.dart
@@ -8,24 +8,21 @@ import 'package:nt_helper/models/package_config.dart';
 import 'package:nt_helper/services/preset_analyzer.dart';
 import 'package:nt_helper/services/package_creator.dart';
 import 'package:nt_helper/services/settings_service.dart';
-import 'package:nt_helper/db/database.dart';
 
 /// Dialog for creating preset packages
 class PresetPackageDialog extends StatefulWidget {
   final String presetFilePath; // e.g., "presets/MyPreset.json"
   final PresetFileSystem fileSystem;
-  final AppDatabase database;
 
-  /// Optional plugin paths from AlgorithmInfo for direct SD card reads.
-  /// Map of plugin GUID to file path. If provided, these paths are used
-  /// for plugin file collection instead of database lookup.
+  /// Plugin GUID → SD-card file path map, sourced from live AlgorithmInfo.
+  /// Required for community-plugin packaging — without it, plugin binaries
+  /// cannot be located.
   final Map<String, String>? pluginPaths;
 
   const PresetPackageDialog({
     super.key,
     required this.presetFilePath,
     required this.fileSystem,
-    required this.database,
     this.pluginPaths,
   });
 
@@ -111,10 +108,7 @@ class _PresetPackageDialogState extends State<PresetPackageDialog> {
       );
 
       if (outputPath != null) {
-        final packageCreator = PackageCreator(
-          widget.fileSystem,
-          widget.database,
-        );
+        final packageCreator = PackageCreator(widget.fileSystem);
         final packageResult = await packageCreator.createPackage(
           presetFilePath: widget.presetFilePath,
           config: config,

--- a/test/cubit/disting_cubit_preset_rename_test.dart
+++ b/test/cubit/disting_cubit_preset_rename_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/cubit/disting_cubit.dart';
+import 'package:nt_helper/domain/i_disting_midi_manager.dart';
+import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/db/daos/metadata_dao.dart';
+import 'package:nt_helper/models/firmware_version.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../test_helpers/mock_midi_command.dart';
+
+class MockAppDatabase extends Mock implements AppDatabase {}
+
+class MockMetadataDao extends Mock implements MetadataDao {}
+
+class MockDistingMidiManager extends Mock implements IDistingMidiManager {}
+
+void main() {
+  late DistingCubit cubit;
+  late MockAppDatabase mockDatabase;
+  late MockMetadataDao mockMetadataDao;
+  late MockDistingMidiManager mockDisting;
+  late MockMidiCommand mockMidiCommand;
+
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    registerFallbackValue(DistingState.initial());
+  });
+
+  setUp(() {
+    mockDatabase = MockAppDatabase();
+    mockMetadataDao = MockMetadataDao();
+    mockDisting = MockDistingMidiManager();
+    mockMidiCommand = MockMidiCommand();
+
+    when(() => mockDatabase.metadataDao).thenReturn(mockMetadataDao);
+    when(
+      () => mockMetadataDao.hasCachedAlgorithms(),
+    ).thenAnswer((_) async => false);
+
+    when(
+      () => mockDisting.requestSetPresetName(any()),
+    ).thenAnswer((_) async {});
+    when(
+      () => mockDisting.requestSavePreset(),
+    ).thenAnswer((_) async {});
+    when(
+      () => mockDisting.requestPresetName(),
+    ).thenAnswer((_) async => null);
+
+    cubit = DistingCubit(mockDatabase, midiCommand: mockMidiCommand);
+  });
+
+  tearDown(() async {
+    await cubit.close();
+  });
+
+  DistingStateSynchronized makeSyncState({String presetName = 'Old Name'}) {
+    return DistingStateSynchronized(
+      disting: mockDisting,
+      distingVersion: '1.10.0',
+      firmwareVersion: FirmwareVersion('1.14.0'),
+      presetName: presetName,
+      algorithms: const [],
+      slots: const [],
+      unitStrings: const [],
+      offline: false,
+    );
+  }
+
+  Future<void> pumpEventQueue() async {
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  group('renamePreset auto-save', () {
+    test('rename to non-empty name calls set then save in order', () async {
+      cubit.emit(makeSyncState(presetName: 'Old Name'));
+
+      cubit.renamePreset('New Name');
+      await pumpEventQueue();
+
+      verifyInOrder([
+        () => mockDisting.requestSetPresetName('New Name'),
+        () => mockDisting.requestSavePreset(),
+      ]);
+    });
+
+    test('rename to empty string does not set or save', () async {
+      cubit.emit(makeSyncState(presetName: 'Old Name'));
+
+      cubit.renamePreset('');
+      await pumpEventQueue();
+
+      verifyNever(() => mockDisting.requestSetPresetName(any()));
+      verifyNever(() => mockDisting.requestSavePreset());
+    });
+
+    test('rename to whitespace-only name does not set or save', () async {
+      cubit.emit(makeSyncState(presetName: 'Old Name'));
+
+      cubit.renamePreset('   \t\n  ');
+      await pumpEventQueue();
+
+      verifyNever(() => mockDisting.requestSetPresetName(any()));
+      verifyNever(() => mockDisting.requestSavePreset());
+    });
+
+    test('rename to the same trimmed name does not set or save', () async {
+      cubit.emit(makeSyncState(presetName: 'Same Name'));
+
+      cubit.renamePreset('  Same Name  ');
+      await pumpEventQueue();
+
+      verifyNever(() => mockDisting.requestSetPresetName(any()));
+      verifyNever(() => mockDisting.requestSavePreset());
+    });
+
+    test('rename when not synchronized does not set or save', () async {
+      cubit.renamePreset('Anything');
+      await pumpEventQueue();
+
+      verifyNever(() => mockDisting.requestSetPresetName(any()));
+      verifyNever(() => mockDisting.requestSavePreset());
+    });
+
+    test('save is skipped when requestSetPresetName fails', () async {
+      when(
+        () => mockDisting.requestSetPresetName(any()),
+      ).thenAnswer((_) async => throw Exception('rename failed'));
+
+      cubit.emit(makeSyncState(presetName: 'Old Name'));
+
+      cubit.renamePreset('New Name');
+      await pumpEventQueue();
+
+      verify(() => mockDisting.requestSetPresetName('New Name')).called(1);
+      verifyNever(() => mockDisting.requestSavePreset());
+    });
+
+    test('two rapid renames produce two saves with last name being final',
+        () async {
+      cubit.emit(makeSyncState(presetName: 'Old Name'));
+
+      cubit.renamePreset('First');
+      cubit.renamePreset('Second');
+      await pumpEventQueue();
+
+      final captured = verify(
+        () => mockDisting.requestSetPresetName(captureAny()),
+      ).captured;
+      expect(captured, ['First', 'Second']);
+      verify(() => mockDisting.requestSavePreset()).called(2);
+    });
+  });
+}

--- a/test/cubit/routing_editor_cubit_auto_center_test.dart
+++ b/test/cubit/routing_editor_cubit_auto_center_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/core/routing/node_layout_algorithm.dart';
+import 'package:nt_helper/cubit/disting_cubit.dart';
+import 'package:nt_helper/cubit/routing_editor_cubit.dart';
+import 'package:nt_helper/cubit/routing_editor_state.dart';
+import 'package:nt_helper/domain/disting_nt_sysex.dart';
+import 'package:nt_helper/services/settings_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockDistingCubit extends Mock implements DistingCubit {}
+
+void main() {
+  group('RoutingEditorCubit auto-center on selection', () {
+    late RoutingEditorCubit cubit;
+    late _MockDistingCubit mockDistingCubit;
+
+    const algoId = 'algo_0';
+    const algoNodePos = NodePosition(
+      x: 100.0,
+      y: 200.0,
+      width: 80.0,
+      height: 40.0,
+    );
+
+    RoutingEditorStateLoaded buildLoadedState() => RoutingEditorState.loaded(
+          physicalInputs: const [],
+          physicalOutputs: const [],
+          algorithms: [
+            RoutingAlgorithm(
+              id: algoId,
+              index: 0,
+              algorithm: Algorithm(
+                algorithmIndex: 0,
+                guid: 'test0',
+                name: 'Test Algorithm',
+              ),
+              inputPorts: const [],
+              outputPorts: const [],
+            ),
+          ],
+          connections: const [],
+          nodePositions: const {algoId: algoNodePos},
+        ) as RoutingEditorStateLoaded;
+
+    Future<void> initWithSetting({required bool autoCenter}) async {
+      // Reseed prefs and force the singleton to pick them up.
+      SharedPreferences.setMockInitialValues(
+        {'auto_center_on_selection': autoCenter},
+      );
+      await SettingsService().init();
+
+      mockDistingCubit = _MockDistingCubit();
+      when(() => mockDistingCubit.stream)
+          .thenAnswer((_) => const Stream.empty());
+      when(() => mockDistingCubit.state).thenReturn(const DistingState.initial());
+      cubit = RoutingEditorCubit(mockDistingCubit);
+      cubit.emit(buildLoadedState());
+    }
+
+    tearDown(() async {
+      await cubit.close();
+    });
+
+    test('sets cascadeScrollTarget when setting is enabled', () async {
+      await initWithSetting(autoCenter: true);
+
+      cubit.setFocusedAlgorithm(algoId);
+
+      final state = cubit.state as RoutingEditorStateLoaded;
+      expect(state.focusedAlgorithmIds, contains(algoId));
+      expect(
+        state.cascadeScrollTarget,
+        // centroid = (x + w/2, y + h/2) = (140, 220)
+        equals(const Offset(140.0, 220.0)),
+      );
+    });
+
+    test('leaves cascadeScrollTarget null when setting is disabled', () async {
+      await initWithSetting(autoCenter: false);
+
+      cubit.setFocusedAlgorithm(algoId);
+
+      final state = cubit.state as RoutingEditorStateLoaded;
+      expect(state.focusedAlgorithmIds, contains(algoId));
+      expect(state.cascadeScrollTarget, isNull);
+    });
+
+    test('default (no key persisted) auto-centers, preserving prior behavior',
+        () async {
+      // No 'auto_center_on_selection' key — getter returns default true.
+      SharedPreferences.setMockInitialValues({});
+      await SettingsService().init();
+
+      mockDistingCubit = _MockDistingCubit();
+      when(() => mockDistingCubit.stream)
+          .thenAnswer((_) => const Stream.empty());
+      when(() => mockDistingCubit.state).thenReturn(const DistingState.initial());
+      cubit = RoutingEditorCubit(mockDistingCubit);
+      cubit.emit(buildLoadedState());
+
+      cubit.setFocusedAlgorithm(algoId);
+
+      final state = cubit.state as RoutingEditorStateLoaded;
+      expect(state.cascadeScrollTarget, equals(const Offset(140.0, 220.0)));
+    });
+  });
+}

--- a/test/services/file_collector_test.dart
+++ b/test/services/file_collector_test.dart
@@ -2,8 +2,6 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:nt_helper/db/database.dart';
-import 'package:nt_helper/db/daos/metadata_dao.dart';
 import 'package:nt_helper/interfaces/preset_file_system.dart';
 import 'package:nt_helper/models/package_config.dart';
 import 'package:nt_helper/models/preset_dependencies.dart';
@@ -11,24 +9,13 @@ import 'package:nt_helper/services/file_collector.dart';
 
 class MockPresetFileSystem extends Mock implements PresetFileSystem {}
 
-class MockAppDatabase extends Mock implements AppDatabase {}
-
-class MockMetadataDao extends Mock implements MetadataDao {}
-
 void main() {
   late MockPresetFileSystem mockFileSystem;
-  late MockAppDatabase mockDatabase;
-  late MockMetadataDao mockMetadataDao;
   late FileCollector fileCollector;
 
   setUp(() {
     mockFileSystem = MockPresetFileSystem();
-    mockDatabase = MockAppDatabase();
-    mockMetadataDao = MockMetadataDao();
-
-    when(() => mockDatabase.metadataDao).thenReturn(mockMetadataDao);
-
-    fileCollector = FileCollector(mockFileSystem, mockDatabase);
+    fileCollector = FileCollector(mockFileSystem);
   });
 
   group('FileCollector - pluginPaths', () {
@@ -36,6 +23,10 @@ void main() {
       // Arrange
       final deps = PresetDependencies();
       deps.pluginPaths['MYPLUGIN'] = 'programs/plug-ins/MyPlugin.elf';
+      // The preset must reference the plugin by GUID or we skip it (the
+      // pluginPaths map is the full NT library; we only package plugins
+      // the preset actually uses).
+      deps.communityPlugins.add('MYPLUGIN');
 
       final pluginBytes = Uint8List.fromList([0x7F, 0x45, 0x4C, 0x46]); // ELF
       when(
@@ -54,51 +45,35 @@ void main() {
       expect(result.files.length, 1);
       expect(result.files.first.relativePath, 'programs/plug-ins/MyPlugin.elf');
       expect(result.files.first.bytes, pluginBytes);
-
-      // Should NOT call database lookup since we have direct paths
-      verifyNever(
-        () => mockMetadataDao.getPluginFilePathsByGuids(any()),
-      );
     });
 
-    test('falls back to database for plugins not in pluginPaths', () async {
-      // Arrange
+    test('warns about community plugins missing from pluginPaths', () async {
+      // Community-plugin GUID detected in the preset but no path supplied
+      // (e.g. plugin is referenced but not installed on the connected NT).
       final deps = PresetDependencies();
       deps.communityPlugins.add('OTHERPLUGIN');
-      // Note: pluginPaths is empty, so database lookup should be used
-
-      final pluginBytes = Uint8List.fromList([0x7F, 0x45, 0x4C, 0x46]);
-      when(
-        () => mockMetadataDao.getPluginFilePathsByGuids({'OTHERPLUGIN'}),
-      ).thenAnswer(
-        (_) async => {'OTHERPLUGIN': 'programs/plug-ins/Other.elf'},
-      );
-      when(
-        () => mockFileSystem.readFile('programs/plug-ins/Other.elf'),
-      ).thenAnswer((_) async => pluginBytes);
 
       final config = const PackageConfig(includeCommunityPlugins: true);
 
-      // Act
       final result = await fileCollector.collectDependencies(
         deps,
         config: config,
       );
 
-      // Assert
-      expect(result.files.length, 1);
-      expect(result.files.first.relativePath, 'programs/plug-ins/Other.elf');
+      expect(result.files, isEmpty);
+      expect(result.warnings, hasLength(1));
+      expect(result.warnings.first, contains('OTHERPLUGIN'));
+      expect(result.warnings.first, contains('not installed'));
 
-      // Should call database lookup for plugins without direct paths
-      verify(
-        () => mockMetadataDao.getPluginFilePathsByGuids({'OTHERPLUGIN'}),
-      ).called(1);
+      // No file reads — there's nothing to read.
+      verifyNever(() => mockFileSystem.readFile(any()));
     });
 
     test('handles missing plugin file gracefully (returns null)', () async {
       // Arrange
       final deps = PresetDependencies();
       deps.pluginPaths['MISSING'] = 'programs/plug-ins/Missing.elf';
+      deps.communityPlugins.add('MISSING');
 
       when(
         () => mockFileSystem.readFile('programs/plug-ins/Missing.elf'),
@@ -120,6 +95,7 @@ void main() {
       // Arrange
       final deps = PresetDependencies();
       deps.pluginPaths['ERROR'] = 'programs/plug-ins/Error.elf';
+      deps.communityPlugins.add('ERROR');
 
       when(
         () => mockFileSystem.readFile('programs/plug-ins/Error.elf'),
@@ -137,43 +113,35 @@ void main() {
       expect(result.files, isEmpty);
     });
 
-    test('collects from both pluginPaths and communityPlugins', () async {
-      // Arrange
-      final deps = PresetDependencies();
-      deps.pluginPaths['DIRECT_PLUGIN'] = 'programs/plug-ins/Direct.elf';
-      deps.communityPlugins.add('DB_PLUGIN');
+    test(
+      'collects pluginPaths and warns for unmatched communityPlugins',
+      () async {
+        // Mixed scenario: one plugin is referenced AND has a direct path,
+        // another is referenced but not in pluginPaths. The first should
+        // package; the second should produce a "not installed" warning.
+        final deps = PresetDependencies();
+        deps.pluginPaths['DIRECT_PLUGIN'] = 'programs/plug-ins/Direct.elf';
+        deps.communityPlugins.add('DIRECT_PLUGIN');
+        deps.communityPlugins.add('NOT_INSTALLED');
 
-      final directBytes = Uint8List.fromList([1, 2, 3, 4]);
-      final dbBytes = Uint8List.fromList([5, 6, 7, 8]);
+        final directBytes = Uint8List.fromList([1, 2, 3, 4]);
+        when(
+          () => mockFileSystem.readFile('programs/plug-ins/Direct.elf'),
+        ).thenAnswer((_) async => directBytes);
 
-      when(
-        () => mockFileSystem.readFile('programs/plug-ins/Direct.elf'),
-      ).thenAnswer((_) async => directBytes);
+        final config = const PackageConfig(includeCommunityPlugins: true);
 
-      when(
-        () => mockMetadataDao.getPluginFilePathsByGuids({'DB_PLUGIN'}),
-      ).thenAnswer(
-        (_) async => {'DB_PLUGIN': 'programs/plug-ins/DbPlugin.elf'},
-      );
-      when(
-        () => mockFileSystem.readFile('programs/plug-ins/DbPlugin.elf'),
-      ).thenAnswer((_) async => dbBytes);
+        final result = await fileCollector.collectDependencies(
+          deps,
+          config: config,
+        );
 
-      final config = const PackageConfig(includeCommunityPlugins: true);
-
-      // Act
-      final result = await fileCollector.collectDependencies(
-        deps,
-        config: config,
-      );
-
-      // Assert
-      expect(result.files.length, 2);
-
-      final paths = result.files.map((f) => f.relativePath).toSet();
-      expect(paths, contains('programs/plug-ins/Direct.elf'));
-      expect(paths, contains('programs/plug-ins/DbPlugin.elf'));
-    });
+        expect(result.files, hasLength(1));
+        expect(result.files.first.relativePath, 'programs/plug-ins/Direct.elf');
+        expect(result.warnings, hasLength(1));
+        expect(result.warnings.first, contains('NOT_INSTALLED'));
+      },
+    );
 
     test('skips plugin collection when includeCommunityPlugins is false', () async {
       // Arrange
@@ -218,9 +186,70 @@ void main() {
       // Assert - should only collect once
       expect(result.files.length, 1);
       expect(result.files.first.relativePath, 'programs/plug-ins/Same.elf');
+      // No "not installed" warning — the GUID is in pluginPaths so it's
+      // considered resolved.
+      expect(result.warnings, isEmpty);
+    });
 
-      // Should NOT call database lookup since direct path was used
-      verifyNever(() => mockMetadataDao.getPluginFilePathsByGuids(any()));
+    test(
+      'does not package plugins that are in pluginPaths but not referenced '
+      'by the preset',
+      () async {
+        // Regression: `pluginPaths` is the full NT library, not just the
+        // plugins the preset uses. We must only package plugins whose
+        // GUID appears in `communityPlugins`.
+        final deps = PresetDependencies();
+        deps.pluginPaths['USED'] = 'programs/plug-ins/Used.o';
+        deps.pluginPaths['UNUSED_A'] = 'programs/plug-ins/UnusedA.o';
+        deps.pluginPaths['UNUSED_B'] = 'programs/plug-ins/UnusedB.o';
+        deps.communityPlugins.add('USED');
+
+        when(
+          () => mockFileSystem.readFile('programs/plug-ins/Used.o'),
+        ).thenAnswer((_) async => Uint8List.fromList([1, 2, 3]));
+
+        final result = await fileCollector.collectDependencies(
+          deps,
+          config: const PackageConfig(includeCommunityPlugins: true),
+        );
+
+        expect(result.files, hasLength(1));
+        expect(result.files.first.relativePath, 'programs/plug-ins/Used.o');
+        expect(result.warnings, isEmpty);
+
+        // Unused plugins must not be read from the SD card.
+        verifyNever(
+          () => mockFileSystem.readFile('programs/plug-ins/UnusedA.o'),
+        );
+        verifyNever(
+          () => mockFileSystem.readFile('programs/plug-ins/UnusedB.o'),
+        );
+      },
+    );
+
+    test('matches community plugin GUIDs with trailing-space padding', () {
+      // Analyzer preserves trailing spaces on raw GUIDs
+      // (see preset_analyzer.dart), while AlgorithmInfo may return the
+      // trimmed form. The collector must match them regardless of padding.
+      final deps = PresetDependencies();
+      // pluginPaths uses trimmed GUID
+      deps.pluginPaths['MyPl'] = 'programs/plug-ins/MyPlugin.o';
+      // communityPlugins stores the padded form
+      deps.communityPlugins.add('MyPl');
+
+      when(
+        () => mockFileSystem.readFile('programs/plug-ins/MyPlugin.o'),
+      ).thenAnswer((_) async => Uint8List.fromList([1]));
+
+      return fileCollector
+          .collectDependencies(
+            deps,
+            config: const PackageConfig(includeCommunityPlugins: true),
+          )
+          .then((result) {
+        expect(result.files, hasLength(1));
+        expect(result.warnings, isEmpty);
+      });
     });
   });
 

--- a/test/services/preset_analyzer_test.dart
+++ b/test/services/preset_analyzer_test.dart
@@ -141,6 +141,93 @@ void main() {
       // Assert
       expect(result, isEmpty);
     });
+
+    test(
+      'normalizes bare filenames into the correct plugin directory',
+      () {
+        // The firmware returns bare filenames (no directory prefix) for some
+        // plugins. We have to prepend the canonical directory based on the
+        // file extension or readFile() will fail at the SD card root.
+        final algorithmInfos = [
+          AlgorithmInfo(
+            algorithmIndex: 0,
+            guid: 'Th26',
+            name: 'ARP 2600',
+            specifications: const [],
+            isPlugin: true,
+            filename: 'arp2600.o',
+          ),
+          AlgorithmInfo(
+            algorithmIndex: 1,
+            guid: 'LUAX',
+            name: 'Lua plugin',
+            specifications: const [],
+            isPlugin: true,
+            filename: 'my_script.lua',
+          ),
+          AlgorithmInfo(
+            algorithmIndex: 2,
+            guid: 'TPOT',
+            name: 'Three Pot plugin',
+            specifications: const [],
+            isPlugin: true,
+            filename: 'knob_demo.3pot',
+          ),
+        ];
+
+        final result = PresetAnalyzer.extractPluginPaths(algorithmInfos);
+
+        expect(result, {
+          'Th26': 'programs/plug-ins/arp2600.o',
+          'LUAX': 'programs/lua/my_script.lua',
+          'TPOT': 'programs/three_pot/knob_demo.3pot',
+        });
+      },
+    );
+
+    test('prepends plug-ins dir even when filename has a subfolder', () {
+      // Firmware returns filenames relative to the plugin directory, so
+      // `corrupter/corrupter.o` means `/programs/plug-ins/corrupter/corrupter.o`
+      // — the firmware strips the common `programs/plug-ins/` prefix to
+      // save null-terminated string bytes in the SysEx payload.
+      final algorithmInfos = [
+        AlgorithmInfo(
+          algorithmIndex: 0,
+          guid: 'ThCo',
+          name: 'Corrupter',
+          specifications: const [],
+          isPlugin: true,
+          filename: 'corrupter/corrupter.o',
+        ),
+      ];
+
+      final result = PresetAnalyzer.extractPluginPaths(algorithmInfos);
+
+      expect(result, {
+        'ThCo': 'programs/plug-ins/corrupter/corrupter.o',
+      });
+    });
+
+    test('trusts filenames that already start with programs/', () {
+      // If the firmware does return a full SD-rooted path (e.g. on newer
+      // firmware), leave it alone.
+      final algorithmInfos = [
+        AlgorithmInfo(
+          algorithmIndex: 0,
+          guid: 'PLUGIN_C',
+          name: 'Already fully qualified',
+          specifications: const [],
+          isPlugin: true,
+          filename: 'programs/plug-ins/subfolder/PluginC.o',
+        ),
+      ];
+
+      final result = PresetAnalyzer.extractPluginPaths(algorithmInfos);
+
+      expect(result, {
+        'PLUGIN_C': 'programs/plug-ins/subfolder/PluginC.o',
+      });
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -258,6 +345,32 @@ void main() {
       final deps = PresetAnalyzer.analyzeDependencies(preset);
 
       expect(deps.luaScripts, {'my_script.lua'});
+    });
+
+    test('pymu collects top-level folder as multisample folder', () {
+      // `pymu` (current Poly Multisample, firmware >= 1.10) has no
+      // `timbres[]` array — one folder per slot, stored top-level. The
+      // `saveFolder`/`saveFilename` fields are the recording destination
+      // and must NOT be treated as dependencies.
+      final preset = {
+        'slots': [
+          {
+            'guid': 'pymu',
+            'folder': '!CORec_Modular Percussion Stereo',
+            'saveFolder': 'untitled',
+            'saveFilename': 'sample',
+          },
+        ],
+      };
+
+      final deps = PresetAnalyzer.analyzeDependencies(preset);
+
+      expect(
+        deps.multisampleFolders,
+        {'!CORec_Modular Percussion Stereo'},
+      );
+      // saveFolder is a record destination, not a dependency.
+      expect(deps.sampleFolders, isEmpty);
     });
 
     test('granulator slot collects sample when populated', () {

--- a/test/services/preset_export_integration_test.dart
+++ b/test/services/preset_export_integration_test.dart
@@ -15,16 +15,9 @@ import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
-import 'package:nt_helper/db/database.dart';
-import 'package:nt_helper/db/daos/metadata_dao.dart';
 import 'package:nt_helper/interfaces/preset_file_system.dart';
 import 'package:nt_helper/models/package_config.dart';
 import 'package:nt_helper/services/package_creator.dart';
-
-class MockAppDatabase extends Mock implements AppDatabase {}
-
-class MockMetadataDao extends Mock implements MetadataDao {}
 
 /// In-memory fake of [PresetFileSystem] driven by a map of relative path
 /// to bytes. Directory listings are derived from the map's keyspace.
@@ -51,17 +44,6 @@ class _FakeFileSystem implements PresetFileSystem {
 }
 
 void main() {
-  late MockAppDatabase mockDatabase;
-  late MockMetadataDao mockMetadataDao;
-
-  setUp(() {
-    mockDatabase = MockAppDatabase();
-    mockMetadataDao = MockMetadataDao();
-    when(() => mockDatabase.metadataDao).thenReturn(mockMetadataDao);
-    when(() => mockMetadataDao.getPluginFilePathsByGuids(any()))
-        .thenAnswer((_) async => <String, String>{});
-  });
-
   test('SyncLatchDemo round-trip captures lua + samp triggers + pyms folder',
       () async {
     final presetJson = File('test/fixtures/presets/sync_latch_demo.json')
@@ -86,7 +68,7 @@ void main() {
       'multisamples/LABS Soft Pno - PedOn/C2.aif': aif,
     });
 
-    final creator = PackageCreator(fs, mockDatabase);
+    final creator = PackageCreator(fs);
     final result = await creator.createPackage(
       presetFilePath: 'presets/SyncLatchDemo.json',
       config: const PackageConfig(),
@@ -142,7 +124,7 @@ void main() {
       'presets/SyncLatchDemo.json': presetBytes,
     });
 
-    final creator = PackageCreator(fs, mockDatabase);
+    final creator = PackageCreator(fs);
     final result = await creator.createPackage(
       presetFilePath: 'presets/SyncLatchDemo.json',
       config: const PackageConfig(),


### PR DESCRIPTION
## Summary

Eliminates the rename-without-save footgun: changing the preset name now persists the preset immediately by re-using the existing manual save path.

- `lib/cubit/disting_cubit_preset_ops.dart` — after `requestSetPresetName` succeeds, fire `requestSavePreset` on the same manager. On rename failure, fall through to the existing 250ms verification read-back (no save). The unconditional 500ms verification is unchanged.
- `test/cubit/disting_cubit_preset_rename_test.dart` (new) — 7 test cases covering the happy path, the four no-save guards (empty/whitespace/unchanged/not-synced), the rename-failure-skips-save guard, and rapid-rename last-write-wins ordering.

Plan: [`docs/plans/auto-save-on-preset-rename_plan.md`](docs/plans/auto-save-on-preset-rename_plan.md) — includes the 5-agent gap analysis follow-ups (MCP behavior change, semantics announcement, expanded test list).

## Before / after

**Before:** Rename in dialog → preset name updates in UI and on device, but the preset isn't persisted. User must click Save (or Cmd+S) before disconnecting or rebooting, or the rename is lost.

**After:** Rename in dialog → name change is also saved to the device immediately, using the exact same `IDistingMidiManager.requestSavePreset()` call that the keyboard shortcut, popup menu, and MCP `savePreset` already use.

## Acceptance criteria

- [x] Rename to non-empty value persists immediately, no manual save needed.
- [x] Rename to empty / whitespace-only does not save (existing trim-empty guard at `disting_cubit_preset_ops.dart:36`).
- [x] Manual save action (keyboard / menu / MCP) unchanged.
- [x] Auto-save invokes the same code path as manual save (no parallel logic).
- [x] Rapid renames: each fires its own save; the last `requestSetPresetName` wins on the device.
- [x] `flutter analyze` clean.
- [x] All affected tests pass; new test file added.

## Test plan

- [x] `flutter analyze` — clean (no issues).
- [x] `flutter test test/cubit/disting_cubit_preset_rename_test.dart` — 7 / 7 pass.
- [x] `flutter test test/cubit/ test/mcp/tools/disting_tools_preset_ops_test.dart test/mcp/tools/disting_tools_preset_ops_audit_test.dart test/ui/metadata_sync/` — 224 / 224 pass.
- [x] `flutter test test/ui/widgets/routing/routing_editor_widget_test.dart` — pass.
- [ ] Manual smoke test on hardware: rename → verify preset persisted across power cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)