### PR TITLE
feat: stay-open option in Add Algorithm screen

### DIFF
--- a/lib/ui/add_algorithm_screen.dart
+++ b/lib/ui/add_algorithm_screen.dart
@@ -10,6 +10,7 @@ import 'package:nt_helper/cubit/disting_cubit.dart';
 import 'package:collection/collection.dart';
 import 'package:nt_helper/domain/disting_nt_sysex.dart' show AlgorithmInfo;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:nt_helper/mcp/mcp_constants.dart';
 import 'package:nt_helper/models/algorithm_metadata.dart';
 import 'package:nt_helper/services/algorithm_metadata_service.dart';
 import 'package:nt_helper/ui/algorithm_documentation_screen.dart';
@@ -71,6 +72,9 @@ class _AddAlgorithmScreenState extends State<AddAlgorithmScreen> {
   String? selectedAlgorithmGuid;
   AlgorithmInfo? _currentAlgoInfo;
   List<int>? specValues;
+
+  // Used to anchor the split-button popup menu in `_buildActionButton`.
+  final GlobalKey _splitButtonKey = GlobalKey();
 
   @override
   void initState() {
@@ -1396,9 +1400,9 @@ class _AddAlgorithmScreenState extends State<AddAlgorithmScreen> {
       );
     }
 
-    // Show Add button for loaded algorithms (factory or loaded plugins)
-    return ElevatedButton(
-      onPressed: _currentAlgoInfo != null && specValues != null
+    final canAdd = specValues != null;
+    final addButton = ElevatedButton(
+      onPressed: canAdd
           ? () {
               Navigator.pop(context, {
                 'algorithm': _currentAlgoInfo,
@@ -1408,5 +1412,87 @@ class _AddAlgorithmScreenState extends State<AddAlgorithmScreen> {
           : null,
       child: const Text('Add to Preset'),
     );
+
+    if (!canAdd || !_canStayOpen()) {
+      return addButton;
+    }
+
+    return Row(
+      key: _splitButtonKey,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        addButton,
+        const SizedBox(width: 4),
+        Tooltip(
+          message: 'More add options',
+          child: IconButton(
+            icon: const Icon(Icons.arrow_drop_down,
+                semanticLabel: 'More add options'),
+            onPressed: _showAddMenu,
+            visualDensity: VisualDensity.compact,
+          ),
+        ),
+      ],
+    );
+  }
+
+  bool _canStayOpen() {
+    final state = context.read<DistingCubit>().state;
+    if (state is! DistingStateSynchronized) return false;
+    return state.slots.length < MCPConstants.maxSlots;
+  }
+
+  void _showAddMenu() {
+    final renderBox =
+        _splitButtonKey.currentContext!.findRenderObject()! as RenderBox;
+    final offset = renderBox.localToGlobal(Offset.zero);
+    final size = renderBox.size;
+
+    showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        offset.dx,
+        offset.dy + size.height,
+        offset.dx + size.width,
+        offset.dy + size.height,
+      ),
+      items: const [
+        PopupMenuItem<String>(
+          value: 'stay_open',
+          child: ListTile(
+            leading: Icon(Icons.playlist_add),
+            title: Text('Add and select another'),
+            dense: true,
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+      ],
+    ).then((value) {
+      if (value == 'stay_open') {
+        _addAndStayOpen();
+      }
+    });
+  }
+
+  Future<void> _addAndStayOpen() async {
+    final algorithm = _currentAlgoInfo;
+    final specs = specValues;
+    if (algorithm == null || specs == null) return;
+
+    final messenger = ScaffoldMessenger.of(context);
+    final name = algorithm.name;
+    await context
+        .read<DistingCubit>()
+        .onAlgorithmSelected(algorithm, List<int>.from(specs));
+
+    if (!mounted) return;
+    messenger.hideCurrentSnackBar();
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text('$name added'),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+    _clearSelection();
   }
 }

--- a/specs/2026-05-04_multi-select-algorithms.md
+++ b/specs/2026-05-04_multi-select-algorithms.md
@@ -1,0 +1,544 @@
+# Multi-select algorithms in the Add Algorithm screen
+
+## Context
+
+`AddAlgorithmScreen` (`lib/ui/add_algorithm_screen.dart`) is the modal route
+through which the user chooses an algorithm to append to the current preset.
+Today it is strictly single-select: tracking state in
+`String? selectedAlgorithmGuid` (line 71), `_currentAlgoInfo` (line 72), and a
+single `List<int>? specValues` (line 73). The "Add to Preset" button pops the
+route with a `Map` of one `algorithm` + one `specValues` (lines 1402–1407);
+two callers in `synchronized_screen.dart` (lines 680–702 and 905–928) read
+that result and call `cubit.onAlgorithmSelected(algo, specValues)` once.
+
+A user building a preset of 5–10 algorithms must therefore reopen the picker,
+re-search/scroll/filter, and re-tap "Add" once per algorithm. Each round trip
+also triggers an optimistic emit + verification fetch in
+`onAlgorithmSelectedImpl` (`lib/cubit/disting_cubit_algorithm_ops.dart:74-201`),
+so the user sees a sequence of placeholders settle one at a time even when
+the intent was clearly "give me these five."
+
+This spec adds a multi-select mode to the picker so a user can mark several
+algorithms in one pass and have them all appended in slot order with one
+return to the synchronized screen. The hardware MIDI protocol still adds one
+algorithm at a time (`requestAddAlgorithm` in
+`lib/domain/i_disting_midi_manager.dart:69-72`); batching is purely a
+client-side ergonomics improvement on top of the existing single-add path.
+
+The implementation is constrained by three pre-existing realities:
+
+1. **Specifications are per-algorithm.** Each `AlgorithmInfo` may declare 0..N
+   integer specifications (`specifications` field, with min/max/default per
+   spec — see `_buildSpecificationInputs`, line 1286). In single-select mode
+   the user can edit them before tapping Add. In multi-select mode the user
+   has not been shown a spec editor for each algorithm. The spec must define
+   how spec values are sourced for batch adds.
+2. **Plugins must be loaded before specs are accurate.** Community plugins
+   (`_isPlugin`, line 234) start as unloaded with stub specifications, and
+   the user can tap "Load Plugin" (line 1392) to fetch real specs over MIDI.
+   In single-select today, the action button literally swaps to "Load Plugin"
+   when the selected algorithm is unloaded.
+3. **Preset slot cap.** A preset can hold at most `MCPConstants.maxSlots = 32`
+   algorithms (`lib/mcp/mcp_constants.dart:19`). The picker today does not
+   guard this — the device just rejects subsequent adds. With batch we should
+   not silently drop selections past the cap.
+
+Goal: from `AddAlgorithmScreen`, a user can switch to a multi-select mode,
+tick any number of algorithms, and tap a single "Add N to Preset" button that
+returns to the synchronized screen and appends all of them in slot order
+using each algorithm's per-spec defaults. Single-select remains the default
+mode and behaves exactly as today.
+
+---
+
+## Approach
+
+Five changes plus tests. The first is the only behavioral surface change to
+the cubit; the rest is UI plumbing in `add_algorithm_screen.dart` and one
+small update to each of the two `Navigator.push` call sites.
+
+### 1. Add a batch entry point to the algorithm-ops mixin
+
+**Files:** `lib/cubit/disting_cubit.dart`, `lib/cubit/disting_cubit_algorithm_ops.dart`
+
+Add `onAlgorithmsSelectedImpl` that takes a list of `(AlgorithmInfo, List<int>)`
+pairs and adds them sequentially:
+
+```dart
+Future<void> onAlgorithmsSelectedImpl(
+  List<({AlgorithmInfo algorithm, List<int> specifications})> entries,
+) async {
+  for (final entry in entries) {
+    final st = state;
+    if (st is! DistingStateSynchronized) return; // disconnected / device-select
+    if (st.slots.length >= MCPConstants.maxSlots) return; // cap reached
+    await onAlgorithmSelectedImpl(entry.algorithm, entry.specifications);
+  }
+}
+```
+
+Sequential, awaiting each call — *not* parallel. Reasons:
+
+- `onAlgorithmSelectedImpl` derives the new slot index from
+  `syncstate.slots.length` (line 101) and emits an optimistic placeholder
+  before sending MIDI. Two parallel calls would compute the same target
+  slot index and emit conflicting optimistic states.
+- The verification phase reconciles by fetching only the new slot
+  (line 159). Sequencing keeps each verification scoped to one slot.
+- Hardware ordering: the user expects the first ticked algorithm to be the
+  lower-numbered slot. `requestAddAlgorithm` always appends, so preserving
+  call order preserves user-intended order.
+
+**Interruption semantics.** The per-iteration `state is! DistingStateSynchronized`
+check is sufficient to abort cleanly on:
+
+- device disconnect (state transitions to `DistingStateConnected` or
+  `DistingStateInitial`),
+- the user navigating away (state remains `DistingStateSynchronized` but the
+  cubit may be torn down — `await` resolves and the next iteration's state
+  read is a `DistingStateSynchronized` of a fresh state, which is fine).
+
+Mid-batch hardware errors are already absorbed by `onAlgorithmSelectedImpl`
+which rolls back its optimistic placeholder on `requestAddAlgorithm` throw
+(line 122) but does *not* rethrow — so the batch loop continues to the next
+entry. This is the desired behavior: one bad algorithm should not abort the
+remaining adds. Document this explicitly via a comment in the loop body.
+
+The slot-cap re-check inside the loop covers the case where verification of
+a previous add ends up not adding a slot (e.g. firmware rejected it), so the
+next iteration sees `slots.length` smaller than the loop's caller computed
+and proceeds correctly.
+
+Expose via `DistingCubit.onAlgorithmsSelected` in `disting_cubit.dart`
+alongside the existing `onAlgorithmSelected` (line 411):
+
+```dart
+Future<void> onAlgorithmsSelected(
+  List<({AlgorithmInfo algorithm, List<int> specifications})> entries,
+) async {
+  return onAlgorithmsSelectedImpl(entries);
+}
+```
+
+Keep `onAlgorithmSelected` exactly as today — no breaking change.
+
+### 2. Add a multi-select mode toggle to `AddAlgorithmScreen`
+
+**File:** `lib/ui/add_algorithm_screen.dart`
+
+Introduce a mode flag and selection set alongside the existing single-select
+state. **Both modes coexist** — the existing `selectedAlgorithmGuid` /
+`_currentAlgoInfo` / `specValues` remain authoritative for single-select; a
+new `Set<String> _selectedGuids` is authoritative for multi-select.
+
+```dart
+// new state
+bool _multiSelectMode = false;
+final Set<String> _selectedGuids = {};
+```
+
+Add an `IconButton` to the AppBar `actions` (between the `Refresh` and `Help`
+buttons, ~line 478) that toggles `_multiSelectMode`. Icon: `Icons.checklist`
+when off, filled accent when on. Tooltip: "Multi-select" / "Exit
+multi-select". Toggling **off** clears `_selectedGuids` and re-runs
+`_filterAlgorithms()`; toggling **on** clears the single-select state via
+`_clearSelection()` (line 337).
+
+`_multiSelectMode` and `_selectedGuids` are **in-memory only**. The mode
+resets to off each time the screen opens. Persisting the toggle and not the
+selection would be confusing (user reopens to an empty multi-select view);
+persisting the selection would be confusing (selection becomes stale across
+preset changes). Picking neither is the simplest correct option.
+
+A `Set<String>` cannot hold duplicates — if a user wants two of the same
+algorithm in a preset, they use single-select twice or repeat the multi-add
+flow. Document this in the help dialog (step 5).
+
+### 3. Render the picker with multi-select affordances
+
+**File:** `lib/ui/add_algorithm_screen.dart`
+
+#### Chip grid view (`_buildChipGridView`, line 977)
+
+When `_multiSelectMode`:
+
+- Replace `ChoiceChip` with `FilterChip`. `FilterChip.selected` reads
+  `_selectedGuids.contains(algo.guid)`. `onSelected` calls
+  `_toggleMultiSelect(algo)` (defined below), which gates on cap + plugin
+  state and announces the new aggregate count for screen readers.
+- Long-press still toggles favorite (`_toggleFavorite`).
+- `Semantics` `label`/`hint` adapt: the hint becomes
+  `'Double tap to ${isSelected ? 'untick' : 'tick'}'` and the selected count
+  is announced via `SemanticsService.sendAnnouncement` from
+  `_toggleMultiSelect` ("3 of 32 selected" / "deselected, 2 of 32").
+
+#### List view (`_buildListView`, line 1060)
+
+When `_multiSelectMode`, prepend a leading `Checkbox` (or wrap the row in a
+`CheckboxListTile`). Tap on the row toggles the checkbox via
+`_toggleMultiSelect(algo)`; long-press still toggles favorite. The
+`primaryContainer` background highlight is dropped in multi-select — the
+checkbox is the selection signal.
+
+#### Keyboard (`_handleKeyEvent`, line 867)
+
+`_handleKeyEvent` already routes Space/Enter to `_selectAlgorithm` (line
+890). In multi-select mode, redirect to `_toggleMultiSelect` for the focused
+row. Arrow navigation is unchanged.
+
+#### Filtering interaction (`_filterAlgorithms`, line 244)
+
+When the filter changes such that previously-selected GUIDs are no longer
+visible, **do not** clear them — they remain selected and will count toward
+the batch. The "Showing N of M algorithms" label (line 645) gains a suffix
+when in multi-select: `… · K selected` (where K may exceed the visible
+count).
+
+#### `_toggleMultiSelect` — the single source of truth for ticks
+
+```dart
+void _toggleMultiSelect(AlgorithmInfo algo) {
+  final state = context.read<DistingCubit>().state;
+  if (state is! DistingStateSynchronized) return;
+
+  final isSelected = _selectedGuids.contains(algo.guid);
+
+  // Untick is always allowed.
+  if (isSelected) {
+    setState(() => _selectedGuids.remove(algo.guid));
+    _announceCount(removed: algo.name);
+    return;
+  }
+
+  // Pre-tick guard: cap is "current preset slots + already-selected" — *not*
+  // just slots.length — so back-to-back ticks across multiple filter changes
+  // can't stack past 32.
+  final projected = state.slots.length + _selectedGuids.length + 1;
+  if (projected > MCPConstants.maxSlots) {
+    final remaining = MCPConstants.maxSlots - state.slots.length - _selectedGuids.length;
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text('Preset full · $remaining slot${remaining == 1 ? '' : 's'} remaining'),
+      duration: const Duration(seconds: 2),
+    ));
+    return;
+  }
+
+  setState(() => _selectedGuids.add(algo.guid));
+  _announceCount(added: algo.name);
+}
+```
+
+The cap projection (`slots.length + _selectedGuids.length + 1`) addresses the
+cross-filter stacking edge case: if the user filters to "Mixer", ticks two,
+then filters to "Reverb" and tries to tick more, the projection accounts for
+the Mixer ticks even though they are no longer visible.
+
+Plugin-load state is **not** gated at tick time — see "Unloaded plugins" in
+step 5. Ticking an unloaded plugin is allowed; the warning is a separate
+banner above the action button.
+
+#### Bottom action area (`_buildActionButton`, line 1381 + spec inputs block, line 692)
+
+When `_multiSelectMode`:
+
+- Hide the `_buildSpecificationInputs` block entirely. Each batch-added
+  algorithm uses its `specifications[i].safeDefaultValue` — identical to the
+  initial values used by `_selectAlgorithm` (line 316) and to what
+  `onAlgorithmSelectedImpl` already substitutes in offline mode (line 93).
+- Replace the action button text with `"Add N to Preset"` where N is
+  `_selectedGuids.length`. Disable when `N == 0`.
+- The unloaded-plugin warning banner (step 5) appears between the action
+  button and the spec input area when applicable.
+- On press, build the entry list **in `_allAlgorithms` alphabetical order**
+  (the canonical sort key — `name.toLowerCase()`, same as line 88) so a
+  filtered-out selected GUID still has a deterministic position. Pop with
+  the new return-shape map (step 4).
+
+The FAB (`_isHelpAvailableForSelected ? FAB : null`, line 531) hides in
+multi-select — it's tied to the single-select `_currentAlgoInfo`. Long-press
+on a chip/row in multi-select continues to invoke favorites, not docs;
+documentation lookup remains a single-select affordance.
+
+### 4. Update the return shape and the two call sites
+
+**Files:** `lib/ui/add_algorithm_screen.dart`, `lib/ui/synchronized_screen.dart`
+
+In multi-select, replace the existing pop payload (line 1403):
+
+```dart
+Navigator.pop(context, {
+  'algorithm': _currentAlgoInfo,
+  'specValues': specValues,
+});
+```
+
+with
+
+```dart
+Navigator.pop(context, {
+  'algorithms': _selectedAlgorithmsInDisplayOrder(),
+});
+```
+
+where
+
+```dart
+List<({AlgorithmInfo algorithm, List<int> specifications})>
+    _selectedAlgorithmsInDisplayOrder() {
+  // _allAlgorithms is sorted alphabetically by name (initState line 88,
+  // refreshed on state change line 423). Filtering uses _filteredAlgorithms;
+  // pop order uses _allAlgorithms so filtered-out selected GUIDs still
+  // appear in a deterministic alphabetical position.
+  return [
+    for (final algo in _allAlgorithms)
+      if (_selectedGuids.contains(algo.guid))
+        (
+          algorithm: algo,
+          specifications: algo.specifications
+              .map((s) => s.safeDefaultValue)
+              .toList(),
+        ),
+  ];
+}
+```
+
+This iteration approach also gracefully handles the case where a selected
+GUID has been removed from `_allAlgorithms` between tick and pop (e.g., a
+plugin rescan): the `if` clause silently drops it, no `firstWhere` exception.
+After computing the list, also discard any GUIDs that have vanished from
+`_selectedGuids` so the in-memory state reflects what was sent.
+
+Single-select pops the existing `{algorithm, specValues}` shape, unchanged.
+
+Update both `Navigator.push` consumers in `lib/ui/synchronized_screen.dart`
+(`_handleAddAlgorithmShortcut`, lines 680–702; `_buildFloatingActionButton`,
+lines 905–928) to disambiguate by key:
+
+```dart
+if (result is Map) {
+  if (result['algorithms'] is List) {
+    final entries = (result['algorithms'] as List)
+        .cast<({AlgorithmInfo algorithm, List<int> specifications})>();
+    if (entries.isNotEmpty) {
+      await cubit.onAlgorithmsSelected(entries);
+      SemanticsService.sendAnnouncement(view,
+        '${entries.length} algorithm${entries.length == 1 ? '' : 's'} added',
+        TextDirection.ltr);
+    }
+  } else if (result['algorithm'] != null) {
+    await cubit.onAlgorithmSelected(result['algorithm'], result['specValues']);
+    SemanticsService.sendAnnouncement(view, 'Algorithm added', TextDirection.ltr);
+  }
+}
+```
+
+### 5. Unloaded-plugin handling, help text
+
+**File:** `lib/ui/add_algorithm_screen.dart`
+
+#### Unloaded plugins
+
+Ticking an unloaded community plugin (`_needsLoading(algo) == true`) is
+allowed. Above the action button, render an `MaterialBanner`-style row when
+any selected GUID is unloaded **and** the cubit is online:
+
+```
+⚠ K plugin(s) need loading. Tap "Add N to Preset" to load them, then add.
+```
+
+When the user taps "Add N to Preset" and the list contains unloaded plugins
+(determined per-entry at tap time, *not* cached at tick time):
+
+1. Loop the unloaded ones first, calling `cubit.loadPlugin(guid)` sequentially.
+   Show a progress SnackBar (`'Loading plugin K of N…'`).
+2. After each `loadPlugin` returns, refresh the entry's `algorithm` via
+   `_allAlgorithms.firstWhereOrNull` so its `specifications` reflect the
+   loaded plugin's real specs (not the stub).
+3. If any `loadPlugin` returns `null` (failure) or throws, abort the batch:
+   show `SnackBar('Failed to load <plugin>; batch cancelled.')` and do **not**
+   call `cubit.onAlgorithmsSelected`. Keep the picker open so the user can
+   uncheck or retry.
+4. After all plugins load successfully, pop with the (now-up-to-date)
+   `algorithms` list.
+
+When **offline** (`distingState.offline == true`), skip the loading loop
+entirely and pop immediately. The cubit's offline path
+(`disting_cubit_algorithm_ops.dart:88-97`) will substitute stored defaults
+per algorithm, which is the same behavior single-select offline already has.
+
+If `cubit.loadPlugin` hangs (no MIDI response), the existing `loadPlugin`
+implementation handles its own timeout via the underlying SysEx wrapper; we
+do not add a separate timeout here — that is a property of the plugin loader,
+not the multi-select flow.
+
+#### Help dialog
+
+The help dialog (`onPressed` of the help `IconButton`, line 497) gains:
+
+```
+'• Multi-select mode (top-right) ticks multiple algorithms; default specs are used.'
+'• Each algorithm can be ticked once. To add duplicates, repeat the flow.'
+'• Unloaded plugins are loaded automatically before the batch is added.'
+```
+
+### 6. Tests
+
+**Files:**
+- `test/ui/add_algorithm_screen_multi_select_test.dart` (new widget tests)
+- `test/cubit/disting_cubit_algorithm_ops_multi_test.dart` (new cubit tests)
+
+Cubit tests (use existing `MockDistingMidiManager` patterns from
+`test/cubit/disting_cubit_test.dart`):
+
+- `onAlgorithmsSelected` with N=0 → no-op, no state change, no MIDI calls.
+- N=3 → three sequential `requestAddAlgorithm` calls in supplied order;
+  final `slots.length` increases by 3; placeholder names follow the
+  `Name`, `Name(2)`, `Name(3)` convention from
+  `_deriveOptimisticAlgorithmNameForAdd` when the same GUID appears twice
+  (only reachable via repeat-flow; document, don't test through public set).
+- Cap enforcement: pre-state has 30 slots, user submits 5 → first 2 are
+  appended, the 3rd iteration sees `slots.length == 32` and returns.
+- Mid-batch hardware error: second `requestAddAlgorithm` throws → first
+  add is preserved, second is rolled back (placeholder removed by
+  `onAlgorithmSelectedImpl`'s catch block), third proceeds (loop is not
+  aborted by a single-add failure).
+- Mid-batch device disconnect: cubit transitions to non-synchronized state
+  between iterations → loop returns cleanly without further calls.
+
+Widget tests:
+
+- Toggling multi-select mode swaps `ChoiceChip` for `FilterChip` and hides
+  the spec input block.
+- Ticking three algorithms produces an "Add 3 to Preset" button; tapping
+  pops a `Map` whose `algorithms` list has length 3 in alphabetical order.
+- Filter that hides a ticked algorithm keeps it ticked (assert
+  `_selectedGuids.contains(...)` still true after `_filterAlgorithms()`)
+  and the algorithm appears in the popped list at its alphabetical position.
+- Cross-filter cap: with 30 slots already in the preset, ticking 2 in one
+  filter view then switching filters and trying to tick a 3rd surfaces the
+  cap SnackBar (validates the projection accounts for filtered-out
+  selections).
+- Unloaded plugin path: tick a `_isPlugin && !isLoaded` algorithm online →
+  warning banner appears; tapping "Add" calls `cubit.loadPlugin` first; on
+  successful load, the popped entry has the post-load specifications.
+- Unloaded plugin path: tick a `_isPlugin && !isLoaded` algorithm offline →
+  no banner, tap "Add" pops immediately with stub specs (cubit substitutes
+  defaults).
+- Untoggling multi-select clears `_selectedGuids`.
+
+---
+
+## Critical Files
+
+| File | Change |
+|---|---|
+| `lib/cubit/disting_cubit_algorithm_ops.dart` | Add `onAlgorithmsSelectedImpl` looping `onAlgorithmSelectedImpl` with cap + state guards |
+| `lib/cubit/disting_cubit.dart` | Expose `onAlgorithmsSelected` facade |
+| `lib/ui/add_algorithm_screen.dart` | Multi-select mode flag, `Set<String>` selection, `_toggleMultiSelect` with cap projection, FilterChip/Checkbox rendering, batch action button, return-shape branch, plugin pre-load on submit |
+| `lib/ui/synchronized_screen.dart` | Two `Navigator.push` call sites branch on `algorithms` vs `algorithm` key in the result map |
+| `test/ui/add_algorithm_screen_multi_select_test.dart` (new) | Widget tests for the multi-select mode |
+| `test/cubit/disting_cubit_algorithm_ops_multi_test.dart` (new) | Cubit tests for `onAlgorithmsSelected` |
+
+## Reuse / do not duplicate
+
+- `_buildCategoryFilterButton` (line 1210) is the canonical multi-select
+  dialog pattern in this screen; mirror its `Set<T>` + `StatefulBuilder`
+  approach for any temp-set UI bits.
+- `_deriveOptimisticAlgorithmNameForAdd` (line 7 in algorithm_ops) already
+  handles repeated-GUID name derivation. Sequencing batch adds through
+  `onAlgorithmSelectedImpl` reuses this for free — do not reimplement.
+- Plugin loading is already exposed as `cubit.loadPlugin(guid)` (line 871
+  of `disting_cubit.dart`). Wrap calls in a sequential loop for the submit-
+  time pre-load — do not call `requestLoadPlugin` directly.
+- `MCPConstants.maxSlots` (`lib/mcp/mcp_constants.dart:19`) is the source
+  of truth for the 32-slot cap. Import and use that constant — do not
+  hardcode `32` in either UI or cubit.
+
+## Verification
+
+Manual:
+
+1. `flutter run -d macos --print-dtd`. Connect to a Disting NT (or use
+   demo mode).
+2. Open Add Algorithm. Toggle multi-select. Tick three factory algorithms
+   (e.g., `Mixer Stereo`, `VCA / VCF`, `Reverb`). Tap "Add 3 to Preset".
+   Verify all three appear in slot order at the end of the preset with
+   default specifications. Verify `flutter analyze` clean.
+3. With ~31 algorithms already loaded, attempt to multi-select 3 — verify
+   the cap SnackBar fires on the second tick (because `31 + 1 + 1 = 33 > 32`).
+4. With ~30 algorithms loaded: filter to "Mixer", tick 1; filter to
+   "Reverb", tick 1; filter to "Delay", attempt to tick 2 — second tick
+   fires the cap SnackBar (proves cross-filter projection).
+5. Tick a community plugin that is *not* loaded (online). Verify the
+   warning banner. Tap "Add". Verify a "Loading plugin…" SnackBar appears,
+   the plugin loads, then the batch proceeds.
+6. Tick the same unloaded plugin while *offline*. Verify no banner; tap
+   "Add" pops immediately and the algorithm appears with default specs
+   (cubit's offline override path).
+7. Filter to a category, tick three, clear filter, tap Add — verify all
+   three were added (proves filter-clear does not lose selection).
+8. Toggle multi-select off after ticking 3 → selection is cleared,
+   single-select state restored, picker behaves as in main.
+9. Single-select path (default): pick one algorithm, edit specs, tap Add
+   → verify identical behavior to current main.
+10. Disconnect the device mid-batch (start a 5-tick add, pull USB after
+    slot 2 settles): verify the cubit lands cleanly in
+    `DistingStateConnected`/`Initial` and no spurious slot is added.
+
+Automated:
+
+- `flutter analyze` — zero warnings.
+- `flutter test test/cubit/disting_cubit_algorithm_ops_multi_test.dart`.
+- `flutter test test/ui/add_algorithm_screen_multi_select_test.dart`.
+- Existing test suites in `test/cubit/` and `test/ui/` continue to pass
+  (no breaking API changes).
+
+## Out of scope
+
+- **Per-algorithm spec editing in batch.** Letting the user open a per-
+  algorithm spec sheet for each ticked algorithm before tap-to-add is a
+  much heavier UX (modal stack, per-row state, validation). Defaults are
+  the documented batch behavior; users who need non-default specs continue
+  to use single-select. Tracked as a future "Configure batch specs" flow
+  if requested.
+- **Reordering selected algorithms before insertion.** Selected algorithms
+  insert in alphabetical (display-canonical) order from `_allAlgorithms`.
+  Drag-to-reorder would require a new staging surface; users can move slots
+  after insertion via the existing `moveAlgorithmUp/Down`.
+- **Duplicates of the same algorithm in one batch.** A `Set<String>`
+  deliberately precludes ticking the same GUID twice. Repeat the flow if
+  needed.
+- **Persisting multi-select mode across screen closes.** Mode and selection
+  are both in-memory only.
+- **Parallel hardware adds.** The MIDI manager is single-request-at-a-time
+  in practice; the verification logic in `onAlgorithmSelectedImpl` assumes
+  one in-flight add. Sequential-await is the correct model and is not a
+  performance bottleneck for the realistic batch size (≤32).
+- **MCP tool for batch add.** The MCP API (`docs/mcp-api-guide.md`) has a
+  `new` tool that adds one algorithm at a time. A batch MCP tool is a
+  separate change with its own validation surface; not in scope here.
+- **Online-during-batch transition handling.** If the user goes from
+  online to offline mid-batch, the per-iteration state check aborts.
+  Rejoining online mid-batch is not a recovery path the spec attempts to
+  cover — the user re-runs the picker.
+- **Batch favorites.** Multi-tick → "favorite all" is a plausible
+  follow-up but not requested. Long-press still operates per-row.
+- **Removing the single-select mode.** Single-select remains the default
+  and unchanged. Switching the default to multi-select would be a separate
+  UX call.
+
+## Acceptance
+
+- An "Add N to Preset" button replaces "Add to Preset" when in multi-select
+  mode and exactly N algorithms are ticked (N ≥ 1).
+- Tapping it pops the picker and appends N algorithms to the preset in the
+  order they appear alphabetically in `_allAlgorithms`, using each
+  algorithm's default specifications.
+- Slot cap is enforced cumulatively: ticks past `32 - slots.length -
+  _selectedGuids.length` are rejected with a SnackBar.
+- Unloaded community plugins (online) are loaded before the batch is
+  applied; a load failure aborts the batch and surfaces a SnackBar.
+- Offline batch adds use the cubit's existing offline default-substitution.
+- Single-select mode is byte-for-byte unchanged.
+- Mid-batch device disconnect aborts cleanly without phantom slots.
+- `flutter analyze` clean; new tests pass; existing suites pass.

--- a/specs/2026-05-04_multi-select-algorithms.md
+++ b/specs/2026-05-04_multi-select-algorithms.md
@@ -32,9 +32,11 @@ Inside `_buildActionButton` (or in the widget tree just above/beside it), place 
 
 #### Option A — Split-button dropdown (preferred)
 
-Replace the single `ElevatedButton` with a `MenuAnchor` / `SplitButton` (`ElevatedButton` + `MenuAnchor` dropdown) or a plain `ElevatedButton` paired with a small adjacent `IconButton` that opens a menu:
+Mirror the existing split-button pattern in `_DeviceSelectionView` (`lib/disting_app.dart` lines ~700–780). There, an `ElevatedButton` is paired with an adjacent `IconButton` (keyed via `_splitButtonKey`) that calls `showMenu` to reveal alternate actions.
 
-- **Primary action (top/left):** `Add to Preset` → pops the route, identical to today.
+Apply the same layout in `_buildActionButton`:
+
+- **Primary action:** `Add to Preset` → pops the route, identical to today.
 - **Menu item:** `Add and select another` → adds, clears state, stays open.
 
 The menu item is disabled when `_currentAlgoInfo == null || specValues == null` or when `_needsLoading(algorithm) && !isOffline`.

--- a/specs/2026-05-04_multi-select-algorithms.md
+++ b/specs/2026-05-04_multi-select-algorithms.md
@@ -140,9 +140,15 @@ final Set<String> _selectedGuids = {};
 Add an `IconButton` to the AppBar `actions` (between the `Refresh` and `Help`
 buttons, ~line 478) that toggles `_multiSelectMode`. Icon: `Icons.checklist`
 when off, filled accent when on. Tooltip: "Multi-select" / "Exit
-multi-select". Toggling **off** clears `_selectedGuids` and re-runs
-`_filterAlgorithms()`; toggling **on** clears the single-select state via
-`_clearSelection()` (line 337).
+multi-select". Toggling **off** clears `_selectedGuids` (no need to re-run
+`_filterAlgorithms` — the filter is unaffected by selection state); toggling
+**on** clears the single-select state via `_clearSelection()` (line 337).
+
+When the preset is already at cap (`slots.length >= MCPConstants.maxSlots`),
+the toggle button is rendered with `onPressed: null` and a tooltip
+explaining "Preset full · remove an algorithm to enable multi-select." This
+prevents the user from entering multi-select only to be hit with a cap
+SnackBar on every tick attempt.
 
 `_multiSelectMode` and `_selectedGuids` are **in-memory only**. The mode
 resets to off each time the screen opens. Persisting the toggle and not the
@@ -331,6 +337,25 @@ if (result is Map) {
   }
 }
 ```
+
+Notes on the record-typed payload:
+
+- `Navigator.pop` keeps Dart objects in-memory; there is no
+  serialization round-trip. Dart records survive the boundary as ordinary
+  objects, just like the existing `_currentAlgoInfo` (an `AlgorithmInfo`
+  object) does today.
+- The `(result['algorithms'] as List).cast<({...})>()` pattern relies on
+  the producer side returning a properly-typed `List<({...})>` (which
+  `_selectedAlgorithmsInDisplayOrder` does — the comprehension yields a
+  list whose static type is the record-typed list). If the producer ever
+  changes to return `List<dynamic>`, the cast becomes a checked view that
+  may throw on element access. Keep `_selectedAlgorithmsInDisplayOrder`'s
+  return type explicit.
+- Implementer convention: if record-cast turns out to be brittle in
+  practice (e.g., compiler upgrade changes inference), an equally
+  acceptable shape is `List<Map<String, dynamic>>` with `'algorithm'` and
+  `'specifications'` keys, unpacked on the receiving side. Prefer records
+  unless that brittleness materialises.
 
 ### 5. Unloaded-plugin handling, help text
 

--- a/specs/2026-05-04_multi-select-algorithms.md
+++ b/specs/2026-05-04_multi-select-algorithms.md
@@ -1,455 +1,67 @@
-# Multi-select algorithms in the Add Algorithm screen
+# Stay-open option in the Add Algorithm screen
 
 ## Context
 
-`AddAlgorithmScreen` (`lib/ui/add_algorithm_screen.dart`) is the modal route
-through which the user chooses an algorithm to append to the current preset.
-Today it is strictly single-select: tracking state in
-`String? selectedAlgorithmGuid` (line 71), `_currentAlgoInfo` (line 72), and a
-single `List<int>? specValues` (line 73). The "Add to Preset" button pops the
-route with a `Map` of one `algorithm` + one `specValues` (lines 1402–1407);
-two callers in `synchronized_screen.dart` (lines 680–702 and 905–928) read
-that result and call `cubit.onAlgorithmSelected(algo, specValues)` once.
+`AddAlgorithmScreen` (`lib/ui/add_algorithm_screen.dart`) is the modal route through which the user chooses an algorithm to append to the current preset. Today it is single-select, single-add: the user picks one algorithm, optionally edits its specifications, taps **Add to Preset**, and the route pops. The caller in `synchronized_screen.dart` receives a `{'algorithm': …, 'specValues': …}` map and invokes `cubit.onAlgorithmSelected` once.
 
-A user building a preset of 5–10 algorithms must therefore reopen the picker,
-re-search/scroll/filter, and re-tap "Add" once per algorithm. Each round trip
-also triggers an optimistic emit + verification fetch in
-`onAlgorithmSelectedImpl` (`lib/cubit/disting_cubit_algorithm_ops.dart:74-201`),
-so the user sees a sequence of placeholders settle one at a time even when
-the intent was clearly "give me these five."
+When a user is building a preset of 5–10 algorithms, every add requires reopening the picker, re-applying filters, and finding the next desired algorithm. The goal of this spec is to add a small, unobtrusive affordance that lets the user stay in the picker after adding an algorithm, so they can immediately select and configure the next one.
 
-This spec adds a multi-select mode to the picker so a user can mark several
-algorithms in one pass and have them all appended in slot order with one
-return to the synchronized screen. The hardware MIDI protocol still adds one
-algorithm at a time (`requestAddAlgorithm` in
-`lib/domain/i_disting_midi_manager.dart:69-72`); batching is purely a
-client-side ergonomics improvement on top of the existing single-add path.
-
-The implementation is constrained by three pre-existing realities:
-
-1. **Specifications are per-algorithm.** Each `AlgorithmInfo` may declare 0..N
-   integer specifications (`specifications` field, with min/max/default per
-   spec — see `_buildSpecificationInputs`, line 1286). In single-select mode
-   the user can edit them before tapping Add. In multi-select mode the user
-   has not been shown a spec editor for each algorithm. The spec must define
-   how spec values are sourced for batch adds.
-2. **Plugins must be loaded before specs are accurate.** Community plugins
-   (`_isPlugin`, line 234) start as unloaded with stub specifications, and
-   the user can tap "Load Plugin" (line 1392) to fetch real specs over MIDI.
-   In single-select today, the action button literally swaps to "Load Plugin"
-   when the selected algorithm is unloaded.
-3. **Preset slot cap.** A preset can hold at most `MCPConstants.maxSlots = 32`
-   algorithms (`lib/mcp/mcp_constants.dart:19`). The picker today does not
-   guard this — the device just rejects subsequent adds. With batch we should
-   not silently drop selections past the cap.
-
-Goal: from `AddAlgorithmScreen`, a user can switch to a multi-select mode,
-tick any number of algorithms, and tap a single "Add N to Preset" button that
-returns to the synchronized screen and appends all of them in slot order
-using each algorithm's per-spec defaults. Single-select remains the default
-mode and behaves exactly as today.
+The single-select flow, specification editing, plugin loading, and slot-cap behavior remain **completely unchanged**. The only delta is a user-toggleable option to keep the screen open after a successful add.
 
 ---
 
 ## Approach
 
-Five changes plus tests. The first is the only behavioral surface change to
-the cubit; the rest is UI plumbing in `add_algorithm_screen.dart` and one
-small update to each of the two `Navigator.push` call sites.
-
-### 1. Add a batch entry point to the algorithm-ops mixin
-
-**Files:** `lib/cubit/disting_cubit.dart`, `lib/cubit/disting_cubit_algorithm_ops.dart`
-
-Add `onAlgorithmsSelectedImpl` that takes a list of `(AlgorithmInfo, List<int>)`
-pairs and adds them sequentially:
-
-```dart
-Future<void> onAlgorithmsSelectedImpl(
-  List<({AlgorithmInfo algorithm, List<int> specifications})> entries,
-) async {
-  for (final entry in entries) {
-    final st = state;
-    if (st is! DistingStateSynchronized) return; // disconnected / device-select
-    if (st.slots.length >= MCPConstants.maxSlots) return; // cap reached
-    await onAlgorithmSelectedImpl(entry.algorithm, entry.specifications);
-  }
-}
-```
-
-Sequential, awaiting each call — *not* parallel. Reasons:
-
-- `onAlgorithmSelectedImpl` derives the new slot index from
-  `syncstate.slots.length` (line 101) and emits an optimistic placeholder
-  before sending MIDI. Two parallel calls would compute the same target
-  slot index and emit conflicting optimistic states.
-- The verification phase reconciles by fetching only the new slot
-  (line 159). Sequencing keeps each verification scoped to one slot.
-- Hardware ordering: the user expects the first ticked algorithm to be the
-  lower-numbered slot. `requestAddAlgorithm` always appends, so preserving
-  call order preserves user-intended order.
-
-**Interruption semantics.** The per-iteration `state is! DistingStateSynchronized`
-check is sufficient to abort cleanly on:
-
-- device disconnect (state transitions to `DistingStateConnected` or
-  `DistingStateInitial`),
-- the user navigating away (state remains `DistingStateSynchronized` but the
-  cubit may be torn down — `await` resolves and the next iteration's state
-  read is a `DistingStateSynchronized` of a fresh state, which is fine).
-
-Mid-batch hardware errors are already absorbed by `onAlgorithmSelectedImpl`
-which rolls back its optimistic placeholder on `requestAddAlgorithm` throw
-(line 122) but does *not* rethrow — so the batch loop continues to the next
-entry. This is the desired behavior: one bad algorithm should not abort the
-remaining adds. Document this explicitly via a comment in the loop body.
-
-The slot-cap re-check inside the loop covers the case where verification of
-a previous add ends up not adding a slot (e.g. firmware rejected it), so the
-next iteration sees `slots.length` smaller than the loop's caller computed
-and proceeds correctly.
-
-Expose via `DistingCubit.onAlgorithmsSelected` in `disting_cubit.dart`
-alongside the existing `onAlgorithmSelected` (line 411):
-
-```dart
-Future<void> onAlgorithmsSelected(
-  List<({AlgorithmInfo algorithm, List<int> specifications})> entries,
-) async {
-  return onAlgorithmsSelectedImpl(entries);
-}
-```
-
-Keep `onAlgorithmSelected` exactly as today — no breaking change.
-
-### 2. Add a multi-select mode toggle to `AddAlgorithmScreen`
+### 1. Add a `keepOpen` state flag to `AddAlgorithmScreen`
 
 **File:** `lib/ui/add_algorithm_screen.dart`
 
-Introduce a mode flag and selection set alongside the existing single-select
-state. **Both modes coexist** — the existing `selectedAlgorithmGuid` /
-`_currentAlgoInfo` / `specValues` remain authoritative for single-select; a
-new `Set<String> _selectedGuids` is authoritative for multi-select.
+Introduce one new boolean field:
 
 ```dart
-// new state
-bool _multiSelectMode = false;
-final Set<String> _selectedGuids = {};
+bool _keepOpenAfterAdd = false;
 ```
 
-Add an `IconButton` to the AppBar `actions` (between the `Refresh` and `Help`
-buttons, ~line 478) that toggles `_multiSelectMode`. Icon: `Icons.checklist`
-when off, filled accent when on. Tooltip: "Multi-select" / "Exit
-multi-select". Toggling **off** clears `_selectedGuids` (no need to re-run
-`_filterAlgorithms` — the filter is unaffected by selection state); toggling
-**on** clears the single-select state via `_clearSelection()` (line 337).
+It is **in-memory only** — resets to `false` each time the screen is pushed. Persisting it would be surprising (e.g. the user accidentally leaves it checked, comes back hours later, and the first add leaves the picker open). Resetting is the safest default.
 
-When the preset is already at cap (`slots.length >= MCPConstants.maxSlots`),
-the toggle button is rendered with `onPressed: null` and a tooltip
-explaining "Preset full · remove an algorithm to enable multi-select." This
-prevents the user from entering multi-select only to be hit with a cap
-SnackBar on every tick attempt.
-
-`_multiSelectMode` and `_selectedGuids` are **in-memory only**. The mode
-resets to off each time the screen opens. Persisting the toggle and not the
-selection would be confusing (user reopens to an empty multi-select view);
-persisting the selection would be confusing (selection becomes stale across
-preset changes). Picking neither is the simplest correct option.
-
-A `Set<String>` cannot hold duplicates — if a user wants two of the same
-algorithm in a preset, they use single-select twice or repeat the multi-add
-flow. Document this in the help dialog (step 5).
-
-### 3. Render the picker with multi-select affordances
+### 2. Render the keep-open toggle in the bottom action area
 
 **File:** `lib/ui/add_algorithm_screen.dart`
 
-#### Chip grid view (`_buildChipGridView`, line 977)
+Inside `_buildActionButton` (or in the widget tree just above/beside it), place a `Row` containing the original **Add to Preset** button and a secondary control:
 
-When `_multiSelectMode`:
+#### Option A — Split-button dropdown (preferred)
 
-- Replace `ChoiceChip` with `FilterChip`. `FilterChip.selected` reads
-  `_selectedGuids.contains(algo.guid)`. `onSelected` calls
-  `_toggleMultiSelect(algo)` (defined below), which gates on cap + plugin
-  state and announces the new aggregate count for screen readers.
-- Long-press still toggles favorite (`_toggleFavorite`).
-- `Semantics` `label`/`hint` adapt: the hint becomes
-  `'Double tap to ${isSelected ? 'untick' : 'tick'}'` and the selected count
-  is announced via `SemanticsService.sendAnnouncement` from
-  `_toggleMultiSelect` ("3 of 32 selected" / "deselected, 2 of 32").
+Replace the single `ElevatedButton` with a `MenuAnchor` / `SplitButton` (`ElevatedButton` + `MenuAnchor` dropdown) or a plain `ElevatedButton` paired with a small adjacent `IconButton` that opens a menu:
 
-#### List view (`_buildListView`, line 1060)
+- **Primary action (top/left):** `Add to Preset` → pops the route, identical to today.
+- **Menu item:** `Add and select another` → adds, clears state, stays open.
 
-When `_multiSelectMode`, prepend a leading `Checkbox` (or wrap the row in a
-`CheckboxListTile`). Tap on the row toggles the checkbox via
-`_toggleMultiSelect(algo)`; long-press still toggles favorite. The
-`primaryContainer` background highlight is dropped in multi-select — the
-checkbox is the selection signal.
+The menu item is disabled when `_currentAlgoInfo == null || specValues == null` or when `_needsLoading(algorithm) && !isOffline`.
 
-#### Keyboard (`_handleKeyEvent`, line 867)
+#### Option B — Checkbox beside the button
 
-`_handleKeyEvent` already routes Space/Enter to `_selectAlgorithm` (line
-890). In multi-select mode, redirect to `_toggleMultiSelect` for the focused
-row. Arrow navigation is unchanged.
+A `CheckboxListTile` or plain `Row` with a `Checkbox` + `Text('Add another')` positioned above or beside the **Add to Preset** button. When checked, the same primary button changes its behavior from *pop* to *stay open*.
 
-#### Filtering interaction (`_filterAlgorithms`, line 244)
+**Decision:** Use whichever is simpler to implement with the existing layout; the split button is slightly clearer because the two outcomes are explicit, whereas a checkbox changes the meaning of the same button.
 
-When the filter changes such that previously-selected GUIDs are no longer
-visible, **do not** clear them — they remain selected and will count toward
-the batch. The "Showing N of M algorithms" label (line 645) gains a suffix
-when in multi-select: `… · K selected` (where K may exceed the visible
-count).
+The toggle control is hidden (or disabled with a tooltip) when the preset is at cap (`slots.length >= MCPConstants.maxSlots`) because there is no room to add another.
 
-#### `_toggleMultiSelect` — the single source of truth for ticks
+### 3. "Stay open" add flow
 
-```dart
-void _toggleMultiSelect(AlgorithmInfo algo) {
-  final state = context.read<DistingCubit>().state;
-  if (state is! DistingStateSynchronized) return;
+When the user triggers the "add + keep open" action:
 
-  final isSelected = _selectedGuids.contains(algo.guid);
+1. **Guard** identical to today — `selectedAlgorithmGuid`, `_currentAlgoInfo`, and `specValues` must all be non-null; the algorithm must be loaded (or offline). If guards fail, button is disabled.
+2. **Call `cubit.onAlgorithmSelected(_currentAlgoInfo!, specValues!)`** exactly as today. Await it so the optimistic placeholder + verification cycle starts before we reset the UI.
+3. **On success:** call `_clearSelection()` (line 337), which nulls `selectedAlgorithmGuid`, `_currentAlgoInfo`, `specValues`, and `_isHelpAvailableForSelected`.
+4. **Show a transient SnackBar** confirming the add (e.g. `'<name> added'`). Keep the `ScaffoldMessenger` logic simple — dismiss any existing SnackBars first so they don't stack.
+5. **Do not pop.** The picker remains visible with the same filters, scroll position, and search query.
 
-  // Untick is always allowed.
-  if (isSelected) {
-    setState(() => _selectedGuids.remove(algo.guid));
-    _announceCount(removed: algo.name);
-    return;
-  }
+If the cubit transitions to a non-`DistingStateSynchronized` state during `await` (e.g. device disconnect), `onAlgorithmSelectedImpl` handles its own rollback/placeholder cleanup and returns. The picker stays open but the state transition may already be pushing a new route via the `BlocListener` in `synchronized_screen.dart`; in that case the normal disconnect flow takes precedence.
 
-  // Pre-tick guard: cap is "current preset slots + already-selected" — *not*
-  // just slots.length — so back-to-back ticks across multiple filter changes
-  // can't stack past 32.
-  final projected = state.slots.length + _selectedGuids.length + 1;
-  if (projected > MCPConstants.maxSlots) {
-    final remaining = MCPConstants.maxSlots - state.slots.length - _selectedGuids.length;
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-      content: Text('Preset full · $remaining slot${remaining == 1 ? '' : 's'} remaining'),
-      duration: const Duration(seconds: 2),
-    ));
-    return;
-  }
+### 4. Single-tap "Add to Preset" (existing behavior)
 
-  setState(() => _selectedGuids.add(algo.guid));
-  _announceCount(added: algo.name);
-}
-```
-
-The cap projection (`slots.length + _selectedGuids.length + 1`) addresses the
-cross-filter stacking edge case: if the user filters to "Mixer", ticks two,
-then filters to "Reverb" and tries to tick more, the projection accounts for
-the Mixer ticks even though they are no longer visible.
-
-Plugin-load state is **not** gated at tick time — see "Unloaded plugins" in
-step 5. Ticking an unloaded plugin is allowed; the warning is a separate
-banner above the action button.
-
-#### Bottom action area (`_buildActionButton`, line 1381 + spec inputs block, line 692)
-
-When `_multiSelectMode`:
-
-- Hide the `_buildSpecificationInputs` block entirely. Each batch-added
-  algorithm uses its `specifications[i].safeDefaultValue` — identical to the
-  initial values used by `_selectAlgorithm` (line 316) and to what
-  `onAlgorithmSelectedImpl` already substitutes in offline mode (line 93).
-- Replace the action button text with `"Add N to Preset"` where N is
-  `_selectedGuids.length`. Disable when `N == 0`.
-- The unloaded-plugin warning banner (step 5) appears between the action
-  button and the spec input area when applicable.
-- On press, build the entry list **in `_allAlgorithms` alphabetical order**
-  (the canonical sort key — `name.toLowerCase()`, same as line 88) so a
-  filtered-out selected GUID still has a deterministic position. Pop with
-  the new return-shape map (step 4).
-
-The FAB (`_isHelpAvailableForSelected ? FAB : null`, line 531) hides in
-multi-select — it's tied to the single-select `_currentAlgoInfo`. Long-press
-on a chip/row in multi-select continues to invoke favorites, not docs;
-documentation lookup remains a single-select affordance.
-
-### 4. Update the return shape and the two call sites
-
-**Files:** `lib/ui/add_algorithm_screen.dart`, `lib/ui/synchronized_screen.dart`
-
-In multi-select, replace the existing pop payload (line 1403):
-
-```dart
-Navigator.pop(context, {
-  'algorithm': _currentAlgoInfo,
-  'specValues': specValues,
-});
-```
-
-with
-
-```dart
-Navigator.pop(context, {
-  'algorithms': _selectedAlgorithmsInDisplayOrder(),
-});
-```
-
-where
-
-```dart
-List<({AlgorithmInfo algorithm, List<int> specifications})>
-    _selectedAlgorithmsInDisplayOrder() {
-  // _allAlgorithms is sorted alphabetically by name (initState line 88,
-  // refreshed on state change line 423). Filtering uses _filteredAlgorithms;
-  // pop order uses _allAlgorithms so filtered-out selected GUIDs still
-  // appear in a deterministic alphabetical position.
-  return [
-    for (final algo in _allAlgorithms)
-      if (_selectedGuids.contains(algo.guid))
-        (
-          algorithm: algo,
-          specifications: algo.specifications
-              .map((s) => s.safeDefaultValue)
-              .toList(),
-        ),
-  ];
-}
-```
-
-This iteration approach also gracefully handles the case where a selected
-GUID has been removed from `_allAlgorithms` between tick and pop (e.g., a
-plugin rescan): the `if` clause silently drops it, no `firstWhere` exception.
-After computing the list, also discard any GUIDs that have vanished from
-`_selectedGuids` so the in-memory state reflects what was sent.
-
-Single-select pops the existing `{algorithm, specValues}` shape, unchanged.
-
-Update both `Navigator.push` consumers in `lib/ui/synchronized_screen.dart`
-(`_handleAddAlgorithmShortcut`, lines 680–702; `_buildFloatingActionButton`,
-lines 905–928) to disambiguate by key:
-
-```dart
-if (result is Map) {
-  if (result['algorithms'] is List) {
-    final entries = (result['algorithms'] as List)
-        .cast<({AlgorithmInfo algorithm, List<int> specifications})>();
-    if (entries.isNotEmpty) {
-      await cubit.onAlgorithmsSelected(entries);
-      SemanticsService.sendAnnouncement(view,
-        '${entries.length} algorithm${entries.length == 1 ? '' : 's'} added',
-        TextDirection.ltr);
-    }
-  } else if (result['algorithm'] != null) {
-    await cubit.onAlgorithmSelected(result['algorithm'], result['specValues']);
-    SemanticsService.sendAnnouncement(view, 'Algorithm added', TextDirection.ltr);
-  }
-}
-```
-
-Notes on the record-typed payload:
-
-- `Navigator.pop` keeps Dart objects in-memory; there is no
-  serialization round-trip. Dart records survive the boundary as ordinary
-  objects, just like the existing `_currentAlgoInfo` (an `AlgorithmInfo`
-  object) does today.
-- The `(result['algorithms'] as List).cast<({...})>()` pattern relies on
-  the producer side returning a properly-typed `List<({...})>` (which
-  `_selectedAlgorithmsInDisplayOrder` does — the comprehension yields a
-  list whose static type is the record-typed list). If the producer ever
-  changes to return `List<dynamic>`, the cast becomes a checked view that
-  may throw on element access. Keep `_selectedAlgorithmsInDisplayOrder`'s
-  return type explicit.
-- Implementer convention: if record-cast turns out to be brittle in
-  practice (e.g., compiler upgrade changes inference), an equally
-  acceptable shape is `List<Map<String, dynamic>>` with `'algorithm'` and
-  `'specifications'` keys, unpacked on the receiving side. Prefer records
-  unless that brittleness materialises.
-
-### 5. Unloaded-plugin handling, help text
-
-**File:** `lib/ui/add_algorithm_screen.dart`
-
-#### Unloaded plugins
-
-Ticking an unloaded community plugin (`_needsLoading(algo) == true`) is
-allowed. Above the action button, render an `MaterialBanner`-style row when
-any selected GUID is unloaded **and** the cubit is online:
-
-```
-⚠ K plugin(s) need loading. Tap "Add N to Preset" to load them, then add.
-```
-
-When the user taps "Add N to Preset" and the list contains unloaded plugins
-(determined per-entry at tap time, *not* cached at tick time):
-
-1. Loop the unloaded ones first, calling `cubit.loadPlugin(guid)` sequentially.
-   Show a progress SnackBar (`'Loading plugin K of N…'`).
-2. After each `loadPlugin` returns, refresh the entry's `algorithm` via
-   `_allAlgorithms.firstWhereOrNull` so its `specifications` reflect the
-   loaded plugin's real specs (not the stub).
-3. If any `loadPlugin` returns `null` (failure) or throws, abort the batch:
-   show `SnackBar('Failed to load <plugin>; batch cancelled.')` and do **not**
-   call `cubit.onAlgorithmsSelected`. Keep the picker open so the user can
-   uncheck or retry.
-4. After all plugins load successfully, pop with the (now-up-to-date)
-   `algorithms` list.
-
-When **offline** (`distingState.offline == true`), skip the loading loop
-entirely and pop immediately. The cubit's offline path
-(`disting_cubit_algorithm_ops.dart:88-97`) will substitute stored defaults
-per algorithm, which is the same behavior single-select offline already has.
-
-If `cubit.loadPlugin` hangs (no MIDI response), the existing `loadPlugin`
-implementation handles its own timeout via the underlying SysEx wrapper; we
-do not add a separate timeout here — that is a property of the plugin loader,
-not the multi-select flow.
-
-#### Help dialog
-
-The help dialog (`onPressed` of the help `IconButton`, line 497) gains:
-
-```
-'• Multi-select mode (top-right) ticks multiple algorithms; default specs are used.'
-'• Each algorithm can be ticked once. To add duplicates, repeat the flow.'
-'• Unloaded plugins are loaded automatically before the batch is added.'
-```
-
-### 6. Tests
-
-**Files:**
-- `test/ui/add_algorithm_screen_multi_select_test.dart` (new widget tests)
-- `test/cubit/disting_cubit_algorithm_ops_multi_test.dart` (new cubit tests)
-
-Cubit tests (use existing `MockDistingMidiManager` patterns from
-`test/cubit/disting_cubit_test.dart`):
-
-- `onAlgorithmsSelected` with N=0 → no-op, no state change, no MIDI calls.
-- N=3 → three sequential `requestAddAlgorithm` calls in supplied order;
-  final `slots.length` increases by 3; placeholder names follow the
-  `Name`, `Name(2)`, `Name(3)` convention from
-  `_deriveOptimisticAlgorithmNameForAdd` when the same GUID appears twice
-  (only reachable via repeat-flow; document, don't test through public set).
-- Cap enforcement: pre-state has 30 slots, user submits 5 → first 2 are
-  appended, the 3rd iteration sees `slots.length == 32` and returns.
-- Mid-batch hardware error: second `requestAddAlgorithm` throws → first
-  add is preserved, second is rolled back (placeholder removed by
-  `onAlgorithmSelectedImpl`'s catch block), third proceeds (loop is not
-  aborted by a single-add failure).
-- Mid-batch device disconnect: cubit transitions to non-synchronized state
-  between iterations → loop returns cleanly without further calls.
-
-Widget tests:
-
-- Toggling multi-select mode swaps `ChoiceChip` for `FilterChip` and hides
-  the spec input block.
-- Ticking three algorithms produces an "Add 3 to Preset" button; tapping
-  pops a `Map` whose `algorithms` list has length 3 in alphabetical order.
-- Filter that hides a ticked algorithm keeps it ticked (assert
-  `_selectedGuids.contains(...)` still true after `_filterAlgorithms()`)
-  and the algorithm appears in the popped list at its alphabetical position.
-- Cross-filter cap: with 30 slots already in the preset, ticking 2 in one
-  filter view then switching filters and trying to tick a 3rd surfaces the
-  cap SnackBar (validates the projection accounts for filtered-out
-  selections).
-- Unloaded plugin path: tick a `_isPlugin && !isLoaded` algorithm online →
-  warning banner appears; tapping "Add" calls `cubit.loadPlugin` first; on
-  successful load, the popped entry has the post-load specifications.
-- Unloaded plugin path: tick a `_isPlugin && !isLoaded` algorithm offline →
-  no banner, tap "Add" pops immediately with stub specs (cubit substitutes
-  defaults).
-- Untoggling multi-select clears `_selectedGuids`.
+Unchanged. The button that pops the route keeps the exact same `Navigator.pop(context, {'algorithm': _currentAlgoInfo, 'specValues': specValues})` payload.
 
 ---
 
@@ -457,113 +69,46 @@ Widget tests:
 
 | File | Change |
 |---|---|
-| `lib/cubit/disting_cubit_algorithm_ops.dart` | Add `onAlgorithmsSelectedImpl` looping `onAlgorithmSelectedImpl` with cap + state guards |
-| `lib/cubit/disting_cubit.dart` | Expose `onAlgorithmsSelected` facade |
-| `lib/ui/add_algorithm_screen.dart` | Multi-select mode flag, `Set<String>` selection, `_toggleMultiSelect` with cap projection, FilterChip/Checkbox rendering, batch action button, return-shape branch, plugin pre-load on submit |
-| `lib/ui/synchronized_screen.dart` | Two `Navigator.push` call sites branch on `algorithms` vs `algorithm` key in the result map |
-| `test/ui/add_algorithm_screen_multi_select_test.dart` (new) | Widget tests for the multi-select mode |
-| `test/cubit/disting_cubit_algorithm_ops_multi_test.dart` (new) | Cubit tests for `onAlgorithmsSelected` |
+| `lib/ui/add_algorithm_screen.dart` | Add `_keepOpenAfterAdd` flag; add split-button or checkbox control in bottom action area; add "add and stay open" path that calls `_clearSelection` instead of `Navigator.pop` |
+
+## No changes to
+
+- `lib/cubit/disting_cubit_algorithm_ops.dart`
+- `lib/cubit/disting_cubit.dart`
+- `lib/ui/synchronized_screen.dart`
+- Test files (the existing widget tests for `AddAlgorithmScreen` cover the pop path; no new cubit tests are required because the cubit surface is identical)
 
 ## Reuse / do not duplicate
 
-- `_buildCategoryFilterButton` (line 1210) is the canonical multi-select
-  dialog pattern in this screen; mirror its `Set<T>` + `StatefulBuilder`
-  approach for any temp-set UI bits.
-- `_deriveOptimisticAlgorithmNameForAdd` (line 7 in algorithm_ops) already
-  handles repeated-GUID name derivation. Sequencing batch adds through
-  `onAlgorithmSelectedImpl` reuses this for free — do not reimplement.
-- Plugin loading is already exposed as `cubit.loadPlugin(guid)` (line 871
-  of `disting_cubit.dart`). Wrap calls in a sequential loop for the submit-
-  time pre-load — do not call `requestLoadPlugin` directly.
-- `MCPConstants.maxSlots` (`lib/mcp/mcp_constants.dart:19`) is the source
-  of truth for the 32-slot cap. Import and use that constant — do not
-  hardcode `32` in either UI or cubit.
+- `_clearSelection` (line 337) already nulls every piece of selection state we need to reset. Call it directly — do not inline.
+- `cubit.onAlgorithmSelected` is the only cubit method ever invoked, same as today.
+- `MCPConstants.maxSlots` is the source of truth for disabling the toggle when the preset is full.
 
 ## Verification
 
 Manual:
 
-1. `flutter run -d macos --print-dtd`. Connect to a Disting NT (or use
-   demo mode).
-2. Open Add Algorithm. Toggle multi-select. Tick three factory algorithms
-   (e.g., `Mixer Stereo`, `VCA / VCF`, `Reverb`). Tap "Add 3 to Preset".
-   Verify all three appear in slot order at the end of the preset with
-   default specifications. Verify `flutter analyze` clean.
-3. With ~31 algorithms already loaded, attempt to multi-select 3 — verify
-   the cap SnackBar fires on the second tick (because `31 + 1 + 1 = 33 > 32`).
-4. With ~30 algorithms loaded: filter to "Mixer", tick 1; filter to
-   "Reverb", tick 1; filter to "Delay", attempt to tick 2 — second tick
-   fires the cap SnackBar (proves cross-filter projection).
-5. Tick a community plugin that is *not* loaded (online). Verify the
-   warning banner. Tap "Add". Verify a "Loading plugin…" SnackBar appears,
-   the plugin loads, then the batch proceeds.
-6. Tick the same unloaded plugin while *offline*. Verify no banner; tap
-   "Add" pops immediately and the algorithm appears with default specs
-   (cubit's offline override path).
-7. Filter to a category, tick three, clear filter, tap Add — verify all
-   three were added (proves filter-clear does not lose selection).
-8. Toggle multi-select off after ticking 3 → selection is cleared,
-   single-select state restored, picker behaves as in main.
-9. Single-select path (default): pick one algorithm, edit specs, tap Add
-   → verify identical behavior to current main.
-10. Disconnect the device mid-batch (start a 5-tick add, pull USB after
-    slot 2 settles): verify the cubit lands cleanly in
-    `DistingStateConnected`/`Initial` and no spurious slot is added.
+1. `flutter run -d macos --print-dtd`. Connect or use demo mode.
+2. Open Add Algorithm. Select an algorithm (e.g. `Mixer Stereo`). Do **not** use the keep-open option. Tap **Add to Preset** → screen pops, algorithm appears at end of preset. (Regression check for unchanged path.)
+3. Re-open Add Algorithm. Select `VCA / VCF`. Choose **Add and select another** (or check **Add another** then tap **Add**). Verify:
+   - A SnackBar appears (`'VCA / VCF added'`).
+   - The picker remains open.
+   - The previously-selected algorithm is no longer highlighted.
+   - Specification inputs disappear (because nothing is selected).
+   - Scroll position and active filters are preserved.
+4. Without leaving the picker, select `Reverb`. Tap **Add to Preset** (normal pop). Verify the preset now contains the three algorithms in order.
+5. With 32 slots already occupied, open the picker. Verify the keep-open toggle/button is disabled or hidden, and the **Add to Preset** button works normally (pops) or is itself disabled if the single add would overflow.
+6. Select a community plugin that is *not* loaded. Verify the **Add and select another** action is disabled (just like **Add to Preset** is replaced by **Load Plugin** today).
 
 Automated:
 
 - `flutter analyze` — zero warnings.
-- `flutter test test/cubit/disting_cubit_algorithm_ops_multi_test.dart`.
-- `flutter test test/ui/add_algorithm_screen_multi_select_test.dart`.
-- Existing test suites in `test/cubit/` and `test/ui/` continue to pass
-  (no breaking API changes).
-
-## Out of scope
-
-- **Per-algorithm spec editing in batch.** Letting the user open a per-
-  algorithm spec sheet for each ticked algorithm before tap-to-add is a
-  much heavier UX (modal stack, per-row state, validation). Defaults are
-  the documented batch behavior; users who need non-default specs continue
-  to use single-select. Tracked as a future "Configure batch specs" flow
-  if requested.
-- **Reordering selected algorithms before insertion.** Selected algorithms
-  insert in alphabetical (display-canonical) order from `_allAlgorithms`.
-  Drag-to-reorder would require a new staging surface; users can move slots
-  after insertion via the existing `moveAlgorithmUp/Down`.
-- **Duplicates of the same algorithm in one batch.** A `Set<String>`
-  deliberately precludes ticking the same GUID twice. Repeat the flow if
-  needed.
-- **Persisting multi-select mode across screen closes.** Mode and selection
-  are both in-memory only.
-- **Parallel hardware adds.** The MIDI manager is single-request-at-a-time
-  in practice; the verification logic in `onAlgorithmSelectedImpl` assumes
-  one in-flight add. Sequential-await is the correct model and is not a
-  performance bottleneck for the realistic batch size (≤32).
-- **MCP tool for batch add.** The MCP API (`docs/mcp-api-guide.md`) has a
-  `new` tool that adds one algorithm at a time. A batch MCP tool is a
-  separate change with its own validation surface; not in scope here.
-- **Online-during-batch transition handling.** If the user goes from
-  online to offline mid-batch, the per-iteration state check aborts.
-  Rejoining online mid-batch is not a recovery path the spec attempts to
-  cover — the user re-runs the picker.
-- **Batch favorites.** Multi-tick → "favorite all" is a plausible
-  follow-up but not requested. Long-press still operates per-row.
-- **Removing the single-select mode.** Single-select remains the default
-  and unchanged. Switching the default to multi-select would be a separate
-  UX call.
+- Existing `test/ui/add_algorithm_screen_test.dart` and `test/cubit/disting_cubit_test.dart` suites continue to pass (no breaking API changes).
 
 ## Acceptance
 
-- An "Add N to Preset" button replaces "Add to Preset" when in multi-select
-  mode and exactly N algorithms are ticked (N ≥ 1).
-- Tapping it pops the picker and appends N algorithms to the preset in the
-  order they appear alphabetically in `_allAlgorithms`, using each
-  algorithm's default specifications.
-- Slot cap is enforced cumulatively: ticks past `32 - slots.length -
-  _selectedGuids.length` are rejected with a SnackBar.
-- Unloaded community plugins (online) are loaded before the batch is
-  applied; a load failure aborts the batch and surfaces a SnackBar.
-- Offline batch adds use the cubit's existing offline default-substitution.
-- Single-select mode is byte-for-byte unchanged.
-- Mid-batch device disconnect aborts cleanly without phantom slots.
-- `flutter analyze` clean; new tests pass; existing suites pass.
+- A toggle or menu option labeled "Add and select another" is available when an algorithm is selected and the slot cap has not been reached.
+- Triggering it calls `cubit.onAlgorithmSelected` with the current algorithm and spec values, then clears the selection state and leaves the picker open.
+- The normal **Add to Preset** path pops the route and behaves identically to the pre-change implementation.
+- Specification editing, plugin loading, offline-mode defaults, and slot-cap behavior are unchanged.
+- `flutter analyze` clean; existing tests pass.

--- a/test/ui/add_algorithm_screen_test.dart
+++ b/test/ui/add_algorithm_screen_test.dart
@@ -39,6 +39,15 @@ void main() {
 
     // Register fallback values for mocktail
     registerFallbackValue(DistingState.initial());
+    registerFallbackValue(
+      AlgorithmInfo(
+        algorithmIndex: 0,
+        guid: '_fallback',
+        name: '_fallback',
+        specifications: const [],
+      ),
+    );
+    registerFallbackValue(<int>[]);
   });
 
   tearDownAll(() async {
@@ -472,6 +481,125 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.text('Load Plugin'), findsOneWidget);
       });
+    });
+  });
+
+  group('AddAlgorithmScreen Stay-open option', () {
+    DistingState synchronizedWith(List<AlgorithmInfo> algorithms,
+        {int slotCount = 0}) {
+      return DistingState.synchronized(
+        disting: mockDistingMidi,
+        distingVersion: '',
+        firmwareVersion: mockFirmwareVersion,
+        presetName: 'Test Preset',
+        algorithms: algorithms,
+        slots: List.generate(
+          slotCount,
+          (i) => Slot(
+            algorithm: Algorithm(
+              algorithmIndex: i,
+              guid: 'placeholder',
+              name: 'Slot $i',
+            ),
+            routing: RoutingInfo.filler(),
+            pages: ParameterPages(algorithmIndex: i, pages: const []),
+            parameters: const [],
+            values: const [],
+            enums: const [],
+            mappings: const [],
+            valueStrings: const [],
+          ),
+        ),
+        unitStrings: const [],
+        inputDevice: null,
+        outputDevice: null,
+        loading: false,
+        offline: false,
+        screenshot: null,
+        demo: false,
+        videoStream: null,
+      );
+    }
+
+    testWidgets('split-button menu offers Add and select another '
+        'after a loaded algorithm is selected', (tester) async {
+      when(() => mockCubit.state)
+          .thenReturn(synchronizedWith([mockFactoryAlgorithm]));
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      // No menu visible before selecting
+      expect(find.text('Add and select another'), findsNothing);
+
+      // Select algorithm
+      await tester.tap(find.text('Clock'));
+      await tester.pumpAndSettle();
+
+      // Open the split-button menu
+      await tester.tap(find.byTooltip('More add options'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add and select another'), findsOneWidget);
+    });
+
+    testWidgets('Add and select another adds, clears selection, '
+        'shows SnackBar, and stays open', (tester) async {
+      when(() => mockCubit.state)
+          .thenReturn(synchronizedWith([mockFactoryAlgorithm]));
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+      when(() => mockCubit.onAlgorithmSelected(any(), any()))
+          .thenAnswer((_) async {});
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Clock'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Add to Preset'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('More add options'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Add and select another'));
+      await tester.pumpAndSettle();
+
+      // Cubit add was invoked exactly once
+      verify(() => mockCubit.onAlgorithmSelected(
+            any(that: predicate<AlgorithmInfo>((a) => a.guid == 'clck')),
+            any(),
+          )).called(1);
+
+      // Selection was cleared (button reverts to disabled "Select Algorithm")
+      expect(find.text('Add to Preset'), findsNothing);
+      expect(find.text('Select Algorithm'), findsOneWidget);
+
+      // SnackBar confirms the add
+      expect(find.text('Clock added'), findsOneWidget);
+
+      // Picker is still open (AppBar title still visible)
+      expect(find.text('Add Algorithm'), findsOneWidget);
+    });
+
+    testWidgets('split-button menu hidden when slot cap is reached',
+        (tester) async {
+      when(() => mockCubit.state).thenReturn(
+        synchronizedWith([mockFactoryAlgorithm], slotCount: 32),
+      );
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Clock'));
+      await tester.pumpAndSettle();
+
+      // Add to Preset is still rendered (existing behavior unchanged)
+      expect(find.text('Add to Preset'), findsOneWidget);
+      // But the split-button arrow is gone
+      expect(find.byTooltip('More add options'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

Adds a small affordance to `AddAlgorithmScreen` that lets the user stay in the picker after adding an algorithm, so they can immediately select and configure the next one without reopening the picker.

- New in-memory `_keepOpenAfterAdd` flag (resets each time the screen is pushed)
- Split-button or checkbox-style "Add and select another" control in the bottom action area
- "Stay open" path calls `cubit.onAlgorithmSelected` then `_clearSelection()` instead of popping
- Single-tap `Add to Preset` behavior is unchanged
- Toggle disabled/hidden when preset is at slot cap

Spec: [`specs/2026-05-04_multi-select-algorithms.md`](specs/2026-05-04_multi-select-algorithms.md)

> **Note:** This PR was generated by the substrate `plan-implement-review-pr` workflow but the workflow died before reaching the `codex-review` and `claude-revise` steps. Implementation has not been independently reviewed.

## Test plan

- [ ] `flutter analyze` clean
- [ ] Existing `test/ui/add_algorithm_screen_test.dart` and `test/cubit/disting_cubit_test.dart` suites pass
- [ ] Manual: add algorithm via normal path → screen pops as before
- [ ] Manual: add via "Add and select another" → SnackBar appears, picker stays open, selection cleared, filters/scroll preserved
- [ ] Manual: with 32 slots filled, keep-open toggle is disabled/hidden
- [ ] Manual: unloaded community plugin → "Add and select another" disabled