### PR TITLE
fix: prevent infinite CPU monitor spinner on device disconnect

### DIFF
--- a/lib/cubit/disting_cubit.dart
+++ b/lib/cubit/disting_cubit.dart
@@ -164,7 +164,7 @@ class DistingCubit extends _DistingCubitBase
   }
 
   /// Stream of CPU usage updates that polls every 10 seconds when listeners are active
-  Stream<CpuUsage> get cpuUsageStream => _monitoringDelegate.cpuUsageStream;
+  Stream<CpuUsage?> get cpuUsageStream => _monitoringDelegate.cpuUsageStream;
 
   /// Stream of video state updates from the cubit's state
   Stream<VideoStreamState?> get videoStreamState => stream.map(

--- a/lib/cubit/disting_cubit_monitoring_delegate.dart
+++ b/lib/cubit/disting_cubit_monitoring_delegate.dart
@@ -2,7 +2,7 @@ part of 'disting_cubit.dart';
 
 class _MonitoringDelegate {
   _MonitoringDelegate(this._cubit) {
-    _cpuUsageController = StreamController<CpuUsage>.broadcast(
+    _cpuUsageController = StreamController<CpuUsage?>.broadcast(
       onListen: _startCpuUsagePolling,
       onCancel: _checkStopCpuUsagePolling,
     );
@@ -11,7 +11,7 @@ class _MonitoringDelegate {
   final DistingCubit _cubit;
 
   // CPU Usage Streaming
-  late final StreamController<CpuUsage> _cpuUsageController;
+  late final StreamController<CpuUsage?> _cpuUsageController;
   Timer? _cpuUsageTimer;
   static const Duration _cpuUsagePollingInterval = Duration(seconds: 10);
 
@@ -19,7 +19,7 @@ class _MonitoringDelegate {
   UsbVideoManager? _videoManager;
   StreamSubscription<VideoStreamState>? _videoStateSubscription;
 
-  Stream<CpuUsage> get cpuUsageStream => _cpuUsageController.stream;
+  Stream<CpuUsage?> get cpuUsageStream => _cpuUsageController.stream;
   VideoStreamState? get currentVideoState => _videoManager?.currentState;
   UsbVideoManager? get videoManager => _videoManager;
 
@@ -117,12 +117,14 @@ class _MonitoringDelegate {
   Future<void> _pollCpuUsageOnce() async {
     try {
       final cpuUsage = await getCpuUsage();
-      if (cpuUsage != null && !_cpuUsageController.isClosed) {
+      if (!_cpuUsageController.isClosed) {
         _cpuUsageController.add(cpuUsage);
       }
     } catch (e, stackTrace) {
       debugPrintStack(stackTrace: stackTrace);
-      // Don't add error to stream, just log it
+      if (!_cpuUsageController.isClosed) {
+        _cpuUsageController.add(null);
+      }
     }
   }
 

--- a/lib/ui/cpu_monitor_widget.dart
+++ b/lib/ui/cpu_monitor_widget.dart
@@ -72,7 +72,7 @@ class _CpuMonitorWidgetState extends State<CpuMonitorWidget> {
             // Resume monitoring when visible
             _updateVisibility(true);
 
-            return StreamBuilder<CpuUsage>(
+            return StreamBuilder<CpuUsage?>(
               stream: _distingCubit.cpuUsageStream,
               builder: (context, snapshot) {
                 if (!snapshot.hasData) {
@@ -86,12 +86,12 @@ class _CpuMonitorWidgetState extends State<CpuMonitorWidget> {
                   );
                 }
 
-                final cpuUsage = snapshot.data!;
+                final cpuUsage = snapshot.data;
                 return _buildCpuDisplay(
                   context: context,
-                  cpu1: cpuUsage.cpu1,
-                  cpu2: cpuUsage.cpu2,
-                  slotUsages: cpuUsage.slotUsages,
+                  cpu1: cpuUsage?.cpu1,
+                  cpu2: cpuUsage?.cpu2,
+                  slotUsages: cpuUsage?.slotUsages ?? [],
                   isLoading: false,
                 );
               },


### PR DESCRIPTION
This PR fixes a bug where the CPU monitor spinner would spin indefinitely if the device was disconnected or if the CPU usage request failed. 

It modifies the  to emit  values on failure instead of remaining silent, and updates the  to stop the loading spinner once any value (including ) is received from the stream.