### PR TITLE
chore: release v2.33.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.32.1+244
+version: 2.33.0+245
 
 environment:
   sdk: ">=3.8.1 <4.0.0"


### PR DESCRIPTION
## 🚀 What's New in v2.33.0

### 🐛 Bug Fixes
- fix: firmware-update screen shows accurate disting NT module icon (#123)
- fix: SettingsService.resetToDefaults() covers all persisted settings (#122)
- Auto-save preset on rename (#121)
- Add auto-center on algorithm selection setting (#120)
- fix: avoid double .wav extension on single-file wavetables
- fix: capture full dependency graph in preset export

### 📋 Pull Requests
- fix: firmware-update screen shows accurate disting NT module icon (#123)
- fix: SettingsService.resetToDefaults() covers all persisted settings (#122)
- Auto-save preset on rename (#121)
- Add auto-center on algorithm selection setting (#120)

---
**Full Changelog**: https://github.com/thorinside/nt_helper/compare/v2.32.1...v2.33.0