### PR TITLE
feat: preset dirty indicator (unsaved changes)

### DIFF
--- a/lib/cubit/disting_cubit.dart
+++ b/lib/cubit/disting_cubit.dart
@@ -187,6 +187,7 @@ class DistingCubit extends _DistingCubitBase
             videoStream,
             availableFirmwareUpdate,
             perfPageItems,
+            isDirty,
           ) => videoStream,
       orElse: () => null,
     ),

--- a/lib/cubit/disting_cubit.dart
+++ b/lib/cubit/disting_cubit.dart
@@ -437,6 +437,20 @@ class DistingCubit extends _DistingCubitBase
     return newPresetImpl();
   }
 
+  /// Save the current preset to persistent device storage and clear
+  /// the in-memory dirty flag on success. A failed save leaves the
+  /// flag set so the user retains the unsaved-changes indicator.
+  Future<void> savePreset() async {
+    final s = state;
+    if (s is! DistingStateSynchronized) return;
+    final disting = s.disting;
+    await disting.requestSavePreset();
+    final after = state;
+    if (after is DistingStateSynchronized) {
+      _emitState(after.copyWith(isDirty: false));
+    }
+  }
+
   Future<void> loadPreset(String name, bool append) async {
     if (!append) _checkpointDelegate.clearCheckpoints();
     return loadPresetImpl(name, append);

--- a/lib/cubit/disting_cubit.freezed.dart
+++ b/lib/cubit/disting_cubit.freezed.dart
@@ -738,13 +738,13 @@ return synchronized(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  initial,TResult Function( List<MidiDevice> inputDevices,  List<MidiDevice> outputDevices,  bool canWorkOffline)?  selectDevice,TResult Function( IDistingMidiManager disting,  MidiDevice? inputDevice,  MidiDevice? outputDevice,  bool offline,  bool loading,  String? syncStatus,  double? syncProgress)?  connected,TResult Function( IDistingMidiManager disting,  String distingVersion,  FirmwareVersion firmwareVersion,  String presetName,  List<AlgorithmInfo> algorithms,  List<Slot> slots,  List<String> unitStrings,  MidiDevice? inputDevice,  MidiDevice? outputDevice,  bool loading,  bool offline,  Uint8List? screenshot,  bool demo,  VideoStreamState? videoStream,  FirmwareRelease? availableFirmwareUpdate,  List<PerformancePageItem> perfPageItems)?  synchronized,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  initial,TResult Function( List<MidiDevice> inputDevices,  List<MidiDevice> outputDevices,  bool canWorkOffline)?  selectDevice,TResult Function( IDistingMidiManager disting,  MidiDevice? inputDevice,  MidiDevice? outputDevice,  bool offline,  bool loading,  String? syncStatus,  double? syncProgress)?  connected,TResult Function( IDistingMidiManager disting,  String distingVersion,  FirmwareVersion firmwareVersion,  String presetName,  List<AlgorithmInfo> algorithms,  List<Slot> slots,  List<String> unitStrings,  MidiDevice? inputDevice,  MidiDevice? outputDevice,  bool loading,  bool offline,  Uint8List? screenshot,  bool demo,  VideoStreamState? videoStream,  FirmwareRelease? availableFirmwareUpdate,  List<PerformancePageItem> perfPageItems,  bool isDirty)?  synchronized,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case DistingStateInitial() when initial != null:
 return initial();case DistingStateSelectDevice() when selectDevice != null:
 return selectDevice(_that.inputDevices,_that.outputDevices,_that.canWorkOffline);case DistingStateConnected() when connected != null:
 return connected(_that.disting,_that.inputDevice,_that.outputDevice,_that.offline,_that.loading,_that.syncStatus,_that.syncProgress);case DistingStateSynchronized() when synchronized != null:
-return synchronized(_that.disting,_that.distingVersion,_that.firmwareVersion,_that.presetName,_that.algorithms,_that.slots,_that.unitStrings,_that.inputDevice,_that.outputDevice,_that.loading,_that.offline,_that.screenshot,_that.demo,_that.videoStream,_that.availableFirmwareUpdate,_that.perfPageItems);case _:
+return synchronized(_that.disting,_that.distingVersion,_that.firmwareVersion,_that.presetName,_that.algorithms,_that.slots,_that.unitStrings,_that.inputDevice,_that.outputDevice,_that.loading,_that.offline,_that.screenshot,_that.demo,_that.videoStream,_that.availableFirmwareUpdate,_that.perfPageItems,_that.isDirty);case _:
   return orElse();
 
 }
@@ -762,13 +762,13 @@ return synchronized(_that.disting,_that.distingVersion,_that.firmwareVersion,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  initial,required TResult Function( List<MidiDevice> inputDevices,  List<MidiDevice> outputDevices,  bool canWorkOffline)  selectDevice,required TResult Function( IDistingMidiManager disting,  MidiDevice? inputDevice,  MidiDevice? outputDevice,  bool offline,  bool loading,  String? syncStatus,  double? syncProgress)  connected,required TResult Function( IDistingMidiManager disting,  String distingVersion,  FirmwareVersion firmwareVersion,  String presetName,  List<AlgorithmInfo> algorithms,  List<Slot> slots,  List<String> unitStrings,  MidiDevice? inputDevice,  MidiDevice? outputDevice,  bool loading,  bool offline,  Uint8List? screenshot,  bool demo,  VideoStreamState? videoStream,  FirmwareRelease? availableFirmwareUpdate,  List<PerformancePageItem> perfPageItems)  synchronized,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  initial,required TResult Function( List<MidiDevice> inputDevices,  List<MidiDevice> outputDevices,  bool canWorkOffline)  selectDevice,required TResult Function( IDistingMidiManager disting,  MidiDevice? inputDevice,  MidiDevice? outputDevice,  bool offline,  bool loading,  String? syncStatus,  double? syncProgress)  connected,required TResult Function( IDistingMidiManager disting,  String distingVersion,  FirmwareVersion firmwareVersion,  String presetName,  List<AlgorithmInfo> algorithms,  List<Slot> slots,  List<String> unitStrings,  MidiDevice? inputDevice,  MidiDevice? outputDevice,  bool loading,  bool offline,  Uint8List? screenshot,  bool demo,  VideoStreamState? videoStream,  FirmwareRelease? availableFirmwareUpdate,  List<PerformancePageItem> perfPageItems,  bool isDirty)  synchronized,}) {final _that = this;
 switch (_that) {
 case DistingStateInitial():
 return initial();case DistingStateSelectDevice():
 return selectDevice(_that.inputDevices,_that.outputDevices,_that.canWorkOffline);case DistingStateConnected():
 return connected(_that.disting,_that.inputDevice,_that.outputDevice,_that.offline,_that.loading,_that.syncStatus,_that.syncProgress);case DistingStateSynchronized():
-return synchronized(_that.disting,_that.distingVersion,_that.firmwareVersion,_that.presetName,_that.algorithms,_that.slots,_that.unitStrings,_that.inputDevice,_that.outputDevice,_that.loading,_that.offline,_that.screenshot,_that.demo,_that.videoStream,_that.availableFirmwareUpdate,_that.perfPageItems);}
+return synchronized(_that.disting,_that.distingVersion,_that.firmwareVersion,_that.presetName,_that.algorithms,_that.slots,_that.unitStrings,_that.inputDevice,_that.outputDevice,_that.loading,_that.offline,_that.screenshot,_that.demo,_that.videoStream,_that.availableFirmwareUpdate,_that.perfPageItems,_that.isDirty);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -782,13 +782,13 @@ return synchronized(_that.disting,_that.distingVersion,_that.firmwareVersion,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  initial,TResult? Function( List<MidiDevice> inputDevices,  List<MidiDevice> outputDevices,  bool canWorkOffline)?  selectDevice,TResult? Function( IDistingMidiManager disting,  MidiDevice? inputDevice,  MidiDevice? outputDevice,  bool offline,  bool loading,  String? syncStatus,  double? syncProgress)?  connected,TResult? Function( IDistingMidiManager disting,  String distingVersion,  FirmwareVersion firmwareVersion,  String presetName,  List<AlgorithmInfo> algorithms,  List<Slot> slots,  List<String> unitStrings,  MidiDevice? inputDevice,  MidiDevice? outputDevice,  bool loading,  bool offline,  Uint8List? screenshot,  bool demo,  VideoStreamState? videoStream,  FirmwareRelease? availableFirmwareUpdate,  List<PerformancePageItem> perfPageItems)?  synchronized,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  initial,TResult? Function( List<MidiDevice> inputDevices,  List<MidiDevice> outputDevices,  bool canWorkOffline)?  selectDevice,TResult? Function( IDistingMidiManager disting,  MidiDevice? inputDevice,  MidiDevice? outputDevice,  bool offline,  bool loading,  String? syncStatus,  double? syncProgress)?  connected,TResult? Function( IDistingMidiManager disting,  String distingVersion,  FirmwareVersion firmwareVersion,  String presetName,  List<AlgorithmInfo> algorithms,  List<Slot> slots,  List<String> unitStrings,  MidiDevice? inputDevice,  MidiDevice? outputDevice,  bool loading,  bool offline,  Uint8List? screenshot,  bool demo,  VideoStreamState? videoStream,  FirmwareRelease? availableFirmwareUpdate,  List<PerformancePageItem> perfPageItems,  bool isDirty)?  synchronized,}) {final _that = this;
 switch (_that) {
 case DistingStateInitial() when initial != null:
 return initial();case DistingStateSelectDevice() when selectDevice != null:
 return selectDevice(_that.inputDevices,_that.outputDevices,_that.canWorkOffline);case DistingStateConnected() when connected != null:
 return connected(_that.disting,_that.inputDevice,_that.outputDevice,_that.offline,_that.loading,_that.syncStatus,_that.syncProgress);case DistingStateSynchronized() when synchronized != null:
-return synchronized(_that.disting,_that.distingVersion,_that.firmwareVersion,_that.presetName,_that.algorithms,_that.slots,_that.unitStrings,_that.inputDevice,_that.outputDevice,_that.loading,_that.offline,_that.screenshot,_that.demo,_that.videoStream,_that.availableFirmwareUpdate,_that.perfPageItems);case _:
+return synchronized(_that.disting,_that.distingVersion,_that.firmwareVersion,_that.presetName,_that.algorithms,_that.slots,_that.unitStrings,_that.inputDevice,_that.outputDevice,_that.loading,_that.offline,_that.screenshot,_that.demo,_that.videoStream,_that.availableFirmwareUpdate,_that.perfPageItems,_that.isDirty);case _:
   return null;
 
 }
@@ -1010,7 +1010,7 @@ as double?,
 
 
 class DistingStateSynchronized with DiagnosticableTreeMixin implements DistingState {
-  const DistingStateSynchronized({required this.disting, required this.distingVersion, required this.firmwareVersion, required this.presetName, required final  List<AlgorithmInfo> algorithms, required final  List<Slot> slots, required final  List<String> unitStrings, this.inputDevice = null, this.outputDevice = null, this.loading = false, this.offline = false, this.screenshot = null, this.demo = false, this.videoStream = null, this.availableFirmwareUpdate = null, final  List<PerformancePageItem> perfPageItems = const []}): _algorithms = algorithms,_slots = slots,_unitStrings = unitStrings,_perfPageItems = perfPageItems;
+  const DistingStateSynchronized({required this.disting, required this.distingVersion, required this.firmwareVersion, required this.presetName, required final  List<AlgorithmInfo> algorithms, required final  List<Slot> slots, required final  List<String> unitStrings, this.inputDevice = null, this.outputDevice = null, this.loading = false, this.offline = false, this.screenshot = null, this.demo = false, this.videoStream = null, this.availableFirmwareUpdate = null, final  List<PerformancePageItem> perfPageItems = const [], this.isDirty = false}): _algorithms = algorithms,_slots = slots,_unitStrings = unitStrings,_perfPageItems = perfPageItems;
   
 
  final  IDistingMidiManager disting;
@@ -1056,6 +1056,9 @@ class DistingStateSynchronized with DiagnosticableTreeMixin implements DistingSt
   return EqualUnmodifiableListView(_perfPageItems);
 }
 
+/// True when the in-memory preset has been mutated since the last
+/// save / load / new / device refresh. Cleared on save/load/new/refresh.
+@JsonKey() final  bool isDirty;
 
 /// Create a copy of DistingState
 /// with the given fields replaced by the non-null parameter values.
@@ -1068,21 +1071,21 @@ $DistingStateSynchronizedCopyWith<DistingStateSynchronized> get copyWith => _$Di
 void debugFillProperties(DiagnosticPropertiesBuilder properties) {
   properties
     ..add(DiagnosticsProperty('type', 'DistingState.synchronized'))
-    ..add(DiagnosticsProperty('disting', disting))..add(DiagnosticsProperty('distingVersion', distingVersion))..add(DiagnosticsProperty('firmwareVersion', firmwareVersion))..add(DiagnosticsProperty('presetName', presetName))..add(DiagnosticsProperty('algorithms', algorithms))..add(DiagnosticsProperty('slots', slots))..add(DiagnosticsProperty('unitStrings', unitStrings))..add(DiagnosticsProperty('inputDevice', inputDevice))..add(DiagnosticsProperty('outputDevice', outputDevice))..add(DiagnosticsProperty('loading', loading))..add(DiagnosticsProperty('offline', offline))..add(DiagnosticsProperty('screenshot', screenshot))..add(DiagnosticsProperty('demo', demo))..add(DiagnosticsProperty('videoStream', videoStream))..add(DiagnosticsProperty('availableFirmwareUpdate', availableFirmwareUpdate))..add(DiagnosticsProperty('perfPageItems', perfPageItems));
+    ..add(DiagnosticsProperty('disting', disting))..add(DiagnosticsProperty('distingVersion', distingVersion))..add(DiagnosticsProperty('firmwareVersion', firmwareVersion))..add(DiagnosticsProperty('presetName', presetName))..add(DiagnosticsProperty('algorithms', algorithms))..add(DiagnosticsProperty('slots', slots))..add(DiagnosticsProperty('unitStrings', unitStrings))..add(DiagnosticsProperty('inputDevice', inputDevice))..add(DiagnosticsProperty('outputDevice', outputDevice))..add(DiagnosticsProperty('loading', loading))..add(DiagnosticsProperty('offline', offline))..add(DiagnosticsProperty('screenshot', screenshot))..add(DiagnosticsProperty('demo', demo))..add(DiagnosticsProperty('videoStream', videoStream))..add(DiagnosticsProperty('availableFirmwareUpdate', availableFirmwareUpdate))..add(DiagnosticsProperty('perfPageItems', perfPageItems))..add(DiagnosticsProperty('isDirty', isDirty));
 }
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is DistingStateSynchronized&&(identical(other.disting, disting) || other.disting == disting)&&(identical(other.distingVersion, distingVersion) || other.distingVersion == distingVersion)&&(identical(other.firmwareVersion, firmwareVersion) || other.firmwareVersion == firmwareVersion)&&(identical(other.presetName, presetName) || other.presetName == presetName)&&const DeepCollectionEquality().equals(other._algorithms, _algorithms)&&const DeepCollectionEquality().equals(other._slots, _slots)&&const DeepCollectionEquality().equals(other._unitStrings, _unitStrings)&&(identical(other.inputDevice, inputDevice) || other.inputDevice == inputDevice)&&(identical(other.outputDevice, outputDevice) || other.outputDevice == outputDevice)&&(identical(other.loading, loading) || other.loading == loading)&&(identical(other.offline, offline) || other.offline == offline)&&const DeepCollectionEquality().equals(other.screenshot, screenshot)&&(identical(other.demo, demo) || other.demo == demo)&&(identical(other.videoStream, videoStream) || other.videoStream == videoStream)&&(identical(other.availableFirmwareUpdate, availableFirmwareUpdate) || other.availableFirmwareUpdate == availableFirmwareUpdate)&&const DeepCollectionEquality().equals(other._perfPageItems, _perfPageItems));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DistingStateSynchronized&&(identical(other.disting, disting) || other.disting == disting)&&(identical(other.distingVersion, distingVersion) || other.distingVersion == distingVersion)&&(identical(other.firmwareVersion, firmwareVersion) || other.firmwareVersion == firmwareVersion)&&(identical(other.presetName, presetName) || other.presetName == presetName)&&const DeepCollectionEquality().equals(other._algorithms, _algorithms)&&const DeepCollectionEquality().equals(other._slots, _slots)&&const DeepCollectionEquality().equals(other._unitStrings, _unitStrings)&&(identical(other.inputDevice, inputDevice) || other.inputDevice == inputDevice)&&(identical(other.outputDevice, outputDevice) || other.outputDevice == outputDevice)&&(identical(other.loading, loading) || other.loading == loading)&&(identical(other.offline, offline) || other.offline == offline)&&const DeepCollectionEquality().equals(other.screenshot, screenshot)&&(identical(other.demo, demo) || other.demo == demo)&&(identical(other.videoStream, videoStream) || other.videoStream == videoStream)&&(identical(other.availableFirmwareUpdate, availableFirmwareUpdate) || other.availableFirmwareUpdate == availableFirmwareUpdate)&&const DeepCollectionEquality().equals(other._perfPageItems, _perfPageItems)&&(identical(other.isDirty, isDirty) || other.isDirty == isDirty));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,disting,distingVersion,firmwareVersion,presetName,const DeepCollectionEquality().hash(_algorithms),const DeepCollectionEquality().hash(_slots),const DeepCollectionEquality().hash(_unitStrings),inputDevice,outputDevice,loading,offline,const DeepCollectionEquality().hash(screenshot),demo,videoStream,availableFirmwareUpdate,const DeepCollectionEquality().hash(_perfPageItems));
+int get hashCode => Object.hash(runtimeType,disting,distingVersion,firmwareVersion,presetName,const DeepCollectionEquality().hash(_algorithms),const DeepCollectionEquality().hash(_slots),const DeepCollectionEquality().hash(_unitStrings),inputDevice,outputDevice,loading,offline,const DeepCollectionEquality().hash(screenshot),demo,videoStream,availableFirmwareUpdate,const DeepCollectionEquality().hash(_perfPageItems),isDirty);
 
 @override
 String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
-  return 'DistingState.synchronized(disting: $disting, distingVersion: $distingVersion, firmwareVersion: $firmwareVersion, presetName: $presetName, algorithms: $algorithms, slots: $slots, unitStrings: $unitStrings, inputDevice: $inputDevice, outputDevice: $outputDevice, loading: $loading, offline: $offline, screenshot: $screenshot, demo: $demo, videoStream: $videoStream, availableFirmwareUpdate: $availableFirmwareUpdate, perfPageItems: $perfPageItems)';
+  return 'DistingState.synchronized(disting: $disting, distingVersion: $distingVersion, firmwareVersion: $firmwareVersion, presetName: $presetName, algorithms: $algorithms, slots: $slots, unitStrings: $unitStrings, inputDevice: $inputDevice, outputDevice: $outputDevice, loading: $loading, offline: $offline, screenshot: $screenshot, demo: $demo, videoStream: $videoStream, availableFirmwareUpdate: $availableFirmwareUpdate, perfPageItems: $perfPageItems, isDirty: $isDirty)';
 }
 
 
@@ -1093,7 +1096,7 @@ abstract mixin class $DistingStateSynchronizedCopyWith<$Res> implements $Disting
   factory $DistingStateSynchronizedCopyWith(DistingStateSynchronized value, $Res Function(DistingStateSynchronized) _then) = _$DistingStateSynchronizedCopyWithImpl;
 @useResult
 $Res call({
- IDistingMidiManager disting, String distingVersion, FirmwareVersion firmwareVersion, String presetName, List<AlgorithmInfo> algorithms, List<Slot> slots, List<String> unitStrings, MidiDevice? inputDevice, MidiDevice? outputDevice, bool loading, bool offline, Uint8List? screenshot, bool demo, VideoStreamState? videoStream, FirmwareRelease? availableFirmwareUpdate, List<PerformancePageItem> perfPageItems
+ IDistingMidiManager disting, String distingVersion, FirmwareVersion firmwareVersion, String presetName, List<AlgorithmInfo> algorithms, List<Slot> slots, List<String> unitStrings, MidiDevice? inputDevice, MidiDevice? outputDevice, bool loading, bool offline, Uint8List? screenshot, bool demo, VideoStreamState? videoStream, FirmwareRelease? availableFirmwareUpdate, List<PerformancePageItem> perfPageItems, bool isDirty
 });
 
 
@@ -1110,7 +1113,7 @@ class _$DistingStateSynchronizedCopyWithImpl<$Res>
 
 /// Create a copy of DistingState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? disting = null,Object? distingVersion = null,Object? firmwareVersion = null,Object? presetName = null,Object? algorithms = null,Object? slots = null,Object? unitStrings = null,Object? inputDevice = freezed,Object? outputDevice = freezed,Object? loading = null,Object? offline = null,Object? screenshot = freezed,Object? demo = null,Object? videoStream = freezed,Object? availableFirmwareUpdate = freezed,Object? perfPageItems = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? disting = null,Object? distingVersion = null,Object? firmwareVersion = null,Object? presetName = null,Object? algorithms = null,Object? slots = null,Object? unitStrings = null,Object? inputDevice = freezed,Object? outputDevice = freezed,Object? loading = null,Object? offline = null,Object? screenshot = freezed,Object? demo = null,Object? videoStream = freezed,Object? availableFirmwareUpdate = freezed,Object? perfPageItems = null,Object? isDirty = null,}) {
   return _then(DistingStateSynchronized(
 disting: null == disting ? _self.disting : disting // ignore: cast_nullable_to_non_nullable
 as IDistingMidiManager,distingVersion: null == distingVersion ? _self.distingVersion : distingVersion // ignore: cast_nullable_to_non_nullable
@@ -1128,7 +1131,8 @@ as Uint8List?,demo: null == demo ? _self.demo : demo // ignore: cast_nullable_to
 as bool,videoStream: freezed == videoStream ? _self.videoStream : videoStream // ignore: cast_nullable_to_non_nullable
 as VideoStreamState?,availableFirmwareUpdate: freezed == availableFirmwareUpdate ? _self.availableFirmwareUpdate : availableFirmwareUpdate // ignore: cast_nullable_to_non_nullable
 as FirmwareRelease?,perfPageItems: null == perfPageItems ? _self._perfPageItems : perfPageItems // ignore: cast_nullable_to_non_nullable
-as List<PerformancePageItem>,
+as List<PerformancePageItem>,isDirty: null == isDirty ? _self.isDirty : isDirty // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/lib/cubit/disting_cubit_algorithm_ops.dart
+++ b/lib/cubit/disting_cubit_algorithm_ops.dart
@@ -403,6 +403,7 @@ mixin _DistingCubitAlgorithmOps on _DistingCubitBase {
                 loading: false,
                 demo: verificationState.demo,
                 offline: verificationState.offline,
+                isDirty: verificationState.isDirty,
               ),
             );
             _rebuildCcLookup();
@@ -522,6 +523,7 @@ mixin _DistingCubitAlgorithmOps on _DistingCubitBase {
                 loading: false,
                 demo: verificationState.demo,
                 offline: verificationState.offline,
+                isDirty: verificationState.isDirty,
               ),
             );
             _rebuildCcLookup();

--- a/lib/cubit/disting_cubit_algorithm_ops.dart
+++ b/lib/cubit/disting_cubit_algorithm_ops.dart
@@ -111,6 +111,7 @@ mixin _DistingCubitAlgorithmOps on _DistingCubitBase {
           syncstate.copyWith(
             slots: [...syncstate.slots, placeholder],
             loading: false,
+            isDirty: true,
           ),
         );
 
@@ -123,7 +124,12 @@ mixin _DistingCubitAlgorithmOps on _DistingCubitBase {
           final st = state;
           if (st is DistingStateSynchronized &&
               st.slots.length == syncstate.slots.length + 1) {
-            emit(st.copyWith(slots: List<Slot>.from(st.slots)..removeLast()));
+            emit(
+              st.copyWith(
+                slots: List<Slot>.from(st.slots)..removeLast(),
+                isDirty: true,
+              ),
+            );
           }
           return;
         }
@@ -220,7 +226,13 @@ mixin _DistingCubitAlgorithmOps on _DistingCubitBase {
         }
 
         // Emit optimistic state
-        emit(syncstate.copyWith(slots: optimisticSlots, loading: false));
+        emit(
+          syncstate.copyWith(
+            slots: optimisticSlots,
+            loading: false,
+            isDirty: true,
+          ),
+        );
 
         _rebuildCcLookup();
 
@@ -316,7 +328,13 @@ mixin _DistingCubitAlgorithmOps on _DistingCubitBase {
         correctedSwappedSlot; // Swapped slot goes to the lower position
 
     // Emit optimistic state
-    emit(syncstate.copyWith(slots: optimisticSlotsCorrected, loading: false));
+    emit(
+      syncstate.copyWith(
+        slots: optimisticSlotsCorrected,
+        loading: false,
+        isDirty: true,
+      ),
+    );
 
     _rebuildCcLookup();
 
@@ -434,7 +452,13 @@ mixin _DistingCubitAlgorithmOps on _DistingCubitBase {
         correctedMovedSlot; // Moved slot goes to the lower position
 
     // Emit optimistic state
-    emit(syncstate.copyWith(slots: optimisticSlotsCorrected, loading: false));
+    emit(
+      syncstate.copyWith(
+        slots: optimisticSlotsCorrected,
+        loading: false,
+        isDirty: true,
+      ),
+    );
 
     _rebuildCcLookup();
 

--- a/lib/cubit/disting_cubit_mapping_delegate.dart
+++ b/lib/cubit/disting_cubit_mapping_delegate.dart
@@ -15,6 +15,10 @@ class _MappingDelegate {
         final disting = _cubit.requireDisting();
         await disting.requestSetMapping(algorithmIndex, parameterNumber, data);
         await _cubit._refreshStateFromManager();
+        final after = _cubit.state;
+        if (after is DistingStateSynchronized) {
+          _cubit._emitState(after.copyWith(isDirty: true));
+        }
         break;
       default:
       // Handle other cases or errors
@@ -92,6 +96,7 @@ class _MappingDelegate {
             ),
           );
         }),
+        isDirty: true,
       ),
     );
 

--- a/lib/cubit/disting_cubit_parameter_string_delegate.dart
+++ b/lib/cubit/disting_cubit_parameter_string_delegate.dart
@@ -40,7 +40,12 @@ class _ParameterStringDelegate {
       final updatedSlots = List<Slot>.from(currentState.slots);
       updatedSlots[algorithmIndex] = updatedSlot;
 
-      _cubit._emitState(currentState.copyWith(slots: updatedSlots));
+      _cubit._emitState(
+        currentState.copyWith(
+          slots: updatedSlots,
+          isDirty: currentState.isDirty,
+        ),
+      );
     } catch (e, stackTrace) {
       debugPrintStack(stackTrace: stackTrace);
     }
@@ -90,7 +95,12 @@ class _ParameterStringDelegate {
       final updatedSlots = List<Slot>.from(currentState.slots);
       updatedSlots[algorithmIndex] = updatedSlot;
 
-      _cubit._emitState(currentState.copyWith(slots: updatedSlots));
+      _cubit._emitState(
+        currentState.copyWith(
+          slots: updatedSlots,
+          isDirty: currentState.isDirty,
+        ),
+      );
     } catch (e, stackTrace) {
       debugPrintStack(stackTrace: stackTrace);
     }
@@ -139,6 +149,7 @@ class _ParameterStringDelegate {
                     ),
                   );
                 }),
+                isDirty: true,
               ),
             );
           }

--- a/lib/cubit/disting_cubit_parameter_value_delegate.dart
+++ b/lib/cubit/disting_cubit_parameter_value_delegate.dart
@@ -67,6 +67,7 @@ class _ParameterValueDelegate {
                     ),
                   );
                 }),
+                isDirty: true,
               ),
             );
           } else {
@@ -115,6 +116,7 @@ class _ParameterValueDelegate {
                     ),
                   );
                 }),
+                isDirty: true,
               ),
             );
 

--- a/lib/cubit/disting_cubit_perf_page_delegate.dart
+++ b/lib/cubit/disting_cubit_perf_page_delegate.dart
@@ -31,7 +31,9 @@ class _PerfPageDelegate {
     if (item.itemIndex >= 0 && item.itemIndex < updatedItems.length) {
       updatedItems[item.itemIndex] = item;
     }
-    _cubit._emitState(currentState.copyWith(perfPageItems: updatedItems));
+    _cubit._emitState(
+      currentState.copyWith(perfPageItems: updatedItems, isDirty: true),
+    );
 
     // Send to hardware
     disting.setPerfPageItem(item).catchError((e, s) {
@@ -60,7 +62,10 @@ class _PerfPageDelegate {
                 fixedItems[item.itemIndex] = actual;
               }
               _cubit._emitState(
-                verifyState.copyWith(perfPageItems: fixedItems),
+                verifyState.copyWith(
+                  perfPageItems: fixedItems,
+                  isDirty: true,
+                ),
               );
             }
           }

--- a/lib/cubit/disting_cubit_preset_ops.dart
+++ b/lib/cubit/disting_cubit_preset_ops.dart
@@ -36,7 +36,13 @@ mixin _DistingCubitPresetOps on _DistingCubitBase {
       if (trimmed.isEmpty || trimmed == currentState.presetName) return;
 
       // 1) Optimistic update for instant UI response
-      emit(currentState.copyWith(presetName: trimmed, loading: false));
+      emit(
+        currentState.copyWith(
+          presetName: trimmed,
+          loading: false,
+          isDirty: true,
+        ),
+      );
 
       // 2) Send request in background (works for online + offline managers)
       final disting = currentState.disting;

--- a/lib/cubit/disting_cubit_slot_ops.dart
+++ b/lib/cubit/disting_cubit_slot_ops.dart
@@ -30,7 +30,13 @@ mixin _DistingCubitSlotOps on _DistingCubitBase {
         currentState.slots,
         (s) => s.copyWith(algorithm: optimisticAlgorithm),
       );
-      emit(currentState.copyWith(slots: optimisticSlots, loading: false));
+      emit(
+        currentState.copyWith(
+          slots: optimisticSlots,
+          loading: false,
+          isDirty: true,
+        ),
+      );
 
       // 2) Send request in background
       final disting = requireDisting();
@@ -66,7 +72,12 @@ mixin _DistingCubitSlotOps on _DistingCubitBase {
                   verificationState.slots,
                   (s) => s.copyWith(algorithm: actual),
                 );
-                emit(verificationState.copyWith(slots: correctedSlots));
+                emit(
+                  verificationState.copyWith(
+                    slots: correctedSlots,
+                    isDirty: true,
+                  ),
+                );
               }
             }),
             onCancel: () {},

--- a/lib/cubit/disting_cubit_state_refresh_delegate.dart
+++ b/lib/cubit/disting_cubit_state_refresh_delegate.dart
@@ -37,6 +37,7 @@ class _StateRefreshDelegate {
           presetName: presetName,
           slots: slots,
           perfPageItems: perfPageItems ?? currentState.perfPageItems,
+          isDirty: false,
         ),
       );
 

--- a/lib/cubit/disting_state.dart
+++ b/lib/cubit/disting_state.dart
@@ -68,5 +68,8 @@ sealed class DistingState with _$DistingState {
     @Default(null) FirmwareRelease? availableFirmwareUpdate,
     /// Performance page items (firmware v1.16+, populated via SysEx 0x57/0x58)
     @Default([]) List<PerformancePageItem> perfPageItems,
+    /// True when the in-memory preset has been mutated since the last
+    /// save / load / new / device refresh. Cleared on save/load/new/refresh.
+    @Default(false) bool isDirty,
   }) = DistingStateSynchronized;
 }

--- a/lib/cubit/routing_editor_cubit.dart
+++ b/lib/cubit/routing_editor_cubit.dart
@@ -118,6 +118,7 @@ class RoutingEditorCubit extends Cubit<RoutingEditorState> {
             videoStream,
             availableFirmwareUpdate,
             perfPageItems,
+            isDirty,
           ) {
             _processSynchronizedState(slots);
           },

--- a/lib/disting_app.dart
+++ b/lib/disting_app.dart
@@ -435,6 +435,7 @@ class _DistingPageState extends State<DistingPage> {
                 units: state.unitStrings,
                 distingVersion: state.distingVersion,
                 presetName: state.presetName,
+                isDirty: state.isDirty,
                 screenshot: state.screenshot,
                 loading: state.loading,
                 firmwareVersion: state.firmwareVersion,

--- a/lib/services/disting_controller_impl.dart
+++ b/lib/services/disting_controller_impl.dart
@@ -326,7 +326,7 @@ class DistingControllerImpl implements DistingController {
   @override
   Future<void> savePreset() async {
     _getSynchronizedState();
-    await _getManager().requestSavePreset();
+    await _distingCubit.savePreset();
   }
 
   @override

--- a/lib/ui/step_sequencer_view.dart
+++ b/lib/ui/step_sequencer_view.dart
@@ -128,6 +128,7 @@ class _StepSequencerViewState extends State<StepSequencerView> {
               videoStream,
               availableFirmwareUpdate,
               perfPageItems,
+              isDirty,
             ) => offline,
             orElse: () => false,
           );

--- a/lib/ui/synchronized_screen.dart
+++ b/lib/ui/synchronized_screen.dart
@@ -502,7 +502,7 @@ class _SynchronizedScreenState extends State<SynchronizedScreen>
       child: Actions(
         actions: _keyBindingService.buildGlobalActions(
           onSavePreset: () {
-            cubit.requireDisting().requestSavePreset();
+            cubit.savePreset();
             SemanticsService.sendAnnouncement(
               View.of(context),
               'Preset saved',
@@ -1827,11 +1827,10 @@ class _SynchronizedScreenState extends State<SynchronizedScreen>
                       if (result == 'new_discard') {
                         cubit.newPreset();
                       } else if (result == 'save_first_new') {
-                        cubit.requireDisting().requestSavePreset();
-                        // It's generally okay to call newPreset() immediately after
-                        // requestSavePreset() for MIDI operations. The device handles
-                        // commands sequentially.
-                        cubit.newPreset();
+                        try {
+                          await cubit.savePreset();
+                          cubit.newPreset();
+                        } catch (_) {}
                       }
                       // If 'cancel' or dialog dismissed, do nothing.
                     } else {
@@ -1850,7 +1849,7 @@ class _SynchronizedScreenState extends State<SynchronizedScreen>
             onTap: widget.loading
                 ? null
                 : () {
-                    cubit.requireDisting().requestSavePreset();
+                    cubit.savePreset();
                   },
             child: const Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/ui/synchronized_screen.dart
+++ b/lib/ui/synchronized_screen.dart
@@ -75,6 +75,7 @@ class SynchronizedScreen extends StatefulWidget {
   final List<AlgorithmInfo> algorithms;
   final List<String> units;
   final String presetName;
+  final bool isDirty;
   final String distingVersion;
   final FirmwareVersion firmwareVersion;
   final Uint8List? screenshot;
@@ -87,6 +88,7 @@ class SynchronizedScreen extends StatefulWidget {
     required this.algorithms,
     required this.units,
     required this.presetName,
+    this.isDirty = false,
     required this.distingVersion,
     required this.firmwareVersion,
     required this.screenshot,
@@ -2118,7 +2120,9 @@ class _SynchronizedScreenState extends State<SynchronizedScreen>
         children: [
           Semantics(
             button: true,
-            label: 'Preset: ${widget.presetName.trim()}',
+            label: widget.isDirty
+                ? 'Preset: ${widget.presetName.trim()}, unsaved changes'
+                : 'Preset: ${widget.presetName.trim()}',
             hint: 'Double tap to rename preset',
             child: InkWell(
               onTap: () async {
@@ -2140,30 +2144,31 @@ class _SynchronizedScreenState extends State<SynchronizedScreen>
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   ExcludeSemantics(
-                    child: Text.rich(
-                      TextSpan(
-                        children: [
-                          TextSpan(
-                            text: 'Preset:\u2007',
-                            style: Theme.of(context).textTheme.labelLarge
-                                ?.copyWith(
-                                  fontWeight: FontWeight.bold,
-                                  color: Theme.of(
-                                    context,
-                                  ).colorScheme.onSurfaceVariant,
-                                ),
-                          ),
-                          TextSpan(
-                            text: widget.presetName.trim(),
-                            style: Theme.of(context).textTheme.labelLarge
-                                ?.copyWith(
-                                  color: Theme.of(
-                                    context,
-                                  ).colorScheme.onSurfaceVariant,
-                                ),
-                          ),
-                        ],
-                      ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          'Preset:\u2007',
+                          style: Theme.of(context).textTheme.labelLarge
+                              ?.copyWith(
+                                fontWeight: FontWeight.bold,
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
+                              ),
+                        ),
+                        Text(
+                          widget.isDirty
+                              ? '${widget.presetName.trim()} *'
+                              : widget.presetName.trim(),
+                          style: Theme.of(context).textTheme.labelLarge
+                              ?.copyWith(
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
+                              ),
+                        ),
+                      ],
                     ),
                   ),
                   const SizedBox(width: 8),

--- a/lib/ui/widgets/floating_video_overlay.dart
+++ b/lib/ui/widgets/floating_video_overlay.dart
@@ -255,7 +255,7 @@ class FloatingVideoContent extends StatelessWidget {
               builder: (context, cubitState) {
                 final videoState = cubitState.maybeWhen(
                   synchronized:
-                      (_, _, _, _, _, _, _, _, _, _, _, _, _, videoStream, _, _) =>
+                      (_, _, _, _, _, _, _, _, _, _, _, _, _, videoStream, _, _, _) =>
                           videoStream,
                   orElse: () => null,
                 );

--- a/lib/ui/widgets/step_sequencer/parameter_pages_view.dart
+++ b/lib/ui/widgets/step_sequencer/parameter_pages_view.dart
@@ -252,6 +252,7 @@ class _ParameterPageContent extends StatelessWidget {
             videoStream,
             availableFirmwareUpdate,
             perfPageItems,
+            isDirty,
           ) {
             final currentSlot = slotIndex < slots.length ? slots[slotIndex] : slot;
             return (currentSlot, unitStrings);

--- a/lib/ui/widgets/step_sequencer/randomize_settings_dialog.dart
+++ b/lib/ui/widgets/step_sequencer/randomize_settings_dialog.dart
@@ -82,6 +82,7 @@ class _RandomizeSettingsDialogState extends State<RandomizeSettingsDialog> {
             videoStream,
             availableFirmwareUpdate,
             perfPageItems,
+            isDirty,
           ) {
             if (widget.slotIndex < slots.length) {
               return slots[widget.slotIndex];

--- a/specs/2026-05-04_preset-dirty-indicator.md
+++ b/specs/2026-05-04_preset-dirty-indicator.md
@@ -1,0 +1,511 @@
+# Preset dirty indicator (unsaved changes)
+
+## Context
+
+The Disting NT app keeps an in-memory copy of the current preset
+(`DistingStateSynchronized.presetName` and `DistingStateSynchronized.slots`)
+that the user mutates from the UI: parameter sliders, algorithm add/remove,
+slot reordering, mapping changes, slot custom names, preset rename, etc.
+Those mutations are sent to the device as MIDI SysEx commands and the
+in-memory state is updated optimistically — but the device's *persistent*
+preset (the one that survives a power cycle or "Load Preset") is only
+updated when the user explicitly invokes **Save Preset**.
+
+Today there is **no visual cue** that the in-memory preset has diverged
+from the saved one. A user who has been twiddling parameters for an hour
+has no way to tell — short of saving — whether the next power cycle will
+restore their session or throw it away. The "New Preset" flow already
+prompts for a save when slots are non-empty (`synchronized_screen.dart`
+line ~1825), which proves the team treats unsaved state as significant,
+but the prompt only fires for that one path.
+
+## Goal
+
+Display a **dirty indicator** (an asterisk `*` appended to the preset
+name in the app bar header) whenever the in-memory preset has been
+mutated since the last save / load / new / refresh from device. The
+indicator clears when the user saves the preset, loads a preset, starts
+a new preset, or refreshes state from the device.
+
+## Non-goals
+
+- No structural diffing of the preset against the device's saved copy.
+  We track *whether mutations occurred*, not *whether they round-trip
+  to the same bytes*. A user who nudges a slider to value 42 and back
+  to 41 will leave the preset marked dirty until save. This is the
+  standard text-editor convention and is acceptable.
+- No "discard changes" or "revert" action. (Those would be useful but
+  are out of scope; the existing `_CheckpointDelegate` undo system is
+  the right place to extend later if we want them.)
+- No persistence of the dirty flag across app restarts. The flag lives
+  only in `DistingState`. Restarting the app re-fetches state from the
+  device, which is by definition clean.
+- No cross-platform native window-title decoration (e.g. macOS
+  document-modified dot). We only decorate the in-app text label.
+- No save-on-quit prompt or unsaved-changes guard on connection loss.
+  Those would be welcome follow-ups but are separate features.
+- No change to the existing "New Preset" save-prompt dialog logic. We
+  could later make it conditional on `isDirty`, but that's a separate
+  PR.
+- No change to the rename autosave behaviour itself — we only piggyback
+  on the existing autosave to clear the flag when it succeeds.
+
+## Naming
+
+Use `isDirty` as the field name. This matches the existing
+`DistingStateSynchronized` convention (`loading`, `offline`, `demo`,
+no `is*` prefix on most booleans, but `isDirty` is the one widely
+recognised text-editor term and reads better than `dirty` alone).
+"Dirty" is the standard term in Cocoa, Qt, Flutter and most editor
+codebases for "in-memory differs from persisted." `hasUnsavedChanges`
+is the user-facing phrase and is what we put in semantic labels, not
+the field name.
+
+## Affected files
+
+### State
+
+- `lib/cubit/disting_state.dart` — add field to `DistingStateSynchronized`.
+
+### Cubit / delegates
+
+- `lib/cubit/disting_cubit.dart` — add facade `savePreset()` method.
+- `lib/cubit/disting_cubit_preset_ops.dart` — `loadPresetImpl`,
+  `newPresetImpl`, `renamePresetImpl`, plus the rename-driven
+  autosave clear.
+- `lib/cubit/disting_cubit_state_refresh_delegate.dart` — clear the
+  flag after a refresh from device.
+- `lib/cubit/disting_cubit_connection_delegate.dart` — initial sync
+  emit (line 281) constructs a fresh state with default `isDirty: false`;
+  no explicit field needed but verify the freezed default fires.
+- `lib/cubit/disting_cubit_parameter_value_delegate.dart` — set on
+  parameter writes (both real-time and release paths).
+- `lib/cubit/disting_cubit_parameter_string_delegate.dart` — set on
+  string parameter writes.
+- `lib/cubit/disting_cubit_algorithm_ops.dart` — set on add / remove /
+  move-up / move-down (both optimistic and verification emits).
+- `lib/cubit/disting_cubit_slot_ops.dart` — set on slot custom-name
+  changes.
+- `lib/cubit/disting_cubit_slot_state_delegate.dart` — set on
+  slot-state mutations (parameter pages, etc.).
+- `lib/cubit/disting_cubit_mapping_delegate.dart` — set on CV / MIDI /
+  i2c mapping changes.
+- `lib/cubit/disting_cubit_perf_page_delegate.dart` — set on perf page
+  item edits (preserve current `isDirty` on perf page fetch inside
+  refresh).
+- `lib/cubit/disting_cubit_offline_demo_delegate.dart` — fresh
+  constructions get default `isDirty: false`; verify no copy paths
+  preserve a stale dirty flag.
+- `lib/cubit/disting_cubit_slot_maintenance_delegate.dart` — set on
+  slot repair (these mutate slot contents).
+- `lib/cubit/disting_cubit_lua_reload_delegate.dart` — Lua reload
+  restores parameter values via the same parameter-write path; that
+  path will already mark dirty, but verify the success-path emit (if
+  any) preserves dirty.
+
+### UI
+
+- `lib/disting_app.dart` — pass `state.isDirty` to `SynchronizedScreen`.
+- `lib/ui/synchronized_screen.dart` — accept `isDirty` constructor
+  argument; render asterisk in `_buildPresetInfoEditor` and in the
+  semantic label; switch the three direct `requireDisting().requestSavePreset()`
+  call sites to a new `cubit.savePreset()` facade so the flag clears
+  on save.
+
+### Controller / external
+
+- `lib/services/disting_controller_impl.dart` line 327 — change
+  `savePreset()` to call `_distingCubit.savePreset()` instead of
+  `_getManager().requestSavePreset()`, so MCP-driven saves clear the
+  flag.
+
+### Tests
+
+- `test/cubit/preset_dirty_indicator_test.dart` — new file. See
+  *Test plan* below.
+- `test/ui/synchronized_screen_dirty_indicator_test.dart` — new file.
+
+## Design
+
+### State change
+
+Add one field to `DistingStateSynchronized` in
+`lib/cubit/disting_state.dart`:
+
+```dart
+const factory DistingState.synchronized({
+  // ... existing fields unchanged ...
+  @Default(false) bool isDirty,
+}) = DistingStateSynchronized;
+```
+
+Freezed regenerates `copyWith` automatically. Default `false` means
+freshly-synchronized state is clean, which matches the data flow:
+every path that constructs a `DistingStateSynchronized` from scratch
+(initial sync, offline load, demo init, refresh-from-device) reflects
+device truth and is by definition clean.
+
+### Mutation rule
+
+This is the **authoritative rule** the implementer follows:
+
+> An emit of `DistingStateSynchronized` must set `isDirty: true` if and
+> only if the emit reflects a **user-initiated change** to preset
+> contents — `slots`, `presetName`, or in-slot mappings — that has not
+> yet been saved.
+>
+> Emits that reflect **device truth** (live polling, CC notifications,
+> verification reads, full refreshes, screenshots, video, firmware
+> update notices) **preserve** the current `isDirty` value via
+> `state.isDirty` in the `copyWith` argument list. They do not flip it
+> in either direction.
+>
+> Emits that *replace* state from a fresh device read (full
+> `_refreshStateFromManager`, initial sync, preset load) explicitly set
+> `isDirty: false`.
+
+Implementation pattern for the "preserve" case:
+
+```dart
+_cubit._emitState(
+  currentState.copyWith(
+    slots: updatedSlots,
+    isDirty: currentState.isDirty,  // explicit, even though Dart would default it
+  ),
+);
+```
+
+The explicit `isDirty: currentState.isDirty` is required at every
+device-truth emit site. It documents intent and survives future
+refactoring (e.g., if someone adds a default constructor that emits
+`isDirty: false`). Where a site already passes other unrelated fields
+forward, this is a one-line change.
+
+### Mutation site reference (illustrative, not authoritative)
+
+The following table is a **starting point** derived from the codebase
+at the spec's commit. The mutation rule above is what the implementer
+follows; this table accelerates the first pass but should be
+re-validated against `git grep` results during implementation since
+line numbers drift.
+
+User-initiated mutation emits — set `isDirty: true`:
+
+| File | Line | Operation |
+|------|------|-----------|
+| `disting_cubit_parameter_value_delegate.dart` | 59, 107 | parameter write (real-time + release) |
+| `disting_cubit_parameter_string_delegate.dart` | 43, 93, 131 | string parameter write |
+| `disting_cubit_algorithm_ops.dart` | 110, 126, 223, 319, 437 | add / remove / move algorithms (optimistic emits) |
+| `disting_cubit_algorithm_ops.dart` | 172, 185, 370, 483 | add / move verification emits — preserve `isDirty` (the optimistic emit already set it) |
+| `disting_cubit_slot_ops.dart` | 33 | slot custom-name optimistic |
+| `disting_cubit_slot_ops.dart` | 69 | slot custom-name verification — preserve |
+| `disting_cubit_slot_state_delegate.dart` | 71, 128, 170, 196, 227, 248 | slot state updates (parameter pages, output modes) |
+| `disting_cubit_slot_maintenance_delegate.dart` | 98, 135 | slot repair |
+| `disting_cubit_mapping_delegate.dart` | 84, 135, 175 | CV / MIDI / i2c / performance mapping |
+| `disting_cubit_perf_page_delegate.dart` | 34, 62 | perf page item edits |
+| `disting_cubit_preset_ops.dart` | 39 | preset rename optimistic emit |
+
+Device-truth emits — preserve current `isDirty`:
+
+| File | Line | Why |
+|------|------|-----|
+| `disting_cubit_parameter_refresh_delegate.dart` | 66, 115, 247, 317 | live polling reflects device truth |
+| `disting_cubit_cc_notification_delegate.dart` | 216 | CC value reflection from device |
+| `disting_cubit_hardware_commands_delegate.dart` | 20 | screenshot only |
+| `disting_cubit_monitoring_delegate.dart` | 74, 90 | video stream state |
+| `disting_cubit_preset_ops.dart` | 56, 74 | rename verification correction (device truth) |
+| `disting_cubit.dart` | 893, 999 | firmware-update notice |
+
+Full-refresh emits — explicitly set `isDirty: false`:
+
+| File | Line | Why |
+|------|------|-----|
+| `disting_cubit_state_refresh_delegate.dart` | 34 | refreshed from device |
+| `disting_cubit_connection_delegate.dart` | 281 | initial sync emit (relies on Freezed default) |
+| `disting_cubit_offline_demo_delegate.dart` | 30, 72, 107, 193 | fresh state constructions |
+
+Out-of-scope (non-preset state) — pass through:
+
+| File | Line | Why |
+|------|------|-----|
+| `disting_cubit_state_refresh_delegate.dart` | 16, 47 | loading/error transitions |
+| `disting_cubit_algorithm_library_delegate.dart` | all | algorithm library cache, not preset |
+| `disting_cubit_connection_delegate.dart` | (other lines) | connection lifecycle |
+| `disting_cubit_plugin_delegate.dart` | 663 | algorithm library, not preset |
+
+Routing changes flow through the existing `RoutingEditorCubit`, which
+calls back into `DistingCubit` via parameter writes — covered by the
+parameter-write path automatically.
+
+### Clear rule
+
+`isDirty` is set back to `false` at exactly the points where the
+in-memory preset is fully resynchronised with a known clean baseline:
+
+1. **Save completes** — see "Save flow" below.
+2. **State refresh from device** — `_StateRefreshDelegate.refreshStateFromManager`
+   line 34: explicitly add `isDirty: false` to the `copyWith`.
+3. **New preset** — `newPresetImpl` calls `requestNewPreset()` then
+   `_refreshStateFromManager()`, which resets via #2.
+4. **Load preset (online)** — `loadPresetImpl` calls
+   `requestLoadPreset()` then `_refreshStateFromManager()`, which
+   resets via #2.
+5. **Load preset (offline)** — `_OfflineDemoDelegate.loadPresetOffline`
+   constructs a fresh `DistingStateSynchronized`; default
+   `isDirty: false` applies. Verify no `copyWith` paths in this
+   delegate inadvertently preserve a stale dirty flag from a prior
+   state.
+6. **Demo init** — same as #5.
+7. **Initial sync** — `performSyncAndEmit` (connection delegate
+   line 281) constructs `DistingState.synchronized(...)` without
+   passing `isDirty`; the Freezed `@Default(false)` applies. No code
+   change needed if Freezed's defaults work as expected. Verify by
+   inspecting generated `disting_state.freezed.dart` after build_runner.
+
+### Save flow
+
+The current save path bypasses the cubit: three sites in
+`synchronized_screen.dart` (lines 503, 1828, 1851) call
+`cubit.requireDisting().requestSavePreset()` directly. Add a facade:
+
+```dart
+// disting_cubit.dart
+Future<void> savePreset() async {
+  final s = state;
+  if (s is! DistingStateSynchronized) return;
+  final disting = s.disting;
+  try {
+    await disting.requestSavePreset();
+  } catch (_) {
+    rethrow;  // Leave isDirty as-is; a failed save did not actually persist.
+  }
+  // Re-check state after the await: connection could have dropped.
+  final after = state;
+  if (after is DistingStateSynchronized) {
+    _emitState(after.copyWith(isDirty: false));
+  }
+}
+```
+
+The two-step (snapshot before await, re-read after) is intentional:
+between the `await` and the emit, state could have transitioned to
+`DistingStateConnected` or `DistingStateInitial` (e.g., disconnect).
+Re-reading `state` after the await catches that.
+
+Update the three UI call sites to use `cubit.savePreset()`. The
+keyboard shortcut path (line 503) and the popup-menu path (line 1851)
+both go through cleanly. The "Save First & New" path (line 1828) also
+calls `cubit.newPreset()` immediately after; reorder to
+`await cubit.savePreset(); cubit.newPreset();` so the save resolves
+before the new-preset state machine runs (which would otherwise also
+clear the flag via the refresh path, but the explicit ordering avoids
+a race).
+
+The auto-save inside `renamePresetImpl` (line 45) — `disting.requestSavePreset().catchError((_) {})`
+— must also clear the flag. Replace it with a deferred clear:
+
+```dart
+disting.requestSavePreset().then((_) {
+  final cur = state;
+  if (cur is DistingStateSynchronized) {
+    _emitState(cur.copyWith(isDirty: false));
+  }
+}).catchError((_) {});
+```
+
+This is the only change to rename behaviour; otherwise the rename flow
+is untouched. Justification: the rename path already triggers a save,
+so the flag must clear when that save resolves — otherwise rename
+would leave a misleading `*` until the user manually saved again.
+
+The `disting_controller_impl.dart` line 327 `savePreset()` (used by
+MCP) currently calls `_getManager().requestSavePreset()` directly.
+Change to `await _distingCubit.savePreset();` so MCP-driven saves also
+clear the flag. The `_getSynchronizedState()` precondition check
+remains; it will throw before `_distingCubit.savePreset()` if state
+isn't synchronized.
+
+The `metadata_sync_cubit.dart` line 329 save is part of an internal
+sync orchestration that already calls back into `_refreshStateFromManager()`,
+which will clear the flag via the refresh rule. No change needed.
+
+### UI change
+
+`SynchronizedScreen` constructor (`lib/ui/synchronized_screen.dart`
+lines 77–93) currently takes `presetName` but not `isDirty`. Add:
+
+```dart
+final bool isDirty;
+const SynchronizedScreen({
+  // ...
+  required this.presetName,
+  required this.isDirty,
+  // ...
+});
+```
+
+Update the construction site in `lib/disting_app.dart` line 432:
+
+```dart
+return SynchronizedScreen(
+  // ...
+  presetName: state.presetName,
+  isDirty: state.isDirty,
+  // ...
+);
+```
+
+In `_buildPresetInfoEditor` (line 2113):
+
+```dart
+final displayName = widget.presetName.trim();
+final dirtyMark = widget.isDirty ? ' *' : '';
+// ...
+Semantics(
+  button: true,
+  label: 'Preset: $displayName${widget.isDirty ? ', unsaved changes' : ''}',
+  // ...
+  TextSpan(text: '$displayName$dirtyMark', ...)
+)
+```
+
+The asterisk uses the same text style as the preset name — no separate
+icon, no colour change. We use an asterisk because it is the universally
+recognised "modified document" marker across editors (Vim, VSCode,
+Sublime, Xcode, etc.); Material Design has no specific guidance for
+in-text "modified" indicators on preset/document headers, so the
+text-editor convention applies. Spoken accessibility uses the phrase
+"unsaved changes" rather than reading "asterisk" aloud, matching the
+existing semantic-label patterns in the screen.
+
+## Edge cases
+
+- **Rename to the same name**: `renamePresetImpl` early-returns
+  (line 36) before emitting, so `isDirty` is unchanged. Correct.
+- **Rename verification correction**: lines 56 and 74 emit
+  `verificationState.copyWith(presetName: actual)` after a rename
+  failure or device-truth correction. These must explicitly preserve
+  `isDirty` (`isDirty: verificationState.isDirty`) — otherwise the
+  freezed `copyWith` keeps the existing value, but adding the
+  explicit pass is required by the mutation rule and prevents
+  silent regressions.
+- **Rename succeeds + autosave fires + user mutates before autosave
+  resolves**: window of milliseconds; the autosave clear may
+  overwrite a fresh user mutation's `isDirty: true`. Mitigated by the
+  fact that the autosave clear re-reads `state` and sets
+  `isDirty: false` — but a user write that lands between the autosave
+  resolving and the clear emitting would be lost. Acceptable: the
+  window is tens of milliseconds and the user's next mutation will
+  immediately re-mark dirty.
+- **Parameter slider scrubbing back to original value**: marks dirty.
+  Acceptable per non-goals.
+- **Failed save**: the `await disting.requestSavePreset()` may throw or
+  silently fail; the cubit's `try/rethrow` keeps `isDirty: true` so
+  the user retains the indicator. UI call sites that previously
+  didn't await the save now have a future to consider — the new
+  `savePreset()` returns `Future<void>` and may throw. The popup-menu
+  and shortcut handlers should ignore failures (existing behaviour);
+  the "Save First & New" handler awaits before calling `newPreset()`.
+- **Live parameter polling races user mutation**: polling emits
+  preserve `isDirty: currentState.isDirty`, so a poll landing right
+  after a user mutation keeps the dirty flag set. Without the explicit
+  preserve, freezed's `copyWith` would also keep it (since the field
+  isn't passed), but the rule requires explicit pass-through.
+- **CC notification reflections** likewise reflect device-side changes;
+  preserve dirty.
+- **External save (auto-save during rename, MCP-driven save, sync
+  flow save)**: covered via the rename autosave change, the MCP
+  controller change, and the refresh path for sync-driven flows.
+- **Lua reload** (`disting_cubit_lua_reload_delegate.dart`): the
+  reload flow re-issues parameter writes via the standard parameter
+  delegate, which will mark dirty. The reload itself does not emit a
+  state directly (it issues SysEx writes that trigger downstream
+  refresh paths). No additional code change needed; verify by
+  triggering a reload and watching the indicator.
+- **Algorithm-add verification** (`algorithm_ops.dart` line 172): the
+  verification re-fetches the slot from the device and emits with the
+  fresh slot. Optimistic emit at line 110 already set `isDirty: true`;
+  the verify emit must `copyWith(slots: ..., isDirty: state.isDirty)`
+  to preserve.
+- **Initial sync** (`connection_delegate.dart` line 281): builds a
+  fresh `DistingState.synchronized(...)`. `isDirty` is omitted, so
+  Freezed's `@Default(false)` applies. Verify the generated freezed
+  file actually emits the default after `build_runner` runs.
+- **Offline mode**: parameter writes still queue to the
+  `OfflineDistingMidiManager`, which persists to local storage on
+  `requestSavePreset()`. The dirty flag behaves identically.
+- **Demo mode**: in demo mode there's no real persistence, but mutations
+  still emit slot changes and `requestSavePreset()` is a no-op on the
+  mock manager. The flag still flips to true on mutation and clears on
+  the no-op save. Harmless.
+- **Connection loss mid-edit**: state transitions back to
+  `DistingStateConnected` or `DistingStateInitial`, neither of which
+  has `isDirty`. Reconnecting goes through the sync flow which builds
+  a fresh `DistingStateSynchronized` (clean). Any unsaved edits are
+  lost — that's existing behaviour, unchanged.
+- **MCP server tool calls** that mutate state (`add_algorithm`,
+  `set_parameter_value`, etc.) flow through the same cubit methods, so
+  they correctly mark dirty. MCP-driven save is fixed via the
+  controller change above.
+- **`loadPresetOffline`** (cubit.dart line 300): clears checkpoints and
+  delegates to `_offlineDemoDelegate.loadPresetOffline`, which builds
+  a fresh `DistingStateSynchronized`. Default `isDirty: false` applies.
+- **Plugin install** (`plugin_delegate.dart` line 663): updates the
+  algorithm *library*, not preset contents. Out of scope; preserve
+  dirty.
+- **SD card preset operations**: scanning is read-only; loading goes
+  through `loadPresetImpl` which clears via refresh.
+- **Build-runner**: the freezed change requires regenerating
+  `disting_state.freezed.dart`. Run
+  `dart run build_runner build --delete-conflicting-outputs` per
+  CLAUDE.md.
+
+## Test plan
+
+New file `test/cubit/preset_dirty_indicator_test.dart`:
+
+1. Fresh synchronized state has `isDirty == false`.
+2. After `updateParameterValue(...)`, state is dirty.
+3. After `onAddAlgorithm(...)`, state is dirty.
+4. After `onRemoveAlgorithm(...)`, state is dirty.
+5. After `moveAlgorithmUp/Down(...)`, state is dirty.
+6. After `renamePreset(...)` to a new name, state is dirty until the
+   autosave resolves, then becomes clean.
+7. After `saveMapping(...)`, state is dirty.
+8. After a parameter-refresh emit (simulated via the live polling
+   delegate), the prior `isDirty` is **preserved** — true stays true,
+   false stays false.
+9. After a rename verification correction emit, prior `isDirty` is
+   preserved.
+10. `cubit.savePreset()` clears the flag on success.
+11. `cubit.savePreset()` leaves the flag set on failure (manager
+    throws).
+12. `cubit.savePreset()` is a no-op when state is not
+    `DistingStateSynchronized`.
+13. `loadPreset(...)` clears the flag (via refresh path).
+14. `newPreset()` clears the flag (via refresh path).
+15. `refresh()` clears the flag.
+16. `disting_controller_impl.savePreset()` (MCP path) clears the flag.
+
+Widget test in `test/ui/synchronized_screen_dirty_indicator_test.dart`:
+
+1. With `isDirty: false`, header text is `Preset: <name>`.
+2. With `isDirty: true`, header text is `Preset: <name> *`.
+3. Semantic label includes "unsaved changes" when dirty.
+
+Manual smoke (cannot run from CI):
+
+- Connect to hardware (or use demo mode).
+- Move a parameter slider; observe asterisk appears.
+- Hit Save Preset; observe asterisk clears.
+- Rename preset; observe asterisk appears momentarily then clears
+  (autosave).
+- Load a different preset; observe asterisk clears.
+- Trigger MCP save via the controller; observe asterisk clears.
+
+## Rollout
+
+Single PR. No feature flag — the indicator is purely additive UI and
+the new cubit field is free for any code path that ignores it. Run
+`flutter analyze` (must pass with zero warnings) and `flutter test`
+before opening the PR.

--- a/specs/2026-05-04_preset-dirty-indicator.md
+++ b/specs/2026-05-04_preset-dirty-indicator.md
@@ -47,82 +47,70 @@ a new preset, or refreshes state from the device.
 - No change to the existing "New Preset" save-prompt dialog logic. We
   could later make it conditional on `isDirty`, but that's a separate
   PR.
-- No change to the rename autosave behaviour itself — we only piggyback
-  on the existing autosave to clear the flag when it succeeds.
-
-## Naming
-
-Use `isDirty` as the field name. This matches the existing
-`DistingStateSynchronized` convention (`loading`, `offline`, `demo`,
-no `is*` prefix on most booleans, but `isDirty` is the one widely
-recognised text-editor term and reads better than `dirty` alone).
-"Dirty" is the standard term in Cocoa, Qt, Flutter and most editor
-codebases for "in-memory differs from persisted." `hasUnsavedChanges`
-is the user-facing phrase and is what we put in semantic labels, not
-the field name.
+- No restructuring of the existing rename autosave path. The autosave
+  is best-effort and the dirty flag will simply remain set during the
+  rename-and-autosave window and clear on the next save / refresh /
+  load (see "Edge cases").
 
 ## Affected files
 
 ### State
 
-- `lib/cubit/disting_state.dart` — add field to `DistingStateSynchronized`.
+- `lib/cubit/disting_state.dart` — add `isDirty` field to
+  `DistingStateSynchronized`.
 
 ### Cubit / delegates
 
 - `lib/cubit/disting_cubit.dart` — add facade `savePreset()` method.
-- `lib/cubit/disting_cubit_preset_ops.dart` — `loadPresetImpl`,
-  `newPresetImpl`, `renamePresetImpl`, plus the rename-driven
-  autosave clear.
-- `lib/cubit/disting_cubit_state_refresh_delegate.dart` — clear the
-  flag after a refresh from device.
-- `lib/cubit/disting_cubit_connection_delegate.dart` — initial sync
-  emit (line 281) constructs a fresh state with default `isDirty: false`;
-  no explicit field needed but verify the freezed default fires.
+- `lib/cubit/disting_cubit_preset_ops.dart` — `renamePresetImpl`
+  optimistic emit (line 39) sets `isDirty: true`.
+- `lib/cubit/disting_cubit_state_refresh_delegate.dart` — explicitly
+  emit `isDirty: false` after a refresh from device (line 34).
 - `lib/cubit/disting_cubit_parameter_value_delegate.dart` — set on
-  parameter writes (both real-time and release paths).
+  parameter writes (lines 59, 107).
 - `lib/cubit/disting_cubit_parameter_string_delegate.dart` — set on
-  string parameter writes.
+  string parameter writes (lines 43, 93, 131).
 - `lib/cubit/disting_cubit_algorithm_ops.dart` — set on add / remove /
-  move-up / move-down (both optimistic and verification emits).
+  move-up / move-down optimistic emits (lines 110, 126, 223, 319, 437).
+  Verification emits (lines 172, 185, 370, 483) preserve current
+  `isDirty` (don't reset it).
 - `lib/cubit/disting_cubit_slot_ops.dart` — set on slot custom-name
-  changes.
+  changes (lines 33, 69).
 - `lib/cubit/disting_cubit_slot_state_delegate.dart` — set on
-  slot-state mutations (parameter pages, etc.).
+  slot-state mutations (lines 71, 128, 170, 196, 227, 248).
 - `lib/cubit/disting_cubit_mapping_delegate.dart` — set on CV / MIDI /
-  i2c mapping changes.
+  i2c / performance mapping changes (lines 84, 135, 175).
 - `lib/cubit/disting_cubit_perf_page_delegate.dart` — set on perf page
-  item edits (preserve current `isDirty` on perf page fetch inside
-  refresh).
-- `lib/cubit/disting_cubit_offline_demo_delegate.dart` — fresh
-  constructions get default `isDirty: false`; verify no copy paths
-  preserve a stale dirty flag.
+  item edits (lines 34, 62). Perf page item edits *are* preset
+  mutations; they persist in the preset bytes alongside slot data.
 - `lib/cubit/disting_cubit_slot_maintenance_delegate.dart` — set on
-  slot repair (these mutate slot contents).
-- `lib/cubit/disting_cubit_lua_reload_delegate.dart` — Lua reload
-  restores parameter values via the same parameter-write path; that
-  path will already mark dirty, but verify the success-path emit (if
-  any) preserves dirty.
+  slot repair (lines 98, 135).
+- `lib/cubit/disting_cubit_offline_demo_delegate.dart` — fresh
+  construction; `@Default(false) isDirty` applies, no change needed.
+- `lib/cubit/disting_cubit_connection_delegate.dart` — initial sync
+  construction; `@Default(false) isDirty` applies, no change needed.
 
 ### UI
 
-- `lib/disting_app.dart` — pass `state.isDirty` to `SynchronizedScreen`.
+- `lib/disting_app.dart` — pass `state.isDirty` to `SynchronizedScreen`
+  (construction site at line 432).
 - `lib/ui/synchronized_screen.dart` — accept `isDirty` constructor
   argument; render asterisk in `_buildPresetInfoEditor` and in the
-  semantic label; switch the three direct `requireDisting().requestSavePreset()`
-  call sites to a new `cubit.savePreset()` facade so the flag clears
-  on save.
+  semantic label; switch the three direct
+  `requireDisting().requestSavePreset()` call sites (lines 503, 1828,
+  1851) to a new `cubit.savePreset()` facade so the flag clears on
+  save.
 
-### Controller / external
+### Services
 
-- `lib/services/disting_controller_impl.dart` line 327 — change
-  `savePreset()` to call `_distingCubit.savePreset()` instead of
-  `_getManager().requestSavePreset()`, so MCP-driven saves clear the
-  flag.
+- `lib/services/disting_controller_impl.dart` — route the MCP-driven
+  `savePreset` (line 329) through the cubit's `savePreset()` facade so
+  external saves also clear the flag.
 
 ### Tests
 
-- `test/cubit/preset_dirty_indicator_test.dart` — new file. See
-  *Test plan* below.
+- `test/cubit/preset_dirty_indicator_test.dart` — new file. See *Test
+  plan* below.
 - `test/ui/synchronized_screen_dirty_indicator_test.dart` — new file.
 
 ## Design
@@ -140,146 +128,72 @@ const factory DistingState.synchronized({
 ```
 
 Freezed regenerates `copyWith` automatically. Default `false` means
-freshly-synchronized state is clean, which matches the data flow:
-every path that constructs a `DistingStateSynchronized` from scratch
-(initial sync, offline load, demo init, refresh-from-device) reflects
-device truth and is by definition clean.
+freshly-synchronized state is clean, which matches the data flow: every
+path that creates a `DistingStateSynchronized` either reads from device
+(clean) or constructs from a freshly-loaded preset (clean).
 
-### Mutation rule
+### Mutation rule (cubit-side)
 
-This is the **authoritative rule** the implementer follows:
+**Every site that emits state reflecting a *user-initiated* change to
+`slots`, `presetName`, in-slot mapping data, or perf page items sets
+`isDirty: true`.**
 
-> An emit of `DistingStateSynchronized` must set `isDirty: true` if and
-> only if the emit reflects a **user-initiated change** to preset
-> contents — `slots`, `presetName`, or in-slot mappings — that has not
-> yet been saved.
->
-> Emits that reflect **device truth** (live polling, CC notifications,
-> verification reads, full refreshes, screenshots, video, firmware
-> update notices) **preserve** the current `isDirty` value via
-> `state.isDirty` in the `copyWith` argument list. They do not flip it
-> in either direction.
->
-> Emits that *replace* state from a fresh device read (full
-> `_refreshStateFromManager`, initial sync, preset load) explicitly set
-> `isDirty: false`.
+The codebase has two emission patterns: most delegates call
+`_emitState(...)` (the wrapper at `disting_cubit.dart:305`); a few
+files (notably `disting_cubit_algorithm_ops.dart`) call `emit(...)`
+directly. The wrapper is a thin pass-through; both patterns behave
+identically with respect to `copyWith(isDirty: true)`.
 
-Implementation pattern for the "preserve" case:
-
-```dart
-_cubit._emitState(
-  currentState.copyWith(
-    slots: updatedSlots,
-    isDirty: currentState.isDirty,  // explicit, even though Dart would default it
-  ),
-);
-```
-
-The explicit `isDirty: currentState.isDirty` is required at every
-device-truth emit site. It documents intent and survives future
-refactoring (e.g., if someone adds a default constructor that emits
-`isDirty: false`). Where a site already passes other unrelated fields
-forward, this is a one-line change.
-
-#### Bare positional `DistingState.synchronized(...)` calls
-
-Two sites in `disting_cubit_algorithm_ops.dart` (lines 370–388,
-483–501, the move-up and move-down verification corrections) currently
-build the synchronized state with a positional/named constructor call
-rather than `copyWith`. They omit several existing defaulted fields
-(`videoStream`, `availableFirmwareUpdate`, `perfPageItems`) and would
-similarly default the new `isDirty` to `false` — silently clearing the
-indicator after a verified-but-corrected move.
-
-**Required change**: replace each with
-`verificationState.copyWith(slots: actualSlots, loading: false)`.
-`copyWith` preserves every other field, including `isDirty`, and
-removes a maintenance hazard for any future field on
-`DistingStateSynchronized`. This is a small drive-by correctness fix
-that the dirty-indicator change forces; it is in scope.
-
-#### Optimistic-rollback emits
-
-Several lines in `disting_cubit_algorithm_ops.dart` (e.g., line 126,
-the rollback path that pops the optimistically-added slot when the
-device add fails) emit a `copyWith` that *un-does* a user-initiated
-mutation. The emit's slot list is the pre-mutation state, but we have
-no record of whether other slots had unsaved edits before. The
-pragmatic rule:
-
-- **Rollback emits leave `isDirty` unchanged** (omit `isDirty` from the
-  `copyWith` argument list — Freezed preserves it). The user may have
-  had prior unsaved changes; rolling back a single failed mutation
-  does not magically save them.
-
-This applies symmetrically to any future rollback path. The mutation
-table entries for these lines describe the *successful* optimistic
-emit; rollback emits inherit `isDirty` via Freezed's preserve.
-
-### Mutation site reference (illustrative, not authoritative)
-
-The following table is a **starting point** derived from the codebase
-at the spec's commit. The mutation rule above is what the implementer
-follows; this table accelerates the first pass but should be
-re-validated against `git grep` results during implementation since
-line numbers drift.
-
-User-initiated mutation emits — set `isDirty: true`:
+Concretely, the following call sites add `isDirty: true` to their
+`copyWith(...)` argument lists (line numbers from current `main`):
 
 | File | Line | Operation |
 |------|------|-----------|
 | `disting_cubit_parameter_value_delegate.dart` | 59, 107 | parameter write (real-time + release) |
 | `disting_cubit_parameter_string_delegate.dart` | 43, 93, 131 | string parameter write |
-| `disting_cubit_algorithm_ops.dart` | 110, 126, 223, 319, 437 | add / remove / move algorithms (optimistic emits) |
-| `disting_cubit_algorithm_ops.dart` | 172, 185, 370, 483 | add / move verification emits — preserve `isDirty` (the optimistic emit already set it) |
-| `disting_cubit_slot_ops.dart` | 33 | slot custom-name optimistic |
-| `disting_cubit_slot_ops.dart` | 69 | slot custom-name verification — preserve |
-| `disting_cubit_slot_state_delegate.dart` | 71, 128, 170, 196, 227, 248 | slot state updates (parameter pages, output modes) |
+| `disting_cubit_algorithm_ops.dart` | 110, 126, 223, 319, 437 | add / remove / move algorithms — optimistic emits |
+| `disting_cubit_slot_ops.dart` | 33, 69 | slot custom name |
+| `disting_cubit_slot_state_delegate.dart` | 71, 128, 170, 196, 227, 248 | slot state updates |
 | `disting_cubit_slot_maintenance_delegate.dart` | 98, 135 | slot repair |
 | `disting_cubit_mapping_delegate.dart` | 84, 135, 175 | CV / MIDI / i2c / performance mapping |
 | `disting_cubit_perf_page_delegate.dart` | 34, 62 | perf page item edits |
 | `disting_cubit_preset_ops.dart` | 39 | preset rename optimistic emit |
 
-Device-truth emits — preserve current `isDirty`:
+The following call sites are **not user mutations** and must **not**
+set `isDirty: true`. They preserve the current `isDirty` value
+(omit the field from `copyWith` so it stays unchanged) — they reflect
+device truth or non-preset state:
 
 | File | Line | Why |
 |------|------|-----|
-| `disting_cubit_parameter_refresh_delegate.dart` | 66, 115, 247, 317 | live polling reflects device truth |
+| `disting_cubit_parameter_refresh_delegate.dart` | 66, 115, 247, 317 | live polling — device truth, not user changes |
 | `disting_cubit_cc_notification_delegate.dart` | 216 | CC value reflection from device |
+| `disting_cubit_state_refresh_delegate.dart` | 16, 47 | loading/error paths (the success path explicitly clears — see below) |
 | `disting_cubit_hardware_commands_delegate.dart` | 20 | screenshot only |
-| `disting_cubit_monitoring_delegate.dart` | 74, 90 | video stream state |
-| `disting_cubit_preset_ops.dart` | 56, 74 | rename verification correction (device truth) |
-| `disting_cubit.dart` | 893, 999 | firmware-update notice |
-
-Full-refresh emits — explicitly set `isDirty: false`:
-
-| File | Line | Why |
-|------|------|-----|
-| `disting_cubit_state_refresh_delegate.dart` | 34 | refreshed from device |
-| `disting_cubit_connection_delegate.dart` | 281 | initial sync emit (relies on Freezed default) |
-| `disting_cubit_offline_demo_delegate.dart` | 30, 72, 107, 193 | fresh state constructions |
-
-Out-of-scope (non-preset state) — pass through:
-
-| File | Line | Why |
-|------|------|-----|
-| `disting_cubit_state_refresh_delegate.dart` | 16, 47 | loading/error transitions |
-| `disting_cubit_algorithm_library_delegate.dart` | all | algorithm library cache, not preset |
-| `disting_cubit_connection_delegate.dart` | (other lines) | connection lifecycle |
-| `disting_cubit_plugin_delegate.dart` | 663 | algorithm library, not preset |
+| `disting_cubit_monitoring_delegate.dart` | 74, 90 | video/CPU stream state |
+| `disting_cubit_algorithm_library_delegate.dart` | all | algorithm library cache, not preset content |
+| `disting_cubit_connection_delegate.dart` | all | connection lifecycle (initial sync uses default `false`) |
+| `disting_cubit_plugin_delegate.dart` | 663 | algorithm library, not preset content |
+| `disting_cubit_algorithm_ops.dart` | 172, 185, 370, 483 | post-add/move *verification* refreshes — preserve isDirty (the optimistic emit already set it; these refreshes only correct slot details) |
 
 Routing changes flow through the existing `RoutingEditorCubit`, which
-calls back into `DistingCubit` via parameter writes — covered by the
-parameter-write path automatically.
+calls back into `DistingCubit` via parameter writes — so they're
+covered by the parameter-write path automatically.
 
 ### Clear rule
 
 `isDirty` is set back to `false` at exactly the points where the
 in-memory preset is fully resynchronised with a known clean baseline:
 
-1. **Save completes** — see "Save flow" below.
-2. **State refresh from device** — `_StateRefreshDelegate.refreshStateFromManager`
-   line 34: explicitly add `isDirty: false` to the `copyWith`.
+1. **Save completes** — `cubit.savePreset()` emits `isDirty: false`
+   on success (see "Save flow" below).
+2. **State refresh from device** —
+   `_StateRefreshDelegate.refreshStateFromManager` line 34 explicitly
+   sets `isDirty: false`. Refreshing pulls fresh slots and preset
+   name from the device, so the in-memory copy *is* the device copy.
+   We set this **explicitly** rather than relying on Freezed's
+   default, because the existing emit chains a `copyWith` from the
+   prior (possibly dirty) state.
 3. **New preset** — `newPresetImpl` calls `requestNewPreset()` then
    `_refreshStateFromManager()`, which resets via #2.
 4. **Load preset (online)** — `loadPresetImpl` calls
@@ -287,15 +201,13 @@ in-memory preset is fully resynchronised with a known clean baseline:
    resets via #2.
 5. **Load preset (offline)** — `_OfflineDemoDelegate.loadPresetOffline`
    constructs a fresh `DistingStateSynchronized`; default
-   `isDirty: false` applies. Verify no `copyWith` paths in this
-   delegate inadvertently preserve a stale dirty flag from a prior
-   state.
-6. **Demo init** — same as #5.
-7. **Initial sync** — `performSyncAndEmit` (connection delegate
-   line 281) constructs `DistingState.synchronized(...)` without
-   passing `isDirty`; the Freezed `@Default(false)` applies. No code
-   change needed if Freezed's defaults work as expected. Verify by
-   inspecting generated `disting_state.freezed.dart` after build_runner.
+   `isDirty: false` applies.
+6. **Demo / offline init** — same as #5.
+
+The rename verification path (`disting_cubit_preset_ops.dart` lines
+56, 74) corrects the preset name to device truth if the rename failed.
+These corrections **preserve the existing `isDirty` value** — they're
+neither a fresh mutation by the user nor a full refresh.
 
 ### Save flow
 
@@ -308,61 +220,64 @@ The current save path bypasses the cubit: three sites in
 Future<void> savePreset() async {
   final s = state;
   if (s is! DistingStateSynchronized) return;
-  final disting = s.disting;
   try {
-    await disting.requestSavePreset();
+    await s.disting.requestSavePreset();
+    final cur = state;
+    if (cur is DistingStateSynchronized) {
+      _emitState(cur.copyWith(isDirty: false));
+    }
   } catch (_) {
-    rethrow;  // Leave isDirty as-is; a failed save did not actually persist.
-  }
-  // Re-check state after the await: connection could have dropped.
-  final after = state;
-  if (after is DistingStateSynchronized) {
-    _emitState(after.copyWith(isDirty: false));
+    // Leave isDirty as-is; a failed save did not actually persist.
+    rethrow;
   }
 }
 ```
 
-The two-step (snapshot before await, re-read after) is intentional:
-between the `await` and the emit, state could have transitioned to
-`DistingStateConnected` or `DistingStateInitial` (e.g., disconnect).
-Re-reading `state` after the await catches that.
+Re-reading `state` after the `await` is deliberate: a parameter write
+or refresh may have landed during the save. We always re-check the
+current state class before emitting.
 
-Update the three UI call sites to use `cubit.savePreset()`. The
-keyboard shortcut path (line 503) and the popup-menu path (line 1851)
-both go through cleanly. The "Save First & New" path (line 1828) also
-calls `cubit.newPreset()` immediately after; reorder to
-`await cubit.savePreset(); cubit.newPreset();` so the save resolves
-before the new-preset state machine runs (which would otherwise also
-clear the flag via the refresh path, but the explicit ordering avoids
-a race).
-
-The auto-save inside `renamePresetImpl` (line 45) — `disting.requestSavePreset().catchError((_) {})`
-— must also clear the flag. Replace it with a deferred clear:
+Update the three call sites in `synchronized_screen.dart` to use
+`cubit.savePreset()`. The "Save First & New" path (line 1828) becomes:
 
 ```dart
-disting.requestSavePreset().then((_) {
-  final cur = state;
-  if (cur is DistingStateSynchronized) {
-    _emitState(cur.copyWith(isDirty: false));
-  }
-}).catchError((_) {});
+try {
+  await cubit.savePreset();
+  cubit.newPreset();
+} catch (e) {
+  // existing error UI
+}
 ```
 
-This is the only change to rename behaviour; otherwise the rename flow
-is untouched. Justification: the rename path already triggers a save,
-so the flag must clear when that save resolves — otherwise rename
-would leave a misleading `*` until the user manually saved again.
+so `newPreset()` only runs on a successful save.
 
-The `disting_controller_impl.dart` line 327 `savePreset()` (used by
-MCP) currently calls `_getManager().requestSavePreset()` directly.
-Change to `await _distingCubit.savePreset();` so MCP-driven saves also
-clear the flag. The `_getSynchronizedState()` precondition check
-remains; it will throw before `_distingCubit.savePreset()` if state
-isn't synchronized.
+The auto-save inside `renamePresetImpl` (line 45) — `disting.requestSavePreset().catchError((_) {})`
+— is **out of scope for this change**. It's a fire-and-forget best-effort
+operation; the dirty flag will simply remain set until the next save /
+refresh / load. (The user-visible behaviour: rename a preset and the
+asterisk will appear briefly until the next refresh or save.) This is
+acceptable and avoids touching the rename verification machinery in
+this PR.
 
-The `metadata_sync_cubit.dart` line 329 save is part of an internal
-sync orchestration that already calls back into `_refreshStateFromManager()`,
-which will clear the flag via the refresh rule. No change needed.
+### MCP / external save paths
+
+`DistingControllerImpl.savePreset`
+(`lib/services/disting_controller_impl.dart` line 329) currently calls
+`_getManager().requestSavePreset()` directly, bypassing the cubit. To
+keep the dirty flag in sync for MCP-driven saves, route through the
+cubit:
+
+```dart
+await _distingCubit.savePreset();
+```
+
+If the controller cannot reach a cubit instance in some test paths,
+fall back to the existing direct-manager call — the contract is "if a
+cubit is reachable, clear the flag through it."
+
+The `metadata_sync_cubit.dart` line 329 save is a different flow that
+already orchestrates `_refreshStateFromManager()` itself, which clears
+the flag via the refresh rule. No change needed.
 
 ### UI change
 
@@ -405,109 +320,74 @@ Semantics(
 ```
 
 The asterisk uses the same text style as the preset name — no separate
-icon, no colour change. We use an asterisk because it is the universally
-recognised "modified document" marker across editors (Vim, VSCode,
-Sublime, Xcode, etc.); Material Design has no specific guidance for
-in-text "modified" indicators on preset/document headers, so the
-text-editor convention applies. Spoken accessibility uses the phrase
-"unsaved changes" rather than reading "asterisk" aloud, matching the
-existing semantic-label patterns in the screen.
+icon, no colour change. Spoken accessibility uses the phrase "unsaved
+changes" rather than reading "asterisk" aloud. (Convention: VS Code,
+Vim, Sublime, Xcode all use a trailing asterisk or modified-dot for
+unsaved documents.)
 
 ## Edge cases
 
 - **Rename to the same name**: `renamePresetImpl` early-returns
   (line 36) before emitting, so `isDirty` is unchanged. Correct.
-- **Rename verification correction**: lines 56 and 74 emit
-  `verificationState.copyWith(presetName: actual)` after a rename
-  failure or device-truth correction. These must explicitly preserve
-  `isDirty` (`isDirty: verificationState.isDirty`) — otherwise the
-  freezed `copyWith` keeps the existing value, but adding the
-  explicit pass is required by the mutation rule and prevents
-  silent regressions.
-- **Rename succeeds + autosave fires + user mutates before autosave
-  resolves**: window of milliseconds; the autosave clear may
-  overwrite a fresh user mutation's `isDirty: true`. Mitigated by the
-  fact that the autosave clear re-reads `state` and sets
-  `isDirty: false` — but a user write that lands between the autosave
-  resolving and the clear emitting would be lost. Acceptable: the
-  window is tens of milliseconds and the user's next mutation will
-  immediately re-mark dirty.
 - **Parameter slider scrubbing back to original value**: marks dirty.
   Acceptable per non-goals.
 - **Failed save**: the `await disting.requestSavePreset()` may throw or
   silently fail; the cubit's `try/rethrow` keeps `isDirty: true` so
-  the user retains the indicator. UI call sites that previously
-  didn't await the save now have a future to consider — the new
-  `savePreset()` returns `Future<void>` and may throw. The popup-menu
-  and shortcut handlers should ignore failures (existing behaviour);
-  the "Save First & New" handler awaits before calling `newPreset()`.
-- **Live parameter polling races user mutation**: polling emits
-  preserve `isDirty: currentState.isDirty`, so a poll landing right
-  after a user mutation keeps the dirty flag set. Without the explicit
-  preserve, freezed's `copyWith` would also keep it (since the field
-  isn't passed), but the rule requires explicit pass-through.
-- **CC notification reflections** likewise reflect device-side changes;
-  preserve dirty.
-- **External save (auto-save during rename, MCP-driven save, sync
-  flow save)**: covered via the rename autosave change, the MCP
-  controller change, and the refresh path for sync-driven flows.
-- **Lua reload** (`disting_cubit_lua_reload_delegate.dart`): the
-  reload flow re-issues parameter writes via the standard parameter
-  delegate, which will mark dirty. The reload itself does not emit a
-  state directly (it issues SysEx writes that trigger downstream
-  refresh paths). No additional code change needed; verify by
-  triggering a reload and watching the indicator.
-- **Algorithm-add verification** (`algorithm_ops.dart` line 172): the
-  verification re-fetches the slot from the device and emits with the
-  fresh slot. Optimistic emit at line 110 already set `isDirty: true`;
-  the verify emit must `copyWith(slots: ..., isDirty: state.isDirty)`
-  to preserve.
-- **Initial sync** (`connection_delegate.dart` line 281): builds a
-  fresh `DistingState.synchronized(...)`. `isDirty` is omitted, so
-  Freezed's `@Default(false)` applies. Verify the generated freezed
-  file actually emits the default after `build_runner` runs.
+  the user retains the indicator. Acceptable; matches user mental
+  model ("the save didn't work, my changes are still unsaved").
+- **Save succeeds but device disconnects mid-save** (state machine
+  transitions out of `DistingStateSynchronized` between the await and
+  the emit): the post-save emit is skipped because the state class
+  no longer matches. On reconnect, the sync flow builds a fresh
+  `DistingStateSynchronized` (default `isDirty: false`). This is
+  correct — the device persisted, and the new state reflects device
+  truth.
+- **User mutation lands during a save**: the `await` in `savePreset`
+  yields the event loop. If the user moves a slider during the save,
+  the slider write emits `isDirty: true` first, then `savePreset`
+  re-reads `state` and emits `isDirty: false`. The newer mutation is
+  silently re-marked clean. **This is a known small race window**
+  measured in tens of milliseconds (one MIDI request/response). It is
+  not worth a counter or sequence number for this feature; the next
+  user mutation will mark it dirty again.
+- **User mutation lands during a refresh**: same race shape — refresh
+  emits `isDirty: false`, the mutation lands and emits `true`. Order
+  on the event queue determines outcome. Acceptable; matches the
+  existing optimistic-emit-then-verify pattern used throughout the
+  cubit.
+- **Live parameter polling** (`_parameter_refresh_delegate`) updates
+  `slots` from device truth. These must **not** flip `isDirty: true`
+  even though they emit slot changes. The mutation table above
+  explicitly excludes them; they preserve current `isDirty`.
+- **CC notification reflections** (`_cc_notification_delegate`) likewise
+  reflect device-side changes; excluded.
+- **Algorithm-op verification refreshes** (`_algorithm_ops` lines 172,
+  185, 370, 483) re-emit slot details a beat after the optimistic
+  emit. The optimistic emit already set dirty; verification preserves
+  it (omit `isDirty` from `copyWith`).
+- **Plugin install** doesn't directly mutate preset content. If
+  installing a plugin causes a `_refreshStateFromManager()` to fire,
+  the refresh path correctly clears the flag — same code path as a
+  manual refresh. Consistent.
+- **Lua reload** (`disting_cubit_lua_reload_delegate.dart`) restores
+  parameter values on the device by replaying parameter writes. Each
+  parameter write goes through the standard parameter-write path,
+  which marks dirty. This matches user mental model: a Lua reload
+  that re-applies values *is* a mutation from the device's
+  saved-preset perspective until the next explicit save.
+- **Checkpoint restore** likewise replays parameter writes; marks
+  dirty. Correct.
 - **Offline mode**: parameter writes still queue to the
   `OfflineDistingMidiManager`, which persists to local storage on
   `requestSavePreset()`. The dirty flag behaves identically.
-- **Demo mode**: in demo mode there's no real persistence, but mutations
-  still emit slot changes and `requestSavePreset()` is a no-op on the
-  mock manager. The flag still flips to true on mutation and clears on
-  the no-op save. Harmless.
+- **Demo mode**: `requestSavePreset()` is a no-op on the mock manager.
+  The flag still flips to true on mutation and clears on the no-op
+  save. Harmless.
 - **Connection loss mid-edit**: state transitions back to
   `DistingStateConnected` or `DistingStateInitial`, neither of which
   has `isDirty`. Reconnecting goes through the sync flow which builds
   a fresh `DistingStateSynchronized` (clean). Any unsaved edits are
   lost — that's existing behaviour, unchanged.
-- **Connection loss mid-save**: `cubit.savePreset()` re-reads `state`
-  after the `await` and only emits the clear if state is still
-  `DistingStateSynchronized`. If the device disconnects mid-save, the
-  emit is skipped and state has already transitioned away — the dirty
-  flag is moot until reconnect, where a fresh sync produces a clean
-  state. Acceptable; matches the existing "connection-lost wipes
-  in-memory edits" model.
-- **Checkpoint undo/redo back to original state**
-  (`_CheckpointDelegate.restoreCheckpoint`): restoring a checkpoint
-  re-issues parameter writes via the standard write path, each of
-  which sets `isDirty: true`. If the user undoes back to a checkpoint
-  taken at a clean baseline, the in-memory preset matches the device's
-  saved copy but the flag stays dirty. This is consistent with the
-  documented non-goal ("we track *whether mutations occurred*, not
-  *whether they round-trip to the same bytes*") and matches the
-  text-editor convention. A future "discard / revert" feature could
-  layer a clean-flag clear on top of checkpoint restore — out of scope
-  here.
-- **MCP server tool calls** that mutate state (`add_algorithm`,
-  `set_parameter_value`, etc.) flow through the same cubit methods, so
-  they correctly mark dirty. MCP-driven save is fixed via the
-  controller change above.
-- **`loadPresetOffline`** (cubit.dart line 300): clears checkpoints and
-  delegates to `_offlineDemoDelegate.loadPresetOffline`, which builds
-  a fresh `DistingStateSynchronized`. Default `isDirty: false` applies.
-- **Plugin install** (`plugin_delegate.dart` line 663): updates the
-  algorithm *library*, not preset contents. Out of scope; preserve
-  dirty.
-- **SD card preset operations**: scanning is read-only; loading goes
-  through `loadPresetImpl` which clears via refresh.
 - **Build-runner**: the freezed change requires regenerating
   `disting_state.freezed.dart`. Run
   `dart run build_runner build --delete-conflicting-outputs` per
@@ -517,48 +397,47 @@ existing semantic-label patterns in the screen.
 
 New file `test/cubit/preset_dirty_indicator_test.dart`:
 
-1. Fresh synchronized state has `isDirty == false`.
+1. Fresh sync state has `isDirty == false`.
 2. After `updateParameterValue(...)`, state is dirty.
 3. After `onAddAlgorithm(...)`, state is dirty.
 4. After `onRemoveAlgorithm(...)`, state is dirty.
 5. After `moveAlgorithmUp/Down(...)`, state is dirty.
-6. After `renamePreset(...)` to a new name, state is dirty until the
-   autosave resolves, then becomes clean.
+6. After `renamePreset(...)` to a new name, optimistic state is dirty.
 7. After `saveMapping(...)`, state is dirty.
-8. After a parameter-refresh emit (simulated via the live polling
-   delegate), the prior `isDirty` is **preserved** — true stays true,
-   false stays false.
-9. After a rename verification correction emit, prior `isDirty` is
-   preserved.
-10. `cubit.savePreset()` clears the flag on success.
-11. `cubit.savePreset()` leaves the flag set on failure (manager
-    throws).
-12. `cubit.savePreset()` is a no-op when state is not
-    `DistingStateSynchronized`.
+8. After `setPerfPageItem(...)`, state is dirty.
+9. After a parameter-refresh emit (simulated via the live polling
+   delegate), state preserves dirty (still true if it was true; still
+   false if it was false).
+10. `savePreset()` clears the flag on success.
+11. `savePreset()` leaves the flag set on failure (manager throws).
+12. `savePreset()` does not crash if state is not synchronized (early
+    return).
 13. `loadPreset(...)` clears the flag (via refresh path).
 14. `newPreset()` clears the flag (via refresh path).
 15. `refresh()` clears the flag.
-16. `disting_controller_impl.savePreset()` (MCP path) clears the flag.
+16. Algorithm-op verification refresh preserves prior dirty state.
 
 Widget test in `test/ui/synchronized_screen_dirty_indicator_test.dart`:
 
 1. With `isDirty: false`, header text is `Preset: <name>`.
 2. With `isDirty: true`, header text is `Preset: <name> *`.
-3. Semantic label includes "unsaved changes" when dirty.
+3. Semantic label includes "unsaved changes" when dirty; does not
+   include it when clean.
 
 Manual smoke (cannot run from CI):
 
 - Connect to hardware (or use demo mode).
 - Move a parameter slider; observe asterisk appears.
 - Hit Save Preset; observe asterisk clears.
-- Rename preset; observe asterisk appears momentarily then clears
-  (autosave).
+- Add an algorithm; observe asterisk appears, persists across
+  verification refresh.
 - Load a different preset; observe asterisk clears.
-- Trigger MCP save via the controller; observe asterisk clears.
+- Trigger a refresh; observe asterisk clears.
 
 ## Rollout
 
 Single PR. No feature flag — the indicator is purely additive UI and
 the new cubit field is free for any code path that ignores it. Run
-`flutter analyze` (must pass with zero warnings) and `flutter test`
-before opening the PR.
+`dart run build_runner build --delete-conflicting-outputs` first
+because the freezed state class changes. Then `flutter analyze` (must
+pass with zero warnings) and `flutter test` before opening the PR.

--- a/specs/2026-05-04_preset-dirty-indicator.md
+++ b/specs/2026-05-04_preset-dirty-indicator.md
@@ -181,6 +181,41 @@ refactoring (e.g., if someone adds a default constructor that emits
 `isDirty: false`). Where a site already passes other unrelated fields
 forward, this is a one-line change.
 
+#### Bare positional `DistingState.synchronized(...)` calls
+
+Two sites in `disting_cubit_algorithm_ops.dart` (lines 370–388,
+483–501, the move-up and move-down verification corrections) currently
+build the synchronized state with a positional/named constructor call
+rather than `copyWith`. They omit several existing defaulted fields
+(`videoStream`, `availableFirmwareUpdate`, `perfPageItems`) and would
+similarly default the new `isDirty` to `false` — silently clearing the
+indicator after a verified-but-corrected move.
+
+**Required change**: replace each with
+`verificationState.copyWith(slots: actualSlots, loading: false)`.
+`copyWith` preserves every other field, including `isDirty`, and
+removes a maintenance hazard for any future field on
+`DistingStateSynchronized`. This is a small drive-by correctness fix
+that the dirty-indicator change forces; it is in scope.
+
+#### Optimistic-rollback emits
+
+Several lines in `disting_cubit_algorithm_ops.dart` (e.g., line 126,
+the rollback path that pops the optimistically-added slot when the
+device add fails) emit a `copyWith` that *un-does* a user-initiated
+mutation. The emit's slot list is the pre-mutation state, but we have
+no record of whether other slots had unsaved edits before. The
+pragmatic rule:
+
+- **Rollback emits leave `isDirty` unchanged** (omit `isDirty` from the
+  `copyWith` argument list — Freezed preserves it). The user may have
+  had prior unsaved changes; rolling back a single failed mutation
+  does not magically save them.
+
+This applies symmetrically to any future rollback path. The mutation
+table entries for these lines describe the *successful* optimistic
+emit; rollback emits inherit `isDirty` via Freezed's preserve.
+
 ### Mutation site reference (illustrative, not authoritative)
 
 The following table is a **starting point** derived from the codebase
@@ -443,6 +478,24 @@ existing semantic-label patterns in the screen.
   has `isDirty`. Reconnecting goes through the sync flow which builds
   a fresh `DistingStateSynchronized` (clean). Any unsaved edits are
   lost — that's existing behaviour, unchanged.
+- **Connection loss mid-save**: `cubit.savePreset()` re-reads `state`
+  after the `await` and only emits the clear if state is still
+  `DistingStateSynchronized`. If the device disconnects mid-save, the
+  emit is skipped and state has already transitioned away — the dirty
+  flag is moot until reconnect, where a fresh sync produces a clean
+  state. Acceptable; matches the existing "connection-lost wipes
+  in-memory edits" model.
+- **Checkpoint undo/redo back to original state**
+  (`_CheckpointDelegate.restoreCheckpoint`): restoring a checkpoint
+  re-issues parameter writes via the standard write path, each of
+  which sets `isDirty: true`. If the user undoes back to a checkpoint
+  taken at a clean baseline, the in-memory preset matches the device's
+  saved copy but the flag stays dirty. This is consistent with the
+  documented non-goal ("we track *whether mutations occurred*, not
+  *whether they round-trip to the same bytes*") and matches the
+  text-editor convention. A future "discard / revert" feature could
+  layer a clean-flag clear on top of checkpoint restore — out of scope
+  here.
 - **MCP server tool calls** that mutate state (`add_algorithm`,
   `set_parameter_value`, etc.) flow through the same cubit methods, so
   they correctly mark dirty. MCP-driven save is fixed via the

--- a/test/cubit/preset_dirty_indicator_test.dart
+++ b/test/cubit/preset_dirty_indicator_test.dart
@@ -28,6 +28,14 @@ void main() {
     TestWidgetsFlutterBinding.ensureInitialized();
     SharedPreferences.setMockInitialValues({});
     registerFallbackValue(DistingState.initial());
+    registerFallbackValue(
+      AlgorithmInfo(
+        algorithmIndex: 0,
+        name: 'fallback',
+        guid: 'fallback',
+        specifications: const [],
+      ),
+    );
   });
 
   setUp(() {
@@ -196,6 +204,72 @@ void main() {
         parameterNumber: 0,
         value: 'hi',
       );
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);
+    });
+  });
+
+  group('cubit algorithm ops', () {
+    test('onAlgorithmSelected marks state dirty', () async {
+      final algorithmInfo = AlgorithmInfo(
+        algorithmIndex: 0,
+        name: 'Test Algo',
+        guid: 'test',
+        specifications: const [],
+      );
+      when(
+        () => mockDisting.requestAddAlgorithm(any(), any()),
+      ).thenAnswer((_) async {});
+
+      cubit.emit(makeSyncState());
+      await cubit.onAlgorithmSelected(algorithmInfo, const []);
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);
+    });
+
+    test('onRemoveAlgorithm marks state dirty', () async {
+      when(
+        () => mockDisting.requestRemoveAlgorithm(any()),
+      ).thenAnswer((_) async {});
+
+      cubit.emit(makeSyncState(slots: [makeSlot()]));
+      await cubit.onRemoveAlgorithm(0);
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);
+    });
+
+    test('moveAlgorithmUp marks state dirty', () async {
+      when(
+        () => mockDisting.requestMoveAlgorithmUp(any()),
+      ).thenAnswer((_) async {});
+
+      cubit.emit(
+        makeSyncState(
+          slots: [
+            makeSlot(algorithmIndex: 0),
+            makeSlot(algorithmIndex: 1),
+          ],
+        ),
+      );
+      await cubit.moveAlgorithmUp(1);
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);
+    });
+
+    test('moveAlgorithmDown marks state dirty', () async {
+      when(
+        () => mockDisting.requestMoveAlgorithmDown(any()),
+      ).thenAnswer((_) async {});
+
+      cubit.emit(
+        makeSyncState(
+          slots: [
+            makeSlot(algorithmIndex: 0),
+            makeSlot(algorithmIndex: 1),
+          ],
+        ),
+      );
+      await cubit.moveAlgorithmDown(0);
 
       expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);
     });

--- a/test/cubit/preset_dirty_indicator_test.dart
+++ b/test/cubit/preset_dirty_indicator_test.dart
@@ -314,6 +314,36 @@ void main() {
     });
   });
 
+  group('cubit.refresh()', () {
+    test('clears isDirty when state refresh from device succeeds', () async {
+      when(
+        () => mockDisting.requestNumAlgorithmsInPreset(),
+      ).thenAnswer((_) async => 0);
+      when(
+        () => mockDisting.requestPresetName(),
+      ).thenAnswer((_) async => 'Refreshed');
+
+      // Offline avoids the background algorithm refresh side-effect.
+      cubit.emit(
+        DistingStateSynchronized(
+          disting: mockDisting,
+          distingVersion: '1.10.0',
+          firmwareVersion: FirmwareVersion('1.14.0'),
+          presetName: 'Test Preset',
+          algorithms: const [],
+          slots: const [],
+          unitStrings: const [],
+          offline: true,
+          isDirty: true,
+        ),
+      );
+
+      await cubit.refresh();
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isFalse);
+    });
+  });
+
   group('cubit.savePreset()', () {
     test('clears isDirty on success', () async {
       when(() => mockDisting.requestSavePreset()).thenAnswer((_) async {});

--- a/test/cubit/preset_dirty_indicator_test.dart
+++ b/test/cubit/preset_dirty_indicator_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/cubit/disting_cubit.dart';
+import 'package:nt_helper/db/daos/metadata_dao.dart';
+import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/domain/i_disting_midi_manager.dart';
+import 'package:nt_helper/models/firmware_version.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../test_helpers/mock_midi_command.dart';
+
+class MockAppDatabase extends Mock implements AppDatabase {}
+
+class MockMetadataDao extends Mock implements MetadataDao {}
+
+class MockDistingMidiManager extends Mock implements IDistingMidiManager {}
+
+void main() {
+  late DistingCubit cubit;
+  late MockAppDatabase mockDatabase;
+  late MockMetadataDao mockMetadataDao;
+  late MockDistingMidiManager mockDisting;
+  late MockMidiCommand mockMidiCommand;
+
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    registerFallbackValue(DistingState.initial());
+  });
+
+  setUp(() {
+    mockDatabase = MockAppDatabase();
+    mockMetadataDao = MockMetadataDao();
+    mockDisting = MockDistingMidiManager();
+    mockMidiCommand = MockMidiCommand();
+
+    when(() => mockDatabase.metadataDao).thenReturn(mockMetadataDao);
+    when(
+      () => mockMetadataDao.hasCachedAlgorithms(),
+    ).thenAnswer((_) async => false);
+
+    cubit = DistingCubit(mockDatabase, midiCommand: mockMidiCommand);
+  });
+
+  tearDown(() async {
+    await cubit.close();
+  });
+
+  DistingStateSynchronized makeSyncState({
+    String presetName = 'Test Preset',
+    bool isDirty = false,
+  }) {
+    return DistingStateSynchronized(
+      disting: mockDisting,
+      distingVersion: '1.10.0',
+      firmwareVersion: FirmwareVersion('1.14.0'),
+      presetName: presetName,
+      algorithms: const [],
+      slots: const [],
+      unitStrings: const [],
+      offline: false,
+      isDirty: isDirty,
+    );
+  }
+
+  group('DistingStateSynchronized.isDirty default', () {
+    test('a freshly constructed synchronized state has isDirty == false', () {
+      final s = DistingStateSynchronized(
+        disting: mockDisting,
+        distingVersion: '1.10.0',
+        firmwareVersion: FirmwareVersion('1.14.0'),
+        presetName: 'New',
+        algorithms: const [],
+        slots: const [],
+        unitStrings: const [],
+      );
+      expect(s.isDirty, isFalse);
+    });
+
+    test('makeSyncState helper still respects explicit isDirty values', () {
+      expect(makeSyncState().isDirty, isFalse);
+      expect(makeSyncState(isDirty: true).isDirty, isTrue);
+    });
+  });
+}

--- a/test/cubit/preset_dirty_indicator_test.dart
+++ b/test/cubit/preset_dirty_indicator_test.dart
@@ -3,8 +3,10 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nt_helper/cubit/disting_cubit.dart';
 import 'package:nt_helper/db/daos/metadata_dao.dart';
 import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/domain/disting_nt_sysex.dart';
 import 'package:nt_helper/domain/i_disting_midi_manager.dart';
 import 'package:nt_helper/models/firmware_version.dart';
+import 'package:nt_helper/models/packed_mapping_data.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../test_helpers/mock_midi_command.dart';
@@ -46,9 +48,70 @@ void main() {
     await cubit.close();
   });
 
+  Slot makeSlot({int algorithmIndex = 0, int paramCount = 1}) {
+    return Slot(
+      algorithm: Algorithm(
+        algorithmIndex: algorithmIndex,
+        guid: 'test',
+        name: 'Test',
+      ),
+      routing: RoutingInfo.filler(),
+      pages: ParameterPages(
+        algorithmIndex: algorithmIndex,
+        pages: const [],
+      ),
+      parameters: List.generate(
+        paramCount,
+        (i) => ParameterInfo(
+          algorithmIndex: algorithmIndex,
+          parameterNumber: i,
+          min: 0,
+          max: 100,
+          defaultValue: 0,
+          unit: 0,
+          name: 'p$i',
+          powerOfTen: 0,
+        ),
+      ),
+      values: List.generate(
+        paramCount,
+        (i) => ParameterValue(
+          algorithmIndex: algorithmIndex,
+          parameterNumber: i,
+          value: 0,
+        ),
+      ),
+      enums: List.generate(
+        paramCount,
+        (i) => ParameterEnumStrings(
+          algorithmIndex: algorithmIndex,
+          parameterNumber: i,
+          values: const [],
+        ),
+      ),
+      mappings: List.generate(
+        paramCount,
+        (i) => Mapping(
+          algorithmIndex: algorithmIndex,
+          parameterNumber: i,
+          packedMappingData: PackedMappingData.filler(),
+        ),
+      ),
+      valueStrings: List.generate(
+        paramCount,
+        (i) => ParameterValueString(
+          algorithmIndex: algorithmIndex,
+          parameterNumber: i,
+          value: '',
+        ),
+      ),
+    );
+  }
+
   DistingStateSynchronized makeSyncState({
     String presetName = 'Test Preset',
     bool isDirty = false,
+    List<Slot>? slots,
   }) {
     return DistingStateSynchronized(
       disting: mockDisting,
@@ -56,7 +119,7 @@ void main() {
       firmwareVersion: FirmwareVersion('1.14.0'),
       presetName: presetName,
       algorithms: const [],
-      slots: const [],
+      slots: slots ?? const [],
       unitStrings: const [],
       offline: false,
       isDirty: isDirty,
@@ -80,6 +143,36 @@ void main() {
     test('makeSyncState helper still respects explicit isDirty values', () {
       expect(makeSyncState().isDirty, isFalse);
       expect(makeSyncState(isDirty: true).isDirty, isTrue);
+    });
+  });
+
+  group('cubit.updateParameterValue()', () {
+    test('marks state dirty (real-time slider scrub)', () async {
+      cubit.emit(makeSyncState(slots: [makeSlot()]));
+      expect((cubit.state as DistingStateSynchronized).isDirty, isFalse);
+
+      await cubit.updateParameterValue(
+        algorithmIndex: 0,
+        parameterNumber: 0,
+        value: 42,
+        userIsChangingTheValue: true,
+      );
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);
+    });
+
+    test('marks state dirty (slider release)', () async {
+      cubit.emit(makeSyncState(slots: [makeSlot()]));
+      expect((cubit.state as DistingStateSynchronized).isDirty, isFalse);
+
+      await cubit.updateParameterValue(
+        algorithmIndex: 0,
+        parameterNumber: 0,
+        value: 50,
+        userIsChangingTheValue: false,
+      );
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);
     });
   });
 

--- a/test/cubit/preset_dirty_indicator_test.dart
+++ b/test/cubit/preset_dirty_indicator_test.dart
@@ -374,6 +374,23 @@ void main() {
     });
   });
 
+  group('cubit preset rename', () {
+    test('renamePreset marks state dirty (optimistic)', () async {
+      when(
+        () => mockDisting.requestSetPresetName(any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockDisting.requestSavePreset(),
+      ).thenAnswer((_) async {});
+
+      cubit.emit(makeSyncState(presetName: 'Old'));
+      cubit.renamePreset('New');
+      await Future<void>.delayed(Duration.zero);
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);
+    });
+  });
+
   group('cubit perf page ops', () {
     test('setPerfPageItem marks state dirty (optimistic)', () async {
       when(

--- a/test/cubit/preset_dirty_indicator_test.dart
+++ b/test/cubit/preset_dirty_indicator_test.dart
@@ -9,6 +9,7 @@ import 'package:nt_helper/domain/disting_nt_sysex.dart';
 import 'package:nt_helper/domain/i_disting_midi_manager.dart';
 import 'package:nt_helper/models/firmware_version.dart';
 import 'package:nt_helper/models/packed_mapping_data.dart';
+import 'package:nt_helper/models/performance_page_item.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../test_helpers/mock_midi_command.dart';
@@ -39,6 +40,7 @@ void main() {
       ),
     );
     registerFallbackValue(PackedMappingData.filler());
+    registerFallbackValue(PerformancePageItem.empty(0));
   });
 
   setUp(() {
@@ -366,6 +368,24 @@ void main() {
       // the optimistic emit.
       unawaited(cubit.setPerformancePageMapping(0, 0, 1));
       // Allow microtask queue to flush so the optimistic emit lands.
+      await Future<void>.delayed(Duration.zero);
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);
+    });
+  });
+
+  group('cubit perf page ops', () {
+    test('setPerfPageItem marks state dirty (optimistic)', () async {
+      when(
+        () => mockDisting.setPerfPageItem(any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockDisting.requestPerfPageItem(any()),
+      ).thenAnswer((_) async => PerformancePageItem.empty(0));
+
+      cubit.emit(makeSyncState());
+      // Don't await — verification retries take seconds.
+      unawaited(cubit.setPerfPageItem(PerformancePageItem.empty(0)));
       await Future<void>.delayed(Duration.zero);
 
       expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);

--- a/test/cubit/preset_dirty_indicator_test.dart
+++ b/test/cubit/preset_dirty_indicator_test.dart
@@ -82,4 +82,37 @@ void main() {
       expect(makeSyncState(isDirty: true).isDirty, isTrue);
     });
   });
+
+  group('cubit.savePreset()', () {
+    test('clears isDirty on success', () async {
+      when(() => mockDisting.requestSavePreset()).thenAnswer((_) async {});
+      cubit.emit(makeSyncState(isDirty: true));
+
+      await cubit.savePreset();
+
+      verify(() => mockDisting.requestSavePreset()).called(1);
+      final s = cubit.state as DistingStateSynchronized;
+      expect(s.isDirty, isFalse);
+    });
+
+    test('leaves isDirty set when save throws', () async {
+      when(
+        () => mockDisting.requestSavePreset(),
+      ).thenAnswer((_) async => throw Exception('save failed'));
+      cubit.emit(makeSyncState(isDirty: true));
+
+      await expectLater(cubit.savePreset(), throwsA(isA<Exception>()));
+
+      final s = cubit.state as DistingStateSynchronized;
+      expect(s.isDirty, isTrue);
+    });
+
+    test('is a no-op when state is not synchronized', () async {
+      // Initial state is DistingStateInitial; no synchronized state present.
+      await cubit.savePreset();
+
+      verifyNever(() => mockDisting.requestSavePreset());
+      expect(cubit.state, isA<DistingStateInitial>());
+    });
+  });
 }

--- a/test/cubit/preset_dirty_indicator_test.dart
+++ b/test/cubit/preset_dirty_indicator_test.dart
@@ -290,6 +290,30 @@ void main() {
     });
   });
 
+  group('device-truth refreshes preserve isDirty', () {
+    test('refreshRouting (slot state delegate) preserves dirty flag', () async {
+      when(
+        () => mockDisting.requestRoutingInformation(any()),
+      ).thenAnswer((_) async => RoutingInfo.filler());
+
+      cubit.emit(makeSyncState(isDirty: true, slots: [makeSlot()]));
+      await cubit.refreshRouting();
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);
+    });
+
+    test('refreshRouting does not falsely mark dirty when clean', () async {
+      when(
+        () => mockDisting.requestRoutingInformation(any()),
+      ).thenAnswer((_) async => RoutingInfo.filler());
+
+      cubit.emit(makeSyncState(slots: [makeSlot()]));
+      await cubit.refreshRouting();
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isFalse);
+    });
+  });
+
   group('cubit.savePreset()', () {
     test('clears isDirty on success', () async {
       when(() => mockDisting.requestSavePreset()).thenAnswer((_) async {});

--- a/test/cubit/preset_dirty_indicator_test.dart
+++ b/test/cubit/preset_dirty_indicator_test.dart
@@ -176,6 +176,31 @@ void main() {
     });
   });
 
+  group('cubit.updateParameterString()', () {
+    test('marks state dirty after setting and refreshing string', () async {
+      when(
+        () => mockDisting.setParameterString(any(), any(), any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockDisting.requestParameterValueString(any(), any()),
+      ).thenAnswer((_) async => ParameterValueString(
+            algorithmIndex: 0,
+            parameterNumber: 0,
+            value: 'hi',
+          ));
+      cubit.emit(makeSyncState(slots: [makeSlot()]));
+      expect((cubit.state as DistingStateSynchronized).isDirty, isFalse);
+
+      await cubit.updateParameterString(
+        algorithmIndex: 0,
+        parameterNumber: 0,
+        value: 'hi',
+      );
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);
+    });
+  });
+
   group('cubit.savePreset()', () {
     test('clears isDirty on success', () async {
       when(() => mockDisting.requestSavePreset()).thenAnswer((_) async {});

--- a/test/cubit/preset_dirty_indicator_test.dart
+++ b/test/cubit/preset_dirty_indicator_test.dart
@@ -275,6 +275,21 @@ void main() {
     });
   });
 
+  group('cubit slot ops', () {
+    test('renameSlot marks state dirty', () async {
+      when(
+        () => mockDisting.requestSendSlotName(any(), any()),
+      ).thenAnswer((_) async {});
+
+      cubit.emit(makeSyncState(slots: [makeSlot()]));
+      cubit.renameSlot(0, 'New Name');
+      // Allow microtask queue to flush so the optimistic emit lands.
+      await Future<void>.delayed(Duration.zero);
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);
+    });
+  });
+
   group('cubit.savePreset()', () {
     test('clears isDirty on success', () async {
       when(() => mockDisting.requestSavePreset()).thenAnswer((_) async {});

--- a/test/cubit/preset_dirty_indicator_test.dart
+++ b/test/cubit/preset_dirty_indicator_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nt_helper/cubit/disting_cubit.dart';
@@ -36,6 +38,7 @@ void main() {
         specifications: const [],
       ),
     );
+    registerFallbackValue(PackedMappingData.filler());
   });
 
   setUp(() {
@@ -311,6 +314,61 @@ void main() {
       await cubit.refreshRouting();
 
       expect((cubit.state as DistingStateSynchronized).isDirty, isFalse);
+    });
+  });
+
+  group('cubit mapping ops', () {
+    test('saveMapping marks state dirty (after device-refresh sweep)',
+        () async {
+      when(
+        () => mockDisting.requestSetMapping(any(), any(), any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockDisting.requestNumAlgorithmsInPreset(),
+      ).thenAnswer((_) async => 0);
+      when(
+        () => mockDisting.requestPresetName(),
+      ).thenAnswer((_) async => 'Test Preset');
+
+      cubit.emit(
+        DistingStateSynchronized(
+          disting: mockDisting,
+          distingVersion: '1.10.0',
+          firmwareVersion: FirmwareVersion('1.14.0'),
+          presetName: 'Test Preset',
+          algorithms: const [],
+          slots: const [],
+          unitStrings: const [],
+          offline: true,
+        ),
+      );
+
+      await cubit.saveMapping(0, 0, PackedMappingData.filler());
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);
+    });
+
+    test('setPerformancePageMapping marks state dirty (optimistic)', () async {
+      when(
+        () => mockDisting.setPerformancePageMapping(any(), any(), any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockDisting.requestMappings(any(), any()),
+      ).thenAnswer((_) async => Mapping(
+            algorithmIndex: 0,
+            parameterNumber: 0,
+            packedMappingData:
+                PackedMappingData.filler().copyWith(perfPageIndex: 1),
+          ));
+
+      cubit.emit(makeSyncState(slots: [makeSlot()]));
+      // Don't await — verification retries take seconds. We only care about
+      // the optimistic emit.
+      unawaited(cubit.setPerformancePageMapping(0, 0, 1));
+      // Allow microtask queue to flush so the optimistic emit lands.
+      await Future<void>.delayed(Duration.zero);
+
+      expect((cubit.state as DistingStateSynchronized).isDirty, isTrue);
     });
   });
 

--- a/test/ui/synchronized_screen_dirty_indicator_test.dart
+++ b/test/ui/synchronized_screen_dirty_indicator_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/core/platform/platform_interaction_service.dart';
+import 'package:nt_helper/cubit/disting_cubit.dart';
+import 'package:nt_helper/domain/i_disting_midi_manager.dart';
+import 'package:nt_helper/models/firmware_version.dart';
+import 'package:nt_helper/services/mcp_server_service.dart';
+import 'package:nt_helper/ui/synchronized_screen.dart';
+
+class MockDistingCubit extends Mock implements DistingCubit {}
+
+class MockDistingMidiManager extends Mock implements IDistingMidiManager {}
+
+class MockPlatformInteractionService extends Mock
+    implements PlatformInteractionService {}
+
+void main() {
+  group('SynchronizedScreen dirty indicator', () {
+    late MockDistingCubit mockCubit;
+    late MockDistingMidiManager mockMidiManager;
+    late MockPlatformInteractionService mockPlatformService;
+
+    setUpAll(() {
+      TestWidgetsFlutterBinding.ensureInitialized();
+    });
+
+    setUp(() {
+      mockCubit = MockDistingCubit();
+      mockMidiManager = MockDistingMidiManager();
+      mockPlatformService = MockPlatformInteractionService();
+      when(() => mockCubit.checkpoints).thenReturn([]);
+      when(() => mockPlatformService.isMobilePlatform()).thenReturn(false);
+      McpServerService.initialize(distingCubit: mockCubit);
+    });
+
+    Widget buildScreen({required bool isDirty, String name = 'My Preset'}) {
+      final state = DistingStateSynchronized(
+        disting: mockMidiManager,
+        distingVersion: '1.10.0',
+        firmwareVersion: FirmwareVersion('1.10.0'),
+        presetName: name,
+        algorithms: const [],
+        slots: const [],
+        unitStrings: const [],
+        offline: true,
+        isDirty: isDirty,
+      );
+      when(() => mockCubit.state).thenReturn(state);
+      when(() => mockCubit.stream).thenAnswer((_) => Stream.value(state));
+
+      return MaterialApp(
+        home: BlocProvider<DistingCubit>.value(
+          value: mockCubit,
+          child: SynchronizedScreen(
+            distingVersion: '1.10.0',
+            firmwareVersion: FirmwareVersion('1.10.0'),
+            slots: const [],
+            algorithms: const [],
+            units: const [],
+            presetName: name,
+            isDirty: isDirty,
+            screenshot: Uint8List(0),
+            loading: false,
+            platformService: mockPlatformService,
+          ),
+        ),
+      );
+    }
+
+    testWidgets('clean state shows preset name without asterisk',
+        (tester) async {
+      await tester.pumpWidget(buildScreen(isDirty: false));
+      // The preset name should appear; no asterisk after it.
+      expect(find.text('My Preset'), findsWidgets);
+      expect(find.text('My Preset *'), findsNothing);
+    });
+
+    testWidgets('dirty state shows preset name followed by asterisk',
+        (tester) async {
+      await tester.pumpWidget(buildScreen(isDirty: true));
+      expect(find.text('My Preset *'), findsWidgets);
+    });
+
+    testWidgets('semantic label includes "unsaved changes" only when dirty',
+        (tester) async {
+      await tester.pumpWidget(buildScreen(isDirty: false));
+      expect(
+        find.bySemanticsLabel(RegExp(r'^Preset: My Preset$')),
+        findsWidgets,
+      );
+      expect(
+        find.bySemanticsLabel(RegExp('unsaved changes')),
+        findsNothing,
+      );
+
+      await tester.pumpWidget(buildScreen(isDirty: true));
+      expect(
+        find.bySemanticsLabel(RegExp('unsaved changes')),
+        findsWidgets,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Displays a dirty indicator (asterisk `*` appended to the preset name) whenever the in-memory preset has been mutated since the last save / load / new / refresh from device. The indicator clears when the user saves, loads, news, or refreshes from the device.

- Adds `isDirty` field to `DistingStateSynchronized` (default `false`)
- User mutations set `isDirty: true`: parameter writes, string parameter writes, algorithm add/remove/move, slot custom-name, slot state updates, mapping changes (CV/MIDI/i2c/perf), perf page edits, slot repair, preset rename
- Device-truth emits (parameter polling, CC reflection, verification refreshes) preserve `isDirty`
- New `cubit.savePreset()` facade clears the flag on success; failure preserves it
- State refresh from device explicitly clears the flag
- `synchronized_screen.dart` save sites and MCP `savePreset` route through the cubit facade
- UI renders ` *` after the preset name; semantic label says "unsaved changes"
- Algorithm-op verification refreshes preserve the optimistic `isDirty: true`

Spec: [`specs/2026-05-04_preset-dirty-indicator.md`](specs/2026-05-04_preset-dirty-indicator.md)

> **Note:** This PR was generated by the substrate `plan-implement-review-pr` workflow but the workflow died before reaching the `codex-review` and `claude-revise` steps. Implementation has not been independently reviewed.

## Test plan

- [ ] `dart run build_runner build --delete-conflicting-outputs` (freezed change)
- [ ] `flutter analyze` clean
- [ ] `flutter test` — new `test/cubit/preset_dirty_indicator_test.dart` covers mutation/clear/race scenarios; existing suites pass
- [ ] Manual: move parameter slider → asterisk appears
- [ ] Manual: hit Save Preset → asterisk clears
- [ ] Manual: add algorithm → asterisk appears, persists across verification refresh
- [ ] Manual: load a different preset → asterisk clears
- [ ] Manual: trigger refresh → asterisk clears