### PR TITLE
fix: distinct styling for backwards routing connections

### DIFF
--- a/lib/ui/widgets/routing/connection_painter.dart
+++ b/lib/ui/widgets/routing/connection_painter.dart
@@ -229,7 +229,7 @@ class ConnectionPainter extends CustomPainter {
         _drawDashedPath(canvas, path, paint);
 
       } else if (type == ConnectionVisualType.invalid) {
-        _drawDashedPath(canvas, path, paint);
+        _drawDottedPath(canvas, path, paint);
       } else if (type == ConnectionVisualType.partial) {
         _drawDashedPath(canvas, path, paint);
 
@@ -507,6 +507,27 @@ class ConnectionPainter extends CustomPainter {
       // Orange to white (0.5 - 1.0)
       final t = (dp - 0.5) / 0.5;
       return Color.lerp(Colors.orange, Colors.white, t)!;
+    }
+  }
+
+  /// Draw a stroked path as a sequence of round dots, used for backward-edge
+  /// (uphill) connections. Visually distinct from the dashed pattern used for
+  /// ghost/partial connections because each dot is a small filled circle, so
+  /// the pattern reads as "warning" rather than "broken".
+  void _drawDottedPath(Canvas canvas, Path path, Paint paint) {
+    final dotPaint = Paint()
+      ..style = PaintingStyle.fill
+      ..color = paint.color;
+    final dotRadius = paint.strokeWidth / 2;
+    const dotSpacing = 6.0;
+
+    for (final metric in path.computeMetrics()) {
+      for (double d = 0.0; d <= metric.length; d += dotSpacing) {
+        final tangent = metric.getTangentForOffset(d);
+        if (tangent != null) {
+          canvas.drawCircle(tangent.position, dotRadius, dotPaint);
+        }
+      }
     }
   }
 

--- a/lib/ui/widgets/routing/connection_painter.dart
+++ b/lib/ui/widgets/routing/connection_painter.dart
@@ -112,6 +112,22 @@ class ConnectionPainter extends CustomPainter {
     this.hasExtendedAuxBuses = false,
   });
 
+  /// Classify a connection into the visual style bucket used for batching.
+  ///
+  /// Precedence (highest first): selected, partial, invalid (backward edge),
+  /// ghost, regular. Selection is a transient user-driven highlight and wins
+  /// over backward-edge styling. A backward edge that is also partial renders
+  /// as partial, because an incomplete connection is the more important
+  /// signal than a deferred-bus warning.
+  @visibleForTesting
+  static ConnectionVisualType classifyVisualType(ConnectionData conn) {
+    if (conn.isSelected) return ConnectionVisualType.selected;
+    if (conn.isPartial) return ConnectionVisualType.partial;
+    if (conn.isInvalidOrder) return ConnectionVisualType.invalid;
+    if (conn.isGhostConnection) return ConnectionVisualType.ghost;
+    return ConnectionVisualType.regular;
+  }
+
   @override
   void paint(Canvas canvas, Size size) {
     if (connections.isEmpty) return;
@@ -126,16 +142,22 @@ class ConnectionPainter extends CustomPainter {
     final selectedConnections = <ConnectionData>[];
     final partialConnections = <ConnectionData>[];
     for (final conn in connections) {
-      if (conn.isSelected) {
-        selectedConnections.add(conn);
-      } else if (conn.isPartial) {
-        partialConnections.add(conn);
-      } else if (conn.isInvalidOrder) {
-        invalidConnections.add(conn);
-      } else if (conn.isGhostConnection) {
-        ghostConnections.add(conn);
-      } else {
-        regularConnections.add(conn);
+      switch (classifyVisualType(conn)) {
+        case ConnectionVisualType.selected:
+          selectedConnections.add(conn);
+          break;
+        case ConnectionVisualType.partial:
+          partialConnections.add(conn);
+          break;
+        case ConnectionVisualType.invalid:
+          invalidConnections.add(conn);
+          break;
+        case ConnectionVisualType.ghost:
+          ghostConnections.add(conn);
+          break;
+        case ConnectionVisualType.regular:
+          regularConnections.add(conn);
+          break;
       }
     }
 

--- a/lib/ui/widgets/routing/connection_painter.dart
+++ b/lib/ui/widgets/routing/connection_painter.dart
@@ -10,6 +10,11 @@ import 'ghost_connection_tooltip.dart';
 import 'connection_theme.dart';
 import 'bus_label_formatter.dart';
 
+/// Bright orange used to flag backward-edge ("uphill") connections.
+/// Theme-independent so the warning meaning is uniform in light and dark mode.
+@visibleForTesting
+const Color kBackwardEdgeColor = Color(0xFFFF8800);
+
 /// Represents connection data with bus and output mode information
 class ConnectionData {
   final Connection connection;

--- a/lib/ui/widgets/routing/connection_painter.dart
+++ b/lib/ui/widgets/routing/connection_painter.dart
@@ -267,8 +267,11 @@ class ConnectionPainter extends CustomPainter {
         }
       }
 
-      // Draw endpoints (skip for partial connections)
-      if (type != ConnectionVisualType.partial) {
+      // Draw endpoints (skip for partial and invalid connections; the latter
+      // because port-color circles over an orange dot read as a
+      // "double-ended broken connection").
+      if (type != ConnectionVisualType.partial &&
+          type != ConnectionVisualType.invalid) {
         _drawEndpoints(canvas, conn);
       }
     }

--- a/lib/ui/widgets/routing/connection_painter.dart
+++ b/lib/ui/widgets/routing/connection_painter.dart
@@ -401,11 +401,14 @@ class ConnectionPainter extends CustomPainter {
     ConnectionData conn,
     ConnectionVisualType type,
   ) {
-    // Handle backward connections (wrong slot order) with tertiary color
+    // Handle backward edges (source slot index higher than destination)
+    // with a theme-independent bright orange so the warning reads the same
+    // in light and dark mode and is visually distinct from the muted-grey
+    // dashed style used for partial/disconnected connections.
     if (type == ConnectionVisualType.invalid) {
       paint
         ..strokeWidth = 2.0
-        ..color = theme.colorScheme.tertiary;
+        ..color = kBackwardEdgeColor;
       return;
     }
 
@@ -983,6 +986,15 @@ class ConnectionPainter extends CustomPainter {
       return colors.clockPortColor;
     }
     return theme.colorScheme.outline;
+  }
+
+  /// Resolve the stroke color a given connection would receive when painted.
+  /// Exposes the result of `_applyConnectionStyle()` for unit tests.
+  @visibleForTesting
+  Color debugResolveStyleColor(ConnectionData conn) {
+    final paint = Paint();
+    _applyConnectionStyle(paint, conn, classifyVisualType(conn));
+    return paint.color;
   }
 
   /// Get current label bounds for testing purposes

--- a/specs/2026-05-04_backwards-connection-styling.md
+++ b/specs/2026-05-04_backwards-connection-styling.md
@@ -1,0 +1,301 @@
+# Backwards-connection styling: orange dotted lines
+
+## Context
+
+The Disting NT routing model is strictly forward — a slot can only read from
+buses written by lower-indexed slots earlier in the same processing pass.
+A connection whose source algorithm sits in a *higher* slot than its
+destination is a "backward edge" and only carries signal one block later
+(via a routing/aux/feedback bus). These are valid connections that the user
+sometimes wants on purpose, but they need to be visually flagged.
+
+Today the routing-diagram renderer paints two visually similar things in
+nearly identical styles:
+
+1. **Backward-edge connections** (`Connection.isBackwardEdge == true`,
+   exposed in the painter as `ConnectionData.isInvalidOrder`) — rendered
+   via `ConnectionVisualType.invalid` with `theme.colorScheme.tertiary`
+   color and an 8/4 dashed stroke (see `ConnectionPainter._applyConnectionStyle`
+   line ~378 and `_drawConnectionBatch` line ~204), with port-coloured
+   endpoint circles (line ~244, ~643).
+2. **Partial / disconnected connections** (`Connection.isPartial == true`) —
+   rendered via `ConnectionVisualType.partial` with
+   `theme.colorScheme.onSurface.withValues(alpha: 0.6)` and the same 8/4
+   dashed stroke, but with no endpoint circles.
+
+Both produce dashed muted-grey lines, and users have reported they read
+as "the same thing" — namely, *broken*. The intent for backward edges is
+the opposite: they are working connections that simply require a feedback
+bus, and the visualization should flag them with a distinctive **orange
+dotted** style that survives in both light and dark themes.
+
+The bug is not that the painter "short-circuits" past the backward-edge
+branch — the `invalid` branch is reached. The bug is that the *style
+chosen for that branch* is not visually distinct enough from the `partial`
+branch. Fixing the styling in the existing `invalid` branch (and removing
+endpoint dots) is enough to satisfy the requirement.
+
+## Files to Change
+
+### `lib/ui/widgets/routing/connection_painter.dart`
+
+#### 1. Add a colour constant (top of file, near imports)
+
+```dart
+/// Bright orange used to flag backward-edge ("uphill") connections.
+/// Theme-independent so the warning meaning is uniform in light and dark mode.
+@visibleForTesting
+const Color kBackwardEdgeColor = Color(0xFFFF8800);
+```
+
+#### 2. `_applyConnectionStyle()` — invalid branch (~line 378)
+
+Replace:
+
+```dart
+if (type == ConnectionVisualType.invalid) {
+  paint
+    ..strokeWidth = 2.0
+    ..color = theme.colorScheme.tertiary;
+  return;
+}
+```
+
+with:
+
+```dart
+if (type == ConnectionVisualType.invalid) {
+  paint
+    ..strokeWidth = 2.0
+    ..color = kBackwardEdgeColor;
+  return;
+}
+```
+
+#### 3. New `_drawDottedPath()` method
+
+Add a method that draws a stroked path as a sequence of round dots:
+
+```dart
+void _drawDottedPath(Canvas canvas, Path path, Paint paint) {
+  final dotPaint = Paint()
+    ..style = PaintingStyle.fill
+    ..color = paint.color;
+  final dotRadius = paint.strokeWidth / 2;
+  // Dot centre-to-centre spacing chosen so individual dots remain
+  // visually separate (≥2× radius gap) at strokeWidth 2.0 — gives a
+  // clear "dotted" reading vs. the 8/4 dash used for ghost/partial.
+  const dotSpacing = 6.0;
+
+  for (final metric in path.computeMetrics()) {
+    for (double d = 0.0; d <= metric.length; d += dotSpacing) {
+      final tangent = metric.getTangentForOffset(d);
+      if (tangent != null) {
+        canvas.drawCircle(tangent.position, dotRadius, dotPaint);
+      }
+    }
+  }
+}
+```
+
+Color is read from the mutated `paint` set up by `_applyConnectionStyle()`,
+so the dots inherit `kBackwardEdgeColor` automatically. The method handles
+multi-contour paths from `_createRoutedPath`'s anti-overlap offsets the
+same way `_drawDashedPath` does.
+
+#### 4. `_drawConnectionBatch()` — invalid branch (~line 204)
+
+Replace `_drawDashedPath(canvas, path, paint);` for the invalid type with
+`_drawDottedPath(canvas, path, paint);`. The ghost and partial branches
+continue to use `_drawDashedPath`.
+
+#### 5. `_drawConnectionBatch()` — endpoint skip (~line 244)
+
+Change:
+
+```dart
+if (type != ConnectionVisualType.partial) {
+  _drawEndpoints(canvas, conn);
+}
+```
+
+to:
+
+```dart
+if (type != ConnectionVisualType.partial &&
+    type != ConnectionVisualType.invalid) {
+  _drawEndpoints(canvas, conn);
+}
+```
+
+The endpoint circles in port-type colors on a backward edge visually
+conflict with the warning-orange line and read as a "double-ended broken
+connection". Omitting them lets the dotted line itself be the only
+endpoint signal.
+
+#### 6. Extract a `@visibleForTesting` classifier
+
+To support the test plan without exposing private state, hoist the
+batch-selection logic out of `paint()` (line ~123) into a static method:
+
+```dart
+@visibleForTesting
+static ConnectionVisualType classifyVisualType(ConnectionData conn) {
+  if (conn.isSelected) return ConnectionVisualType.selected;
+  if (conn.isPartial) return ConnectionVisualType.partial;
+  if (conn.isInvalidOrder) return ConnectionVisualType.invalid;
+  if (conn.isGhostConnection) return ConnectionVisualType.ghost;
+  return ConnectionVisualType.regular;
+}
+```
+
+Then use it in the `paint()` batching loop:
+
+```dart
+for (final conn in connections) {
+  switch (classifyVisualType(conn)) {
+    case ConnectionVisualType.selected:  selectedConnections.add(conn); break;
+    case ConnectionVisualType.partial:   partialConnections.add(conn);  break;
+    case ConnectionVisualType.invalid:   invalidConnections.add(conn);  break;
+    case ConnectionVisualType.ghost:     ghostConnections.add(conn);    break;
+    case ConnectionVisualType.regular:   regularConnections.add(conn);  break;
+  }
+}
+```
+
+This both deduplicates the precedence rules and makes them testable.
+
+## Behavior Matrix
+
+| Connection state                          | Stroke style    | Color                                      | Endpoints |
+|-------------------------------------------|-----------------|--------------------------------------------|-----------|
+| Forward (full, neither selected nor dimmed) | Solid          | Port-type (audio blue / CV orange) blended | Drawn     |
+| Backward edge (`isBackwardEdge==true`)      | **Dotted (round)** | **`kBackwardEdgeColor` `#FF8800`**     | **None**  |
+| Partial / disconnected (`isPartial`)        | Dashed (8/4)    | `onSurface @ 0.6`                          | None      |
+| Ghost (`isGhostConnection`)                 | Dashed (8/4)    | `secondaryConnection`                      | Drawn     |
+| Selected                                    | Solid           | `selectionIndicator`                       | Drawn     |
+
+### State precedence (intentional, unchanged)
+
+The classification order in `classifyVisualType()` defines what wins when
+a connection has multiple flags. Confirmed cases:
+
+- `selected` beats backward → a selected backward edge renders in the
+  selection style, not orange dotted. This is the correct UX (selection
+  is a transient user-driven highlight).
+- `partial` beats backward → a backward edge that *also* has an
+  unconnected endpoint renders as the partial dashed style. This is
+  acceptable: the connection is genuinely incomplete and the partial
+  style is the more important signal.
+- `isHighlighted` (hover) and `isDimmed` (focus mode) and the delete
+  animation (`deletingPortId` matches a port) are all branches that run
+  *after* the type is classified, inside `_applyConnectionStyle()`. They
+  intentionally override the orange-dotted styling (`return` early) so
+  hover, dimming, and delete animations are uniform across all
+  connection types. No change.
+
+The "normal forward connections continue to render as solid green" line
+in the bug report describes the *intent* of the existing forward style.
+The current implementation already paints forward edges as solid lines in
+port-type color (audio blue, CV orange) blended with the theme's
+`directConnection.color` (green-ish in the default light theme). No
+change to the forward path is in scope.
+
+## Test Plan
+
+Add `test/ui/widgets/routing/backward_connection_style_test.dart`
+(or extend `connection_painter_test.dart`) with three tests:
+
+```dart
+test('classifies backward edge as invalid', () {
+  final conn = _connData(isBackwardEdge: true);
+  expect(ConnectionPainter.classifyVisualType(conn),
+         ConnectionVisualType.invalid);
+});
+
+test('classifies partial connection as partial (not invalid) even if backward', () {
+  final conn = _connData(isBackwardEdge: true, isPartial: true);
+  expect(ConnectionPainter.classifyVisualType(conn),
+         ConnectionVisualType.partial);
+});
+
+test('classifies selected backward edge as selected', () {
+  final conn = _connData(isBackwardEdge: true, isSelected: true);
+  expect(ConnectionPainter.classifyVisualType(conn),
+         ConnectionVisualType.selected);
+});
+
+testWidgets('backward edge renders dots in kBackwardEdgeColor', (tester) async {
+  final painter = ConnectionPainter(
+    connections: [_connData(isBackwardEdge: true)],
+    theme: ThemeData.light(),
+    showLabels: false,
+  );
+  final recorder = PictureRecorder();
+  final canvas = Canvas(recorder);
+  painter.paint(canvas, const Size(400, 300));
+  // Convert to image and sample a pixel along the bezier path; assert
+  // it matches kBackwardEdgeColor (or transparent — between dots).
+  // No labelBounds entry should exist for the connection (showLabels:false
+  // and invalid type also doesn't draw labels).
+  expect(painter.getLabelBounds(), isEmpty);
+});
+```
+
+The classification tests give certainty about the precedence rules and
+verify the bug-fix branch is reached. The widget-test pixel sampling
+confirms the orange colour and "no endpoints" expectation. A helper
+`_connData({...})` constructs a `Connection` and wraps it in
+`ConnectionData` with reasonable defaults.
+
+If pixel sampling is awkward in CI, the spec accepts replacing the last
+test with an assertion on `kBackwardEdgeColor` directly (proving the
+constant value the code under test will use) plus the classification
+assertion (proving the constant *will* be applied for backward edges).
+
+## Out of Scope
+
+- **Slot Y-position locking on drag.** A separate concern about preventing
+  the user from dragging an algorithm node above/below a neighbouring
+  slot index. Not addressed here.
+- **Forward-edge color changes.** The bug report mentions "solid green"
+  for forward, but the existing accessible-color theme already governs
+  forward color. Not changed.
+- **Bus-number label rendering on backward edges.** Today only
+  `regularConnections` get the white-rounded-rectangle bus label
+  (`_drawConnectionLabel`, called from `paint()` line ~164). Backward
+  edges have never shown that label, and that gap is unrelated to the
+  styling-confusion bug. If labels are desired on backward edges later,
+  it is a separate change.
+- **Renaming `ConnectionVisualType.invalid` → `backwardEdge`.** The name
+  is a misnomer (a backward edge is *valid*, just deferred), but renaming
+  the enum touches every batch site, every theme reference, and the
+  `ConnectionVisualTheme.errorConnection` field. Out of scope for this
+  fix; tracked as a follow-up.
+- **`AccessibilityColors` integration of the orange.** `kBackwardEdgeColor`
+  is intentionally theme-independent so the warning meaning is uniform.
+  If a future high-contrast mode needs a different orange, gate it on
+  `AccessibilityColors.isHighContrast` then — not in this change.
+- **Anti-overlap dot density.** A dotted path on a `_createRoutedPath`
+  offset bezier may have very slight dot spacing variation at high
+  curvature. Acceptable cosmetic trade-off; addressed only if a
+  reviewer flags it.
+- **`drawEndpointsOnly` mode.** This mode (used in mini-map / endpoint
+  overlays) clips a normal path to the source/destination node bounds.
+  Backward edges in that mode will draw clipped *dotted* segments, which
+  is acceptable. The dotted-path method is invoked via the same
+  `_drawConnectionBatch` flow regardless of `drawEndpointsOnly`.
+
+## Acceptance
+
+- A backward-edge connection in the routing diagram is visibly distinct
+  from a partial/disconnected connection: round orange dots vs. grey
+  dashes.
+- Forward, selected, ghost, partial, hover, dimmed, and delete-animation
+  styling are unchanged.
+- A backward edge that is *also* selected renders selected; that is also
+  partial renders partial. Documented and tested.
+- Unit test asserts `classifyVisualType` returns `invalid` for a backward
+  edge and that `kBackwardEdgeColor == #FF8800`.
+- `flutter analyze` passes with zero warnings.
+- `flutter test test/ui/widgets/routing/` passes.

--- a/test/ui/widgets/routing/backward_connection_style_test.dart
+++ b/test/ui/widgets/routing/backward_connection_style_test.dart
@@ -113,13 +113,20 @@ void main() {
       const yScan = 50.0;
 
       bool _isOrangeIsh(int r, int g, int b, int a) {
-        // Tolerance band for kBackwardEdgeColor (#FF8800) accounting for
-        // anti-aliased edges of round dots / dashed segments.
-        return a >= 0x80 &&
-            r >= 0xC0 &&
-            g >= 0x40 &&
-            g <= 0xB0 &&
-            b <= 0x40;
+        // Tolerance band for kBackwardEdgeColor (#FF8800), accounting for
+        // anti-aliased / partially-covered pixels at the edges of round dots
+        // and dashed segments. Output buffer is premultiplied, so partial-
+        // coverage pixels show R≈191/G≈102/A≈191 instead of full intensity;
+        // we therefore unpremultiply against alpha to recover the source
+        // color and assert that against #FF8800 with a generous tolerance.
+        if (a < 0x40) return false;
+        final rNorm = (r * 255) ~/ a;
+        final gNorm = (g * 255) ~/ a;
+        final bNorm = (b * 255) ~/ a;
+        return rNorm >= 0xE0 &&
+            gNorm >= 0x60 &&
+            gNorm <= 0xA8 &&
+            bNorm <= 0x20;
       }
 
       Future<int> maxOrangeRunOnScanlineFor(
@@ -194,6 +201,93 @@ void main() {
               'not 8 px dashes',
         );
       });
+
+      Future<Uint8List> renderToBytes(
+        ConnectionData conn,
+        WidgetTester tester,
+      ) async {
+        late ByteData byteData;
+        await tester.runAsync(() async {
+          final painter = ConnectionPainter(
+            connections: [conn],
+            theme: ThemeData.light(),
+            showLabels: false,
+            enableAntiOverlap: false,
+          );
+          final recorder = dart_ui.PictureRecorder();
+          final canvas = Canvas(recorder);
+          painter.paint(canvas, const Size(w * 1.0, h * 1.0));
+          final picture = recorder.endRecording();
+          final image = await picture.toImage(w, h);
+          byteData =
+              (await image.toByteData(format: dart_ui.ImageByteFormat.rawRgba))!;
+        });
+        return byteData.buffer.asUint8List();
+      }
+
+      bool _hasOpaqueNonOrange(
+        Uint8List bytes,
+        Offset position, {
+        int radius = 3,
+      }) {
+        final px = position.dx.toInt();
+        final py = position.dy.toInt();
+        for (int dy = -radius; dy <= radius; dy++) {
+          for (int dx = -radius; dx <= radius; dx++) {
+            final x = px + dx;
+            final y = py + dy;
+            if (x < 0 || x >= w || y < 0 || y >= h) continue;
+            final i = (y * w + x) * 4;
+            final r = bytes[i];
+            final g = bytes[i + 1];
+            final b = bytes[i + 2];
+            final a = bytes[i + 3];
+            // Pixel is opaque enough that we'd notice it as a drawn shape.
+            if (a < 0x80) continue;
+            if (_isOrangeIsh(r, g, b, a)) continue;
+            return true;
+          }
+        }
+        return false;
+      }
+
+      testWidgets(
+        'backward edge does not draw port-color endpoint circles',
+        (tester) async {
+          // Use a port id that maps to the audio accessible port color
+          // (a blue, non-orange color); a 3px-radius endpoint circle in
+          // that color would be the only thing visible at the source/dest
+          // endpoint area when endpoints are drawn.
+          final conn = ConnectionData(
+            connection: Connection(
+              id: 'be_audio',
+              sourcePortId: 'algA_audio_out_1',
+              destinationPortId: 'algB_audio_in_1',
+              connectionType: ConnectionType.algorithmToAlgorithm,
+              isBackwardEdge: true,
+            ),
+            sourcePosition: const Offset(20, yScan),
+            destinationPosition: const Offset(180, yScan),
+          );
+
+          final bytes = await renderToBytes(conn, tester);
+          expect(
+            _hasOpaqueNonOrange(bytes, const Offset(20, yScan)),
+            isFalse,
+            reason:
+                'an opaque non-orange pixel near the source endpoint means '
+                'the port-color endpoint circle was drawn — backward edges '
+                'must not draw endpoint circles',
+          );
+          expect(
+            _hasOpaqueNonOrange(bytes, const Offset(180, yScan)),
+            isFalse,
+            reason:
+                'an opaque non-orange pixel near the destination endpoint '
+                'means the port-color endpoint circle was drawn',
+          );
+        },
+      );
     });
   });
 }

--- a/test/ui/widgets/routing/backward_connection_style_test.dart
+++ b/test/ui/widgets/routing/backward_connection_style_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/core/routing/models/connection.dart';
+import 'package:nt_helper/ui/widgets/routing/connection_painter.dart';
+
+ConnectionData _connData({
+  String id = 'c',
+  bool isBackwardEdge = false,
+  bool isPartial = false,
+  bool isGhost = false,
+  bool isSelected = false,
+  ConnectionType connectionType = ConnectionType.algorithmToAlgorithm,
+}) {
+  return ConnectionData(
+    connection: Connection(
+      id: id,
+      sourcePortId: 'src',
+      destinationPortId: 'dst',
+      connectionType: connectionType,
+      isBackwardEdge: isBackwardEdge,
+      isPartial: isPartial,
+      isGhostConnection: isGhost,
+    ),
+    sourcePosition: const Offset(0, 0),
+    destinationPosition: const Offset(100, 0),
+    isSelected: isSelected,
+  );
+}
+
+void main() {
+  group('Backward connection styling', () {
+    test('kBackwardEdgeColor is the agreed bright orange (#FF8800)', () {
+      expect(kBackwardEdgeColor, const Color(0xFFFF8800));
+    });
+  });
+}

--- a/test/ui/widgets/routing/backward_connection_style_test.dart
+++ b/test/ui/widgets/routing/backward_connection_style_test.dart
@@ -32,5 +32,48 @@ void main() {
     test('kBackwardEdgeColor is the agreed bright orange (#FF8800)', () {
       expect(kBackwardEdgeColor, const Color(0xFFFF8800));
     });
+
+    group('classifyVisualType precedence', () {
+      test('backward edge classifies as invalid', () {
+        expect(
+          ConnectionPainter.classifyVisualType(
+            _connData(isBackwardEdge: true),
+          ),
+          ConnectionVisualType.invalid,
+        );
+      });
+
+      test('partial backward edge classifies as partial (not invalid)', () {
+        expect(
+          ConnectionPainter.classifyVisualType(
+            _connData(isBackwardEdge: true, isPartial: true),
+          ),
+          ConnectionVisualType.partial,
+        );
+      });
+
+      test('selected backward edge classifies as selected', () {
+        expect(
+          ConnectionPainter.classifyVisualType(
+            _connData(isBackwardEdge: true, isSelected: true),
+          ),
+          ConnectionVisualType.selected,
+        );
+      });
+
+      test('ghost connection classifies as ghost', () {
+        expect(
+          ConnectionPainter.classifyVisualType(_connData(isGhost: true)),
+          ConnectionVisualType.ghost,
+        );
+      });
+
+      test('plain connection classifies as regular', () {
+        expect(
+          ConnectionPainter.classifyVisualType(_connData()),
+          ConnectionVisualType.regular,
+        );
+      });
+    });
   });
 }

--- a/test/ui/widgets/routing/backward_connection_style_test.dart
+++ b/test/ui/widgets/routing/backward_connection_style_test.dart
@@ -1,3 +1,6 @@
+import 'dart:typed_data';
+import 'dart:ui' as dart_ui;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nt_helper/core/routing/models/connection.dart';
@@ -100,6 +103,95 @@ void main() {
         expect(
           painter.debugResolveStyleColor(conn).toARGB32(),
           kBackwardEdgeColor.toARGB32(),
+        );
+      });
+    });
+
+    group('stroke pattern', () {
+      const w = 200;
+      const h = 100;
+      const yScan = 50.0;
+
+      bool _isOrangeIsh(int r, int g, int b, int a) {
+        // Tolerance band for kBackwardEdgeColor (#FF8800) accounting for
+        // anti-aliased edges of round dots / dashed segments.
+        return a >= 0x80 &&
+            r >= 0xC0 &&
+            g >= 0x40 &&
+            g <= 0xB0 &&
+            b <= 0x40;
+      }
+
+      Future<int> maxOrangeRunOnScanlineFor(
+        ConnectionData conn,
+        WidgetTester tester,
+      ) async {
+        late ByteData byteData;
+        await tester.runAsync(() async {
+          final painter = ConnectionPainter(
+            connections: [conn],
+            theme: ThemeData.light(),
+            showLabels: false,
+            enableAntiOverlap: false,
+          );
+          final recorder = dart_ui.PictureRecorder();
+          final canvas = Canvas(recorder);
+          painter.paint(canvas, const Size(w * 1.0, h * 1.0));
+          final picture = recorder.endRecording();
+          final image = await picture.toImage(w, h);
+          byteData =
+              (await image.toByteData(format: dart_ui.ImageByteFormat.rawRgba))!;
+        });
+
+        final bytes = byteData.buffer.asUint8List();
+        int maxRun = 0;
+        // Sample a small vertical band around y=50 so a slight bezier dip
+        // (or anti-aliasing crossing) doesn't make us miss the path.
+        for (int y = yScan.toInt() - 3; y <= yScan.toInt() + 3; y++) {
+          int currentRun = 0;
+          for (int x = 0; x < w; x++) {
+            final i = (y * w + x) * 4;
+            if (_isOrangeIsh(
+                bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3])) {
+              currentRun++;
+              if (currentRun > maxRun) maxRun = currentRun;
+            } else {
+              currentRun = 0;
+            }
+          }
+        }
+        return maxRun;
+      }
+
+      ConnectionData horizontalBackwardEdge() => ConnectionData(
+            connection: Connection(
+              id: 'be_h',
+              sourcePortId: 'src',
+              destinationPortId: 'dst',
+              connectionType: ConnectionType.algorithmToAlgorithm,
+              isBackwardEdge: true,
+            ),
+            sourcePosition: const Offset(20, yScan),
+            destinationPosition: const Offset(180, yScan),
+          );
+
+      testWidgets(
+          'backward edge renders as round dots (max horizontal run ≤ 4 px)',
+          (tester) async {
+        final conn = horizontalBackwardEdge();
+        final maxRun = await maxOrangeRunOnScanlineFor(conn, tester);
+        expect(
+          maxRun,
+          greaterThan(0),
+          reason:
+              'expected to find orange pixels on the rendered backward edge',
+        );
+        expect(
+          maxRun,
+          lessThanOrEqualTo(4),
+          reason:
+              'a dotted stroke should yield short orange runs (~2-3 px), '
+              'not 8 px dashes',
         );
       });
     });

--- a/test/ui/widgets/routing/backward_connection_style_test.dart
+++ b/test/ui/widgets/routing/backward_connection_style_test.dart
@@ -112,7 +112,7 @@ void main() {
       const h = 100;
       const yScan = 50.0;
 
-      bool _isOrangeIsh(int r, int g, int b, int a) {
+      bool isOrangeIsh(int r, int g, int b, int a) {
         // Tolerance band for kBackwardEdgeColor (#FF8800), accounting for
         // anti-aliased / partially-covered pixels at the edges of round dots
         // and dashed segments. Output buffer is premultiplied, so partial-
@@ -158,7 +158,7 @@ void main() {
           int currentRun = 0;
           for (int x = 0; x < w; x++) {
             final i = (y * w + x) * 4;
-            if (_isOrangeIsh(
+            if (isOrangeIsh(
                 bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3])) {
               currentRun++;
               if (currentRun > maxRun) maxRun = currentRun;
@@ -225,7 +225,7 @@ void main() {
         return byteData.buffer.asUint8List();
       }
 
-      bool _hasOpaqueNonOrange(
+      bool hasOpaqueNonOrange(
         Uint8List bytes,
         Offset position, {
         int radius = 3,
@@ -244,7 +244,7 @@ void main() {
             final a = bytes[i + 3];
             // Pixel is opaque enough that we'd notice it as a drawn shape.
             if (a < 0x80) continue;
-            if (_isOrangeIsh(r, g, b, a)) continue;
+            if (isOrangeIsh(r, g, b, a)) continue;
             return true;
           }
         }
@@ -272,7 +272,7 @@ void main() {
 
           final bytes = await renderToBytes(conn, tester);
           expect(
-            _hasOpaqueNonOrange(bytes, const Offset(20, yScan)),
+            hasOpaqueNonOrange(bytes, const Offset(20, yScan)),
             isFalse,
             reason:
                 'an opaque non-orange pixel near the source endpoint means '
@@ -280,7 +280,7 @@ void main() {
                 'must not draw endpoint circles',
           );
           expect(
-            _hasOpaqueNonOrange(bytes, const Offset(180, yScan)),
+            hasOpaqueNonOrange(bytes, const Offset(180, yScan)),
             isFalse,
             reason:
                 'an opaque non-orange pixel near the destination endpoint '

--- a/test/ui/widgets/routing/backward_connection_style_test.dart
+++ b/test/ui/widgets/routing/backward_connection_style_test.dart
@@ -75,5 +75,33 @@ void main() {
         );
       });
     });
+
+    group('resolved style color', () {
+      ConnectionPainter painterFor(ConnectionData conn, {ThemeData? theme}) {
+        return ConnectionPainter(
+          connections: [conn],
+          theme: theme ?? ThemeData.light(),
+          showLabels: false,
+        );
+      }
+
+      test('backward edge uses kBackwardEdgeColor in light theme', () {
+        final conn = _connData(isBackwardEdge: true);
+        final painter = painterFor(conn);
+        expect(
+          painter.debugResolveStyleColor(conn).toARGB32(),
+          kBackwardEdgeColor.toARGB32(),
+        );
+      });
+
+      test('backward edge uses kBackwardEdgeColor in dark theme', () {
+        final conn = _connData(isBackwardEdge: true);
+        final painter = painterFor(conn, theme: ThemeData.dark());
+        expect(
+          painter.debugResolveStyleColor(conn).toARGB32(),
+          kBackwardEdgeColor.toARGB32(),
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Introduce `kBackwardEdgeColor` constant and paint backward edges with it (instead of theme tertiary)
- Render backward edges as round dots and skip endpoint circles to visually distinguish them
- Extract `ConnectionPainter.classifyVisualType` for batch routing reuse

## Test plan
- [x] Full test suite passes
- [x] Codex review applied (see substrate dag-run results)

## Substrate
- Workflow: plan-implement-review-pr
- Slug: backwards-connection-styling

🤖 Substrate dag-run