### PR TITLE
[codex] Add multi-algorithm template manager

### DIFF
--- a/docs/mcp-api-guide.md
+++ b/docs/mcp-api-guide.md
@@ -21,6 +21,58 @@ The Disting NT MCP (Model Context Protocol) API provides 15 individual, well-nam
 
 ## Tool Reference
 
+### Template Tools
+
+#### apply_template_to_preset
+
+Apply selected slots from a saved template to the connected device or to a saved local preset.
+
+**Parameters**:
+- `template_id` (optional, integer): Template preset id.
+- `template_name` (optional, string): Alternative to `template_id`; resolved by exact match, then case-insensitive exact match.
+- `slot_indices` (optional, array of integers): Template slot positions to apply. Omit to apply all slots. Duplicates are allowed.
+- `target` (optional, string): `device` or `preset`. Default: `device`.
+- `target_preset_id` (optional, integer): Required when `target` is `preset` unless `target_preset_name` is supplied.
+- `target_preset_name` (optional, string): Alternative to `target_preset_id`.
+- `insertion_offset` (optional, integer): Target slot index. Defaults to append for device mode and `0` for preset mode.
+- `overwrite` (optional, boolean): Replace target slots starting at `insertion_offset` instead of inserting. Default: `false`.
+
+```json
+{
+  "tool": "apply_template_to_preset",
+  "arguments": {
+    "template_name": "Space Kit",
+    "target": "preset",
+    "target_preset_name": "Live Set",
+    "slot_indices": [0, 2],
+    "insertion_offset": 4
+  }
+}
+```
+
+**Success response**:
+```json
+{
+  "success": true,
+  "target": "preset",
+  "target_preset_id": 42,
+  "applied_slot_count": 2,
+  "inserted_slot_indices": [4, 5],
+  "skipped_template_slot_indices": [],
+  "warning": null
+}
+```
+
+If the target would exceed the 32-slot device limit, the tool returns a structured error:
+
+```json
+{"success": false, "error": "space", "current": 31, "applied": 2, "limit": 32}
+```
+
+Device mode requires a connected Disting NT. If a device apply fails mid-operation, inspect the current device state with `show_preset`; hardware writes are not transactional.
+
+---
+
 ### Search Tools
 
 #### search_algorithms

--- a/docs/mcp-mapping-guide.md
+++ b/docs/mcp-mapping-guide.md
@@ -2,6 +2,8 @@
 
 This guide explains how to work with parameter mappings in the Disting NT MCP API. Mappings allow you to control algorithm parameters through external control sources: CV inputs, MIDI messages, i2c communication, and performance page organization.
 
+Template application preserves packed mapping bytes verbatim. When using `apply_template_to_preset`, copied slots keep their CV, MIDI, i2c, and performance-page mapping data; the tool does not decode or reinterpret those mappings.
+
 ## Table of Contents
 
 1. [CV Mapping](#cv-mapping)

--- a/lib/db/daos/presets_dao.dart
+++ b/lib/db/daos/presets_dao.dart
@@ -25,6 +25,7 @@ class FullPresetSlot {
   final Map<int, int> parameterValues; // paramNum -> value
   final Map<int, String> parameterStringValues; // paramNum -> stringValue
   final Map<int, PackedMappingData> mappings; // paramNum -> mappingData
+  final PresetRoutingEntry? routing;
 
   FullPresetSlot({
     required this.slot,
@@ -32,6 +33,7 @@ class FullPresetSlot {
     required this.parameterValues,
     required this.parameterStringValues,
     required this.mappings,
+    this.routing,
   });
 }
 
@@ -68,10 +70,11 @@ class PresetsDao extends DatabaseAccessor<AppDatabase> with _$PresetsDaoMixin {
   }
 
   Future<List<FullPresetDetails>> getTemplates() async {
-    final templatePresets = await (select(presets)
-          ..where((p) => p.isTemplate.equals(true))
-          ..orderBy([(p) => OrderingTerm.asc(p.name)]))
-        .get();
+    final templatePresets =
+        await (select(presets)
+              ..where((p) => p.isTemplate.equals(true))
+              ..orderBy([(p) => OrderingTerm.asc(p.name)]))
+            .get();
     final List<FullPresetDetails> templates = [];
     for (final preset in templatePresets) {
       final details = await getFullPresetDetails(preset.id);
@@ -90,8 +93,9 @@ class PresetsDao extends DatabaseAccessor<AppDatabase> with _$PresetsDaoMixin {
   }
 
   Future<List<FullPresetDetails>> getNonTemplates() async {
-    final nonTemplatePresets =
-        await (select(presets)..where((p) => p.isTemplate.equals(false))).get();
+    final nonTemplatePresets = await (select(
+      presets,
+    )..where((p) => p.isTemplate.equals(false))).get();
     final List<FullPresetDetails> nonTemplates = [];
     for (final preset in nonTemplatePresets) {
       final details = await getFullPresetDetails(preset.id);
@@ -171,9 +175,19 @@ class PresetsDao extends DatabaseAccessor<AppDatabase> with _$PresetsDaoMixin {
           ).map(
             (slotId, entries) => MapEntry(slotId, {
               for (var e in entries)
-                e.parameterNumber: e.packedData.copyWith(perfPageIndex: e.perfPageIndex),
+                e.parameterNumber: e.packedData.copyWith(
+                  perfPageIndex: e.perfPageIndex,
+                ),
             }),
           );
+
+      // Fetch routing information
+      final routingsQuery = select(presetRoutings)
+        ..where((r) => r.presetSlotId.isIn(slotIds));
+      final routingEntries = await routingsQuery.get();
+      final routingBySlot = {
+        for (final routing in routingEntries) routing.presetSlotId: routing,
+      };
 
       // Assemble FullPresetSlot list
       final List<FullPresetSlot> fullSlots = [];
@@ -188,6 +202,7 @@ class PresetsDao extends DatabaseAccessor<AppDatabase> with _$PresetsDaoMixin {
               parameterValues: paramValuesBySlot[slotId] ?? {},
               parameterStringValues: paramStringValuesBySlot[slotId] ?? {},
               mappings: paramMappingsBySlot[slotId] ?? {},
+              routing: routingBySlot[slotId],
             ),
           );
         } else {
@@ -294,6 +309,10 @@ class PresetsDao extends DatabaseAccessor<AppDatabase> with _$PresetsDaoMixin {
             presetMappings,
             (row) => row.presetSlotId.equals(slotId),
           );
+          batch.deleteWhere(
+            presetRoutings,
+            (row) => row.presetSlotId.equals(slotId),
+          );
         });
 
         // Batch insert new data using .insert() companions
@@ -339,6 +358,15 @@ class PresetsDao extends DatabaseAccessor<AppDatabase> with _$PresetsDaoMixin {
                     ),
                   )
                   .toList(),
+            );
+          }
+          if (fullSlot.routing != null) {
+            batch.insert(
+              presetRoutings,
+              PresetRoutingsCompanion.insert(
+                presetSlotId: Value(slotId),
+                routingInfoJson: fullSlot.routing!.routingInfoJson,
+              ),
             );
           }
         });
@@ -427,25 +455,26 @@ class PresetsDao extends DatabaseAccessor<AppDatabase> with _$PresetsDaoMixin {
     }
 
     return transaction(() async {
-      final templateExists = await (select(presets)
-            ..where((p) => p.id.equals(templateId)))
-          .getSingleOrNull();
+      final templateExists = await (select(
+        presets,
+      )..where((p) => p.id.equals(templateId))).getSingleOrNull();
       if (templateExists == null) {
         throw StateError('Template preset $templateId not found.');
       }
-      final targetExists = await (select(presets)
-            ..where((p) => p.id.equals(targetPresetId)))
-          .getSingleOrNull();
+      final targetExists = await (select(
+        presets,
+      )..where((p) => p.id.equals(targetPresetId))).getSingleOrNull();
       if (targetExists == null) {
         throw StateError('Target preset $targetPresetId not found.');
       }
 
       // Snapshot the template's slot rows in slotIndex order so we can map
       // requested indices to source rows.
-      final templateSlotRows = await (select(presetSlots)
-            ..where((s) => s.presetId.equals(templateId))
-            ..orderBy([(s) => OrderingTerm.asc(s.slotIndex)]))
-          .get();
+      final templateSlotRows =
+          await (select(presetSlots)
+                ..where((s) => s.presetId.equals(templateId))
+                ..orderBy([(s) => OrderingTerm.asc(s.slotIndex)]))
+              .get();
 
       for (final i in templateSlotIndices) {
         if (i < 0 || i >= templateSlotRows.length) {
@@ -458,36 +487,35 @@ class PresetsDao extends DatabaseAccessor<AppDatabase> with _$PresetsDaoMixin {
       }
 
       // Snapshot child rows for the template's slots, keyed by source slot id.
-      final templateSlotIds =
-          templateSlotRows.map((s) => s.id).toList(growable: false);
+      final templateSlotIds = templateSlotRows
+          .map((s) => s.id)
+          .toList(growable: false);
       final tmplValues = templateSlotIds.isEmpty
           ? <PresetParameterValueEntry>[]
-          : await (select(presetParameterValues)
-                ..where((v) => v.presetSlotId.isIn(templateSlotIds)))
-              .get();
+          : await (select(
+              presetParameterValues,
+            )..where((v) => v.presetSlotId.isIn(templateSlotIds))).get();
       final tmplStrings = templateSlotIds.isEmpty
           ? <PresetParameterStringValueEntry>[]
-          : await (select(presetParameterStringValues)
-                ..where((v) => v.presetSlotId.isIn(templateSlotIds)))
-              .get();
+          : await (select(
+              presetParameterStringValues,
+            )..where((v) => v.presetSlotId.isIn(templateSlotIds))).get();
       final tmplMappings = templateSlotIds.isEmpty
           ? <PresetMappingEntry>[]
-          : await (select(presetMappings)
-                ..where((m) => m.presetSlotId.isIn(templateSlotIds)))
-              .get();
+          : await (select(
+              presetMappings,
+            )..where((m) => m.presetSlotId.isIn(templateSlotIds))).get();
       final tmplRoutings = templateSlotIds.isEmpty
           ? <PresetRoutingEntry>[]
-          : await (select(presetRoutings)
-                ..where((r) => r.presetSlotId.isIn(templateSlotIds)))
-              .get();
+          : await (select(
+              presetRoutings,
+            )..where((r) => r.presetSlotId.isIn(templateSlotIds))).get();
 
-      final tmplValuesBySlot =
-          <int, List<PresetParameterValueEntry>>{};
+      final tmplValuesBySlot = <int, List<PresetParameterValueEntry>>{};
       for (final v in tmplValues) {
         tmplValuesBySlot.putIfAbsent(v.presetSlotId, () => []).add(v);
       }
-      final tmplStringsBySlot =
-          <int, List<PresetParameterStringValueEntry>>{};
+      final tmplStringsBySlot = <int, List<PresetParameterStringValueEntry>>{};
       for (final v in tmplStrings) {
         tmplStringsBySlot.putIfAbsent(v.presetSlotId, () => []).add(v);
       }
@@ -506,9 +534,9 @@ class PresetsDao extends DatabaseAccessor<AppDatabase> with _$PresetsDaoMixin {
       };
       final knownAlgoRows = neededGuids.isEmpty
           ? <AlgorithmEntry>[]
-          : await (select(algorithms)
-                ..where((a) => a.guid.isIn(neededGuids)))
-              .get();
+          : await (select(
+              algorithms,
+            )..where((a) => a.guid.isIn(neededGuids))).get();
       final knownGuids = knownAlgoRows.map((a) => a.guid).toSet();
 
       // Build the apply plan: keep templateSlotIndices in order; split into
@@ -528,13 +556,15 @@ class PresetsDao extends DatabaseAccessor<AppDatabase> with _$PresetsDaoMixin {
       final appliedCount = appliedSourceRows.length;
 
       // Target slot space accounting.
-      final existingTargetSlots = await (select(presetSlots)
-            ..where((s) => s.presetId.equals(targetPresetId))
-            ..orderBy([(s) => OrderingTerm.asc(s.slotIndex)]))
-          .get();
+      final existingTargetSlots =
+          await (select(presetSlots)
+                ..where((s) => s.presetId.equals(targetPresetId))
+                ..orderBy([(s) => OrderingTerm.asc(s.slotIndex)]))
+              .get();
       final existingCount = existingTargetSlots.length;
-      final clampedOffset =
-          insertionOffset > existingCount ? existingCount : insertionOffset;
+      final clampedOffset = insertionOffset > existingCount
+          ? existingCount
+          : insertionOffset;
 
       const slotLimit = 32;
       // Space accounting uses the *unclamped* insertionOffset in replace mode
@@ -543,8 +573,8 @@ class PresetsDao extends DatabaseAccessor<AppDatabase> with _$PresetsDaoMixin {
       // of silently being treated as "append starting at slot 5".
       final spaceNeeded = overwrite
           ? (insertionOffset + appliedCount > existingCount
-              ? insertionOffset + appliedCount
-              : existingCount)
+                ? insertionOffset + appliedCount
+                : existingCount)
           : existingCount + appliedCount;
       if (appliedCount > 0 && spaceNeeded > slotLimit) {
         throw TemplateSpaceException(
@@ -566,28 +596,30 @@ class PresetsDao extends DatabaseAccessor<AppDatabase> with _$PresetsDaoMixin {
           if (existing != null) {
             // Explicitly clear non-cascading children (PresetRoutings) and
             // cascading ones too (the slot row will be replaced).
-            await (delete(presetMappings)
-                  ..where((m) => m.presetSlotId.equals(existing.id)))
-                .go();
-            await (delete(presetRoutings)
-                  ..where((r) => r.presetSlotId.equals(existing.id)))
-                .go();
-            await (delete(presetSlots)
-                  ..where((s) => s.id.equals(existing.id)))
-                .go();
+            await (delete(
+              presetMappings,
+            )..where((m) => m.presetSlotId.equals(existing.id))).go();
+            await (delete(
+              presetRoutings,
+            )..where((r) => r.presetSlotId.equals(existing.id))).go();
+            await (delete(
+              presetSlots,
+            )..where((s) => s.id.equals(existing.id))).go();
           }
         }
       } else {
         // Insert mode: shift any existing slots at clampedOffset..end upward
         // by appliedCount. Shift from top down to avoid uniqueness clashes.
         if (appliedCount > 0) {
-          final toShift = existingTargetSlots
-              .where((s) => s.slotIndex >= clampedOffset)
-              .toList()
-            ..sort((a, b) => b.slotIndex.compareTo(a.slotIndex));
+          final toShift =
+              existingTargetSlots
+                  .where((s) => s.slotIndex >= clampedOffset)
+                  .toList()
+                ..sort((a, b) => b.slotIndex.compareTo(a.slotIndex));
           for (final row in toShift) {
-            await (update(presetSlots)..where((s) => s.id.equals(row.id)))
-                .write(
+            await (update(
+              presetSlots,
+            )..where((s) => s.id.equals(row.id))).write(
               PresetSlotsCompanion(
                 slotIndex: Value(row.slotIndex + appliedCount),
               ),

--- a/lib/db/daos/presets_dao.dart
+++ b/lib/db/daos/presets_dao.dart
@@ -44,6 +44,7 @@ class FullPresetSlot {
     PresetParameterValues,
     PresetMappings,
     PresetParameterStringValues,
+    PresetRoutings,
     Algorithms,
   ],
 )
@@ -398,4 +399,347 @@ class PresetsDao extends DatabaseAccessor<AppDatabase> with _$PresetsDaoMixin {
     // Note: Cascading deletes in the table definitions should handle related data
     // (PresetSlots -> PresetParameterValues, PresetParameterStringValues, PresetMappings, PresetRoutings)
   }
+
+  /// Copies a subset of slots from `templateId` into `targetPresetId`.
+  ///
+  /// See [ApplyTemplateSlotsResult] for the result shape and the spec in
+  /// `specs/2026-05-22_multi-algorithm-templates.md` for the full semantics.
+  Future<ApplyTemplateSlotsResult> applyTemplateSlots({
+    required int templateId,
+    required int targetPresetId,
+    required List<int> templateSlotIndices,
+    required int insertionOffset,
+    bool overwrite = false,
+  }) async {
+    if (templateSlotIndices.isEmpty) {
+      throw ArgumentError.value(
+        templateSlotIndices,
+        'templateSlotIndices',
+        'must not be empty',
+      );
+    }
+    if (insertionOffset < 0) {
+      throw ArgumentError.value(
+        insertionOffset,
+        'insertionOffset',
+        'must be >= 0',
+      );
+    }
+
+    return transaction(() async {
+      final templateExists = await (select(presets)
+            ..where((p) => p.id.equals(templateId)))
+          .getSingleOrNull();
+      if (templateExists == null) {
+        throw StateError('Template preset $templateId not found.');
+      }
+      final targetExists = await (select(presets)
+            ..where((p) => p.id.equals(targetPresetId)))
+          .getSingleOrNull();
+      if (targetExists == null) {
+        throw StateError('Target preset $targetPresetId not found.');
+      }
+
+      // Snapshot the template's slot rows in slotIndex order so we can map
+      // requested indices to source rows.
+      final templateSlotRows = await (select(presetSlots)
+            ..where((s) => s.presetId.equals(templateId))
+            ..orderBy([(s) => OrderingTerm.asc(s.slotIndex)]))
+          .get();
+
+      for (final i in templateSlotIndices) {
+        if (i < 0 || i >= templateSlotRows.length) {
+          throw ArgumentError.value(
+            i,
+            'templateSlotIndices',
+            'index out of range [0, ${templateSlotRows.length})',
+          );
+        }
+      }
+
+      // Snapshot child rows for the template's slots, keyed by source slot id.
+      final templateSlotIds =
+          templateSlotRows.map((s) => s.id).toList(growable: false);
+      final tmplValues = templateSlotIds.isEmpty
+          ? <PresetParameterValueEntry>[]
+          : await (select(presetParameterValues)
+                ..where((v) => v.presetSlotId.isIn(templateSlotIds)))
+              .get();
+      final tmplStrings = templateSlotIds.isEmpty
+          ? <PresetParameterStringValueEntry>[]
+          : await (select(presetParameterStringValues)
+                ..where((v) => v.presetSlotId.isIn(templateSlotIds)))
+              .get();
+      final tmplMappings = templateSlotIds.isEmpty
+          ? <PresetMappingEntry>[]
+          : await (select(presetMappings)
+                ..where((m) => m.presetSlotId.isIn(templateSlotIds)))
+              .get();
+      final tmplRoutings = templateSlotIds.isEmpty
+          ? <PresetRoutingEntry>[]
+          : await (select(presetRoutings)
+                ..where((r) => r.presetSlotId.isIn(templateSlotIds)))
+              .get();
+
+      final tmplValuesBySlot =
+          <int, List<PresetParameterValueEntry>>{};
+      for (final v in tmplValues) {
+        tmplValuesBySlot.putIfAbsent(v.presetSlotId, () => []).add(v);
+      }
+      final tmplStringsBySlot =
+          <int, List<PresetParameterStringValueEntry>>{};
+      for (final v in tmplStrings) {
+        tmplStringsBySlot.putIfAbsent(v.presetSlotId, () => []).add(v);
+      }
+      final tmplMappingsBySlot = <int, List<PresetMappingEntry>>{};
+      for (final m in tmplMappings) {
+        tmplMappingsBySlot.putIfAbsent(m.presetSlotId, () => []).add(m);
+      }
+      final tmplRoutingBySlot = <int, PresetRoutingEntry>{};
+      for (final r in tmplRoutings) {
+        tmplRoutingBySlot[r.presetSlotId] = r;
+      }
+
+      // Resolve which algorithm GUIDs are locally known.
+      final neededGuids = {
+        for (final i in templateSlotIndices) templateSlotRows[i].algorithmGuid,
+      };
+      final knownAlgoRows = neededGuids.isEmpty
+          ? <AlgorithmEntry>[]
+          : await (select(algorithms)
+                ..where((a) => a.guid.isIn(neededGuids)))
+              .get();
+      final knownGuids = knownAlgoRows.map((a) => a.guid).toSet();
+
+      // Build the apply plan: keep templateSlotIndices in order; split into
+      // applied vs skipped.
+      final appliedSourceRows = <PresetSlotEntry>[];
+      final skipped = <int>[];
+      final missingGuids = <String>{};
+      for (final i in templateSlotIndices) {
+        final row = templateSlotRows[i];
+        if (knownGuids.contains(row.algorithmGuid)) {
+          appliedSourceRows.add(row);
+        } else {
+          skipped.add(i);
+          missingGuids.add(row.algorithmGuid);
+        }
+      }
+      final appliedCount = appliedSourceRows.length;
+
+      // Target slot space accounting.
+      final existingTargetSlots = await (select(presetSlots)
+            ..where((s) => s.presetId.equals(targetPresetId))
+            ..orderBy([(s) => OrderingTerm.asc(s.slotIndex)]))
+          .get();
+      final existingCount = existingTargetSlots.length;
+      final clampedOffset =
+          insertionOffset > existingCount ? existingCount : insertionOffset;
+
+      const slotLimit = 32;
+      // Space accounting uses the *unclamped* insertionOffset in replace mode
+      // so that a caller asking to "replace at slot 25" of a 5-slot target
+      // (which would need 35 slots) fails the limit check explicitly, instead
+      // of silently being treated as "append starting at slot 5".
+      final spaceNeeded = overwrite
+          ? (insertionOffset + appliedCount > existingCount
+              ? insertionOffset + appliedCount
+              : existingCount)
+          : existingCount + appliedCount;
+      if (appliedCount > 0 && spaceNeeded > slotLimit) {
+        throw TemplateSpaceException(
+          current: existingCount,
+          applied: appliedCount,
+          limit: slotLimit,
+        );
+      }
+
+      // Mutation phase.
+      if (overwrite) {
+        // For each i in 0..appliedCount-1, replace the target slot at
+        // clampedOffset+i (or create it if absent).
+        for (var i = 0; i < appliedCount; i++) {
+          final targetSlotIndex = clampedOffset + i;
+          final existing = existingTargetSlots.firstWhereOrNull(
+            (s) => s.slotIndex == targetSlotIndex,
+          );
+          if (existing != null) {
+            // Explicitly clear non-cascading children (PresetRoutings) and
+            // cascading ones too (the slot row will be replaced).
+            await (delete(presetMappings)
+                  ..where((m) => m.presetSlotId.equals(existing.id)))
+                .go();
+            await (delete(presetRoutings)
+                  ..where((r) => r.presetSlotId.equals(existing.id)))
+                .go();
+            await (delete(presetSlots)
+                  ..where((s) => s.id.equals(existing.id)))
+                .go();
+          }
+        }
+      } else {
+        // Insert mode: shift any existing slots at clampedOffset..end upward
+        // by appliedCount. Shift from top down to avoid uniqueness clashes.
+        if (appliedCount > 0) {
+          final toShift = existingTargetSlots
+              .where((s) => s.slotIndex >= clampedOffset)
+              .toList()
+            ..sort((a, b) => b.slotIndex.compareTo(a.slotIndex));
+          for (final row in toShift) {
+            await (update(presetSlots)..where((s) => s.id.equals(row.id)))
+                .write(
+              PresetSlotsCompanion(
+                slotIndex: Value(row.slotIndex + appliedCount),
+              ),
+            );
+          }
+        }
+      }
+
+      // Copy each applied template slot into the target preset.
+      final insertedSlotIndices = <int>[];
+      for (var i = 0; i < appliedCount; i++) {
+        final source = appliedSourceRows[i];
+        final newSlotIndex = clampedOffset + i;
+        final newSlotId = await into(presetSlots).insert(
+          PresetSlotsCompanion.insert(
+            presetId: targetPresetId,
+            slotIndex: newSlotIndex,
+            algorithmGuid: source.algorithmGuid,
+            customName: Value(source.customName),
+          ),
+        );
+        insertedSlotIndices.add(newSlotIndex);
+
+        final srcValues = tmplValuesBySlot[source.id] ?? const [];
+        if (srcValues.isNotEmpty) {
+          await batch((b) {
+            b.insertAll(
+              presetParameterValues,
+              srcValues
+                  .map(
+                    (v) => PresetParameterValuesCompanion.insert(
+                      presetSlotId: newSlotId,
+                      parameterNumber: v.parameterNumber,
+                      value: v.value,
+                    ),
+                  )
+                  .toList(growable: false),
+            );
+          });
+        }
+        final srcStrings = tmplStringsBySlot[source.id] ?? const [];
+        if (srcStrings.isNotEmpty) {
+          await batch((b) {
+            b.insertAll(
+              presetParameterStringValues,
+              srcStrings
+                  .map(
+                    (v) => PresetParameterStringValuesCompanion.insert(
+                      presetSlotId: newSlotId,
+                      parameterNumber: v.parameterNumber,
+                      stringValue: v.stringValue,
+                    ),
+                  )
+                  .toList(growable: false),
+            );
+          });
+        }
+        final srcMappings = tmplMappingsBySlot[source.id] ?? const [];
+        if (srcMappings.isNotEmpty) {
+          await batch((b) {
+            b.insertAll(
+              presetMappings,
+              srcMappings
+                  .map(
+                    (m) => PresetMappingsCompanion.insert(
+                      presetSlotId: newSlotId,
+                      parameterNumber: m.parameterNumber,
+                      packedData: m.packedData,
+                      perfPageIndex: Value(m.perfPageIndex),
+                    ),
+                  )
+                  .toList(growable: false),
+            );
+          });
+        }
+        final srcRouting = tmplRoutingBySlot[source.id];
+        if (srcRouting != null) {
+          await into(presetRoutings).insert(
+            PresetRoutingsCompanion.insert(
+              presetSlotId: Value(newSlotId),
+              routingInfoJson: srcRouting.routingInfoJson,
+            ),
+          );
+        }
+      }
+
+      // Bump target lastModified.
+      await (update(presets)..where((p) => p.id.equals(targetPresetId))).write(
+        PresetsCompanion(lastModified: Value(DateTime.now())),
+      );
+
+      String? warning;
+      if (skipped.isNotEmpty) {
+        final missingList = missingGuids.toList()..sort();
+        warning =
+            'Skipped ${skipped.length} template slot(s) with missing algorithm '
+            'metadata: ${missingList.join(', ')}.';
+      }
+
+      return ApplyTemplateSlotsResult(
+        targetPresetId: targetPresetId,
+        insertedSlotIndices: List.unmodifiable(insertedSlotIndices),
+        skippedTemplateSlotIndices: List.unmodifiable(skipped),
+        warning: warning,
+      );
+    });
+  }
+}
+
+/// Outcome of [PresetsDao.applyTemplateSlots].
+class ApplyTemplateSlotsResult {
+  final int targetPresetId;
+
+  /// New `slotIndex` values produced in the target preset, in apply order.
+  final List<int> insertedSlotIndices;
+
+  /// Indices from the original `templateSlotIndices` argument that were
+  /// skipped — typically because the source slot's algorithm GUID has no
+  /// matching row in the local `algorithms` table.
+  final List<int> skippedTemplateSlotIndices;
+
+  /// User-facing, non-fatal warning. Null when nothing was skipped.
+  final String? warning;
+
+  const ApplyTemplateSlotsResult({
+    required this.targetPresetId,
+    required this.insertedSlotIndices,
+    required this.skippedTemplateSlotIndices,
+    this.warning,
+  });
+}
+
+/// Thrown by [PresetsDao.applyTemplateSlots] when the target would exceed
+/// the device's 32-slot limit.
+class TemplateSpaceException implements Exception {
+  /// Existing slot count on the target preset before the apply.
+  final int current;
+
+  /// Number of slots the apply would add (after skipping any with missing
+  /// algorithm metadata).
+  final int applied;
+
+  /// Hard upper bound. Defaults to 32 (the device limit).
+  final int limit;
+
+  TemplateSpaceException({
+    required this.current,
+    required this.applied,
+    this.limit = 32,
+  });
+
+  @override
+  String toString() =>
+      'TemplateSpaceException: Cannot apply: $current + $applied > $limit slots';
 }

--- a/lib/db/daos/presets_dao.g.dart
+++ b/lib/db/daos/presets_dao.g.dart
@@ -12,6 +12,7 @@ mixin _$PresetsDaoMixin on DatabaseAccessor<AppDatabase> {
   $PresetMappingsTable get presetMappings => attachedDatabase.presetMappings;
   $PresetParameterStringValuesTable get presetParameterStringValues =>
       attachedDatabase.presetParameterStringValues;
+  $PresetRoutingsTable get presetRoutings => attachedDatabase.presetRoutings;
   PresetsDaoManager get managers => PresetsDaoManager(this);
 }
 
@@ -39,5 +40,10 @@ class PresetsDaoManager {
       $$PresetParameterStringValuesTableTableManager(
         _db.attachedDatabase,
         _db.presetParameterStringValues,
+      );
+  $$PresetRoutingsTableTableManager get presetRoutings =>
+      $$PresetRoutingsTableTableManager(
+        _db.attachedDatabase,
+        _db.presetRoutings,
       );
 }

--- a/lib/db/database.dart
+++ b/lib/db/database.dart
@@ -44,7 +44,8 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 11; // Incremented to fix ParameterOutputModeUsage table creation
+  int get schemaVersion =>
+      12; // Adds Presets.category + Presets.templateMetadata for multi-algorithm templates
 
   // Access DAOs (Drift generates getters)
   // MetadataDao get metadataDao => MetadataDao(this); // This getter is generated
@@ -158,6 +159,20 @@ class AppDatabase extends _$AppDatabase {
           await m.createTable(parameterOutputModeUsage);
         } catch (e) {
           // Intentionally empty - table may already exist in some edge cases
+        }
+      }
+
+      // Migration for version 12: Add category + templateMetadata columns to presets table
+      if (from <= 11) {
+        try {
+          await m.addColumn(presets, presets.category);
+        } catch (e) {
+          // Intentionally empty - column may already exist in some edge cases
+        }
+        try {
+          await m.addColumn(presets, presets.templateMetadata);
+        } catch (e) {
+          // Intentionally empty - column may already exist in some edge cases
         }
       }
     },

--- a/lib/db/database.g.dart
+++ b/lib/db/database.g.dart
@@ -2928,8 +2928,37 @@ class $PresetsTable extends Presets with TableInfo<$PresetsTable, PresetEntry> {
     ),
     defaultValue: const Constant(false),
   );
+  static const VerificationMeta _categoryMeta = const VerificationMeta(
+    'category',
+  );
   @override
-  List<GeneratedColumn> get $columns => [id, name, lastModified, isTemplate];
+  late final GeneratedColumn<String> category = GeneratedColumn<String>(
+    'category',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _templateMetadataMeta = const VerificationMeta(
+    'templateMetadata',
+  );
+  @override
+  late final GeneratedColumn<String> templateMetadata = GeneratedColumn<String>(
+    'template_metadata',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    name,
+    lastModified,
+    isTemplate,
+    category,
+    templateMetadata,
+  ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -2968,6 +2997,21 @@ class $PresetsTable extends Presets with TableInfo<$PresetsTable, PresetEntry> {
         isTemplate.isAcceptableOrUnknown(data['is_template']!, _isTemplateMeta),
       );
     }
+    if (data.containsKey('category')) {
+      context.handle(
+        _categoryMeta,
+        category.isAcceptableOrUnknown(data['category']!, _categoryMeta),
+      );
+    }
+    if (data.containsKey('template_metadata')) {
+      context.handle(
+        _templateMetadataMeta,
+        templateMetadata.isAcceptableOrUnknown(
+          data['template_metadata']!,
+          _templateMetadataMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -2993,6 +3037,14 @@ class $PresetsTable extends Presets with TableInfo<$PresetsTable, PresetEntry> {
         DriftSqlType.bool,
         data['${effectivePrefix}is_template'],
       )!,
+      category: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}category'],
+      ),
+      templateMetadata: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}template_metadata'],
+      ),
     );
   }
 
@@ -3007,11 +3059,15 @@ class PresetEntry extends DataClass implements Insertable<PresetEntry> {
   final String name;
   final DateTime lastModified;
   final bool isTemplate;
+  final String? category;
+  final String? templateMetadata;
   const PresetEntry({
     required this.id,
     required this.name,
     required this.lastModified,
     required this.isTemplate,
+    this.category,
+    this.templateMetadata,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -3020,6 +3076,12 @@ class PresetEntry extends DataClass implements Insertable<PresetEntry> {
     map['name'] = Variable<String>(name);
     map['last_modified'] = Variable<DateTime>(lastModified);
     map['is_template'] = Variable<bool>(isTemplate);
+    if (!nullToAbsent || category != null) {
+      map['category'] = Variable<String>(category);
+    }
+    if (!nullToAbsent || templateMetadata != null) {
+      map['template_metadata'] = Variable<String>(templateMetadata);
+    }
     return map;
   }
 
@@ -3029,6 +3091,12 @@ class PresetEntry extends DataClass implements Insertable<PresetEntry> {
       name: Value(name),
       lastModified: Value(lastModified),
       isTemplate: Value(isTemplate),
+      category: category == null && nullToAbsent
+          ? const Value.absent()
+          : Value(category),
+      templateMetadata: templateMetadata == null && nullToAbsent
+          ? const Value.absent()
+          : Value(templateMetadata),
     );
   }
 
@@ -3042,6 +3110,8 @@ class PresetEntry extends DataClass implements Insertable<PresetEntry> {
       name: serializer.fromJson<String>(json['name']),
       lastModified: serializer.fromJson<DateTime>(json['lastModified']),
       isTemplate: serializer.fromJson<bool>(json['isTemplate']),
+      category: serializer.fromJson<String?>(json['category']),
+      templateMetadata: serializer.fromJson<String?>(json['templateMetadata']),
     );
   }
   @override
@@ -3052,6 +3122,8 @@ class PresetEntry extends DataClass implements Insertable<PresetEntry> {
       'name': serializer.toJson<String>(name),
       'lastModified': serializer.toJson<DateTime>(lastModified),
       'isTemplate': serializer.toJson<bool>(isTemplate),
+      'category': serializer.toJson<String?>(category),
+      'templateMetadata': serializer.toJson<String?>(templateMetadata),
     };
   }
 
@@ -3060,11 +3132,17 @@ class PresetEntry extends DataClass implements Insertable<PresetEntry> {
     String? name,
     DateTime? lastModified,
     bool? isTemplate,
+    Value<String?> category = const Value.absent(),
+    Value<String?> templateMetadata = const Value.absent(),
   }) => PresetEntry(
     id: id ?? this.id,
     name: name ?? this.name,
     lastModified: lastModified ?? this.lastModified,
     isTemplate: isTemplate ?? this.isTemplate,
+    category: category.present ? category.value : this.category,
+    templateMetadata: templateMetadata.present
+        ? templateMetadata.value
+        : this.templateMetadata,
   );
   PresetEntry copyWithCompanion(PresetsCompanion data) {
     return PresetEntry(
@@ -3076,6 +3154,10 @@ class PresetEntry extends DataClass implements Insertable<PresetEntry> {
       isTemplate: data.isTemplate.present
           ? data.isTemplate.value
           : this.isTemplate,
+      category: data.category.present ? data.category.value : this.category,
+      templateMetadata: data.templateMetadata.present
+          ? data.templateMetadata.value
+          : this.templateMetadata,
     );
   }
 
@@ -3085,13 +3167,22 @@ class PresetEntry extends DataClass implements Insertable<PresetEntry> {
           ..write('id: $id, ')
           ..write('name: $name, ')
           ..write('lastModified: $lastModified, ')
-          ..write('isTemplate: $isTemplate')
+          ..write('isTemplate: $isTemplate, ')
+          ..write('category: $category, ')
+          ..write('templateMetadata: $templateMetadata')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(id, name, lastModified, isTemplate);
+  int get hashCode => Object.hash(
+    id,
+    name,
+    lastModified,
+    isTemplate,
+    category,
+    templateMetadata,
+  );
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -3099,7 +3190,9 @@ class PresetEntry extends DataClass implements Insertable<PresetEntry> {
           other.id == this.id &&
           other.name == this.name &&
           other.lastModified == this.lastModified &&
-          other.isTemplate == this.isTemplate);
+          other.isTemplate == this.isTemplate &&
+          other.category == this.category &&
+          other.templateMetadata == this.templateMetadata);
 }
 
 class PresetsCompanion extends UpdateCompanion<PresetEntry> {
@@ -3107,29 +3200,39 @@ class PresetsCompanion extends UpdateCompanion<PresetEntry> {
   final Value<String> name;
   final Value<DateTime> lastModified;
   final Value<bool> isTemplate;
+  final Value<String?> category;
+  final Value<String?> templateMetadata;
   const PresetsCompanion({
     this.id = const Value.absent(),
     this.name = const Value.absent(),
     this.lastModified = const Value.absent(),
     this.isTemplate = const Value.absent(),
+    this.category = const Value.absent(),
+    this.templateMetadata = const Value.absent(),
   });
   PresetsCompanion.insert({
     this.id = const Value.absent(),
     required String name,
     this.lastModified = const Value.absent(),
     this.isTemplate = const Value.absent(),
+    this.category = const Value.absent(),
+    this.templateMetadata = const Value.absent(),
   }) : name = Value(name);
   static Insertable<PresetEntry> custom({
     Expression<int>? id,
     Expression<String>? name,
     Expression<DateTime>? lastModified,
     Expression<bool>? isTemplate,
+    Expression<String>? category,
+    Expression<String>? templateMetadata,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (name != null) 'name': name,
       if (lastModified != null) 'last_modified': lastModified,
       if (isTemplate != null) 'is_template': isTemplate,
+      if (category != null) 'category': category,
+      if (templateMetadata != null) 'template_metadata': templateMetadata,
     });
   }
 
@@ -3138,12 +3241,16 @@ class PresetsCompanion extends UpdateCompanion<PresetEntry> {
     Value<String>? name,
     Value<DateTime>? lastModified,
     Value<bool>? isTemplate,
+    Value<String?>? category,
+    Value<String?>? templateMetadata,
   }) {
     return PresetsCompanion(
       id: id ?? this.id,
       name: name ?? this.name,
       lastModified: lastModified ?? this.lastModified,
       isTemplate: isTemplate ?? this.isTemplate,
+      category: category ?? this.category,
+      templateMetadata: templateMetadata ?? this.templateMetadata,
     );
   }
 
@@ -3162,6 +3269,12 @@ class PresetsCompanion extends UpdateCompanion<PresetEntry> {
     if (isTemplate.present) {
       map['is_template'] = Variable<bool>(isTemplate.value);
     }
+    if (category.present) {
+      map['category'] = Variable<String>(category.value);
+    }
+    if (templateMetadata.present) {
+      map['template_metadata'] = Variable<String>(templateMetadata.value);
+    }
     return map;
   }
 
@@ -3171,7 +3284,9 @@ class PresetsCompanion extends UpdateCompanion<PresetEntry> {
           ..write('id: $id, ')
           ..write('name: $name, ')
           ..write('lastModified: $lastModified, ')
-          ..write('isTemplate: $isTemplate')
+          ..write('isTemplate: $isTemplate, ')
+          ..write('category: $category, ')
+          ..write('templateMetadata: $templateMetadata')
           ..write(')'))
         .toString();
   }
@@ -9002,6 +9117,8 @@ typedef $$PresetsTableCreateCompanionBuilder =
       required String name,
       Value<DateTime> lastModified,
       Value<bool> isTemplate,
+      Value<String?> category,
+      Value<String?> templateMetadata,
     });
 typedef $$PresetsTableUpdateCompanionBuilder =
     PresetsCompanion Function({
@@ -9009,6 +9126,8 @@ typedef $$PresetsTableUpdateCompanionBuilder =
       Value<String> name,
       Value<DateTime> lastModified,
       Value<bool> isTemplate,
+      Value<String?> category,
+      Value<String?> templateMetadata,
     });
 
 final class $$PresetsTableReferences
@@ -9060,6 +9179,16 @@ class $$PresetsTableFilterComposer
 
   ColumnFilters<bool> get isTemplate => $composableBuilder(
     column: $table.isTemplate,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get templateMetadata => $composableBuilder(
+    column: $table.templateMetadata,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -9117,6 +9246,16 @@ class $$PresetsTableOrderingComposer
     column: $table.isTemplate,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get category => $composableBuilder(
+    column: $table.category,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get templateMetadata => $composableBuilder(
+    column: $table.templateMetadata,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$PresetsTableAnnotationComposer
@@ -9141,6 +9280,14 @@ class $$PresetsTableAnnotationComposer
 
   GeneratedColumn<bool> get isTemplate => $composableBuilder(
     column: $table.isTemplate,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get category =>
+      $composableBuilder(column: $table.category, builder: (column) => column);
+
+  GeneratedColumn<String> get templateMetadata => $composableBuilder(
+    column: $table.templateMetadata,
     builder: (column) => column,
   );
 
@@ -9202,11 +9349,15 @@ class $$PresetsTableTableManager
                 Value<String> name = const Value.absent(),
                 Value<DateTime> lastModified = const Value.absent(),
                 Value<bool> isTemplate = const Value.absent(),
+                Value<String?> category = const Value.absent(),
+                Value<String?> templateMetadata = const Value.absent(),
               }) => PresetsCompanion(
                 id: id,
                 name: name,
                 lastModified: lastModified,
                 isTemplate: isTemplate,
+                category: category,
+                templateMetadata: templateMetadata,
               ),
           createCompanionCallback:
               ({
@@ -9214,11 +9365,15 @@ class $$PresetsTableTableManager
                 required String name,
                 Value<DateTime> lastModified = const Value.absent(),
                 Value<bool> isTemplate = const Value.absent(),
+                Value<String?> category = const Value.absent(),
+                Value<String?> templateMetadata = const Value.absent(),
               }) => PresetsCompanion.insert(
                 id: id,
                 name: name,
                 lastModified: lastModified,
                 isTemplate: isTemplate,
+                category: category,
+                templateMetadata: templateMetadata,
               ),
           withReferenceMapper: (p0) => p0
               .map(

--- a/lib/db/tables.dart
+++ b/lib/db/tables.dart
@@ -134,6 +134,12 @@ class Presets extends Table {
   DateTimeColumn get lastModified =>
       dateTime().withDefault(currentDateAndTime)();
   BoolColumn get isTemplate => boolean().withDefault(const Constant(false))();
+  // Free-form short string used to group templates in the Template Manager.
+  // Meaningful only when isTemplate = true.
+  TextColumn get category => text().nullable()();
+  // JSON-encoded TemplateMetadata (description, tags, author, createdAt, extras).
+  // Meaningful only when isTemplate = true.
+  TextColumn get templateMetadata => text().nullable()();
 }
 
 @DataClassName('PresetSlotEntry')

--- a/lib/disting_app.dart
+++ b/lib/disting_app.dart
@@ -17,11 +17,36 @@ import 'package:nt_helper/services/settings_service.dart';
 import 'package:nt_helper/services/zoom_hotkey_service.dart';
 import 'package:nt_helper/ui/firmware/firmware_update_screen.dart';
 import 'package:nt_helper/ui/synchronized_screen.dart';
+import 'package:nt_helper/ui/template_manager/template_manager_screen.dart';
 import 'package:nt_helper/utils/build_config.dart';
 import 'package:nt_helper/ui/midi_listener/midi_listener_cubit.dart';
 
 class DistingApp extends StatefulWidget {
+  static const templateManagerRoute = '/template-manager';
+
   const DistingApp({super.key});
+
+  static Map<String, WidgetBuilder> buildRoutes() {
+    return {
+      '/': (context) => MultiBlocProvider(
+        providers: [
+          BlocProvider(
+            create: (context) {
+              // Get the AppDatabase instance from the context
+              final database = context.read<AppDatabase>();
+
+              // Create DistingCubit and pass the database instance
+              final cubit = DistingCubit(database); // Pass database here
+              cubit.initialize(); // Load settings and auto-connect if possible
+              return cubit;
+            },
+          ),
+        ],
+        child: Material(child: DistingPage()),
+      ),
+      templateManagerRoute: (context) => const TemplateManagerScreen(),
+    };
+  }
 
   @override
   State<DistingApp> createState() => _DistingAppState();
@@ -172,9 +197,7 @@ class _DistingAppState extends State<DistingApp> {
           builder: (context, scale, _) {
             final mediaQuery = MediaQuery.of(context);
             return MediaQuery(
-              data: mediaQuery.copyWith(
-                textScaler: TextScaler.linear(scale),
-              ),
+              data: mediaQuery.copyWith(textScaler: TextScaler.linear(scale)),
               child: Shortcuts(
                 shortcuts: _keyBindingService.desktopZoomShortcuts,
                 child: Actions(
@@ -197,25 +220,7 @@ class _DistingAppState extends State<DistingApp> {
         );
       },
       initialRoute: '/',
-      routes: {
-        '/': (context) => MultiBlocProvider(
-          providers: [
-            BlocProvider(
-              create: (context) {
-                // Get the AppDatabase instance from the context
-                final database = context.read<AppDatabase>();
-
-                // Create DistingCubit and pass the database instance
-                final cubit = DistingCubit(database); // Pass database here
-                cubit
-                    .initialize(); // Load settings and auto-connect if possible
-                return cubit;
-              },
-            ),
-          ],
-          child: Material(child: DistingPage()),
-        ),
-      },
+      routes: DistingApp.buildRoutes(),
     );
   }
 }
@@ -296,11 +301,15 @@ class _DistingPageState extends State<DistingPage> {
             : InternetAddress.loopbackIPv4;
         if (isMcpEnabledAfterDialog) {
           if (!isServerStillRunningBeforeAction) {
-            await mcpInstance.start(bindAddress: bindAddress).catchError((e) {});
+            await mcpInstance
+                .start(bindAddress: bindAddress)
+                .catchError((e) {});
           } else {
             // Server already running — restart if bind address changed
             if (mcpInstance.boundAddress?.address != bindAddress.address) {
-              await mcpInstance.restart(bindAddress: bindAddress).catchError((e) {});
+              await mcpInstance
+                  .restart(bindAddress: bindAddress)
+                  .catchError((e) {});
             }
           }
         } else {
@@ -360,8 +369,17 @@ class _DistingPageState extends State<DistingPage> {
                 onOfflinePressed: () async {
                   context.read<DistingCubit>().goOffline();
                 },
-                onFirmwarePressed: !kPlayStoreBuild && (Platform.isMacOS || Platform.isWindows || Platform.isLinux)
-                    ? (String? probedVersion, MidiDevice? inputDevice, MidiDevice? outputDevice, int? sysExId) {
+                onFirmwarePressed:
+                    !kPlayStoreBuild &&
+                        (Platform.isMacOS ||
+                            Platform.isWindows ||
+                            Platform.isLinux)
+                    ? (
+                        String? probedVersion,
+                        MidiDevice? inputDevice,
+                        MidiDevice? outputDevice,
+                        int? sysExId,
+                      ) {
                         Navigator.of(context).push(
                           MaterialPageRoute(
                             builder: (_) => FirmwareUpdateScreen(
@@ -413,7 +431,8 @@ class _DistingPageState extends State<DistingPage> {
                                 )
                               : CircularProgressIndicator(
                                   value: state.syncProgress,
-                                  semanticsLabel: state.syncStatus ??
+                                  semanticsLabel:
+                                      state.syncStatus ??
                                       'Synchronizing with Disting NT',
                                 ),
                         ),
@@ -464,7 +483,13 @@ class _DeviceSelectionView extends StatefulWidget {
   final Function() onSettingsPressed;
   final Function() onDemoPressed;
   final Function() onOfflinePressed;
-  final void Function(String? probedVersion, MidiDevice? inputDevice, MidiDevice? outputDevice, int? sysExId)? onFirmwarePressed;
+  final void Function(
+    String? probedVersion,
+    MidiDevice? inputDevice,
+    MidiDevice? outputDevice,
+    int? sysExId,
+  )?
+  onFirmwarePressed;
   final bool canWorkOffline;
 
   const _DeviceSelectionView({
@@ -530,13 +555,13 @@ class _DeviceSelectionViewState extends State<_DeviceSelectionView> {
   void _preserveOrReselectDevices() {
     final preservedInput = selectedInputDevice != null
         ? widget.inputDevices
-            .where((d) => d.name == selectedInputDevice!.name)
-            .firstOrNull
+              .where((d) => d.name == selectedInputDevice!.name)
+              .firstOrNull
         : null;
     final preservedOutput = selectedOutputDevice != null
         ? widget.outputDevices
-            .where((d) => d.name == selectedOutputDevice!.name)
-            .firstOrNull
+              .where((d) => d.name == selectedOutputDevice!.name)
+              .firstOrNull
         : null;
 
     if (preservedInput != null && preservedOutput != null) {
@@ -597,7 +622,9 @@ class _DeviceSelectionViewState extends State<_DeviceSelectionView> {
     final sysExId = selectedSysExId!;
     _lastProbedInputId = input.id;
     _lastProbedOutputId = output.id;
-    context.read<DistingCubit>().probeFirmwareVersion(input, output, sysExId).then((version) {
+    context.read<DistingCubit>().probeFirmwareVersion(input, output, sysExId).then((
+      version,
+    ) {
       if (mounted) {
         setState(() {
           _probedFirmwareVersion = version;
@@ -631,27 +658,31 @@ class _DeviceSelectionViewState extends State<_DeviceSelectionView> {
     final items = <PopupMenuEntry<String>>[];
     if (_distingDetected) {
       if (widget.canWorkOffline) {
-        items.add(PopupMenuItem<String>(
-          value: 'offline',
+        items.add(
+          PopupMenuItem<String>(
+            value: 'offline',
+            child: ListTile(
+              leading: const Icon(Icons.cloud_off),
+              title: const Text('Offline'),
+              dense: true,
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
+        );
+      }
+    } else {
+      items.add(
+        PopupMenuItem<String>(
+          value: 'connect',
+          enabled: _devicesSelected,
           child: ListTile(
-            leading: const Icon(Icons.cloud_off),
-            title: const Text('Offline'),
+            leading: const Icon(Icons.link),
+            title: const Text('Connect'),
             dense: true,
             contentPadding: EdgeInsets.zero,
           ),
-        ));
-      }
-    } else {
-      items.add(PopupMenuItem<String>(
-        value: 'connect',
-        enabled: _devicesSelected,
-        child: ListTile(
-          leading: const Icon(Icons.link),
-          title: const Text('Connect'),
-          dense: true,
-          contentPadding: EdgeInsets.zero,
         ),
-      ));
+      );
     }
 
     if (items.isEmpty) return;
@@ -687,11 +718,15 @@ class _DeviceSelectionViewState extends State<_DeviceSelectionView> {
     // Determine primary action
     final bool primaryIsConnect = _distingDetected;
     final String primaryLabel = primaryIsConnect ? 'Connect' : 'Offline';
-    final IconData primaryIcon = primaryIsConnect ? Icons.link : Icons.cloud_off;
-    final bool primaryEnabled =
-        primaryIsConnect ? _devicesSelected : widget.canWorkOffline;
-    final VoidCallback? primaryOnPressed =
-        primaryEnabled ? (primaryIsConnect ? _onConnect : widget.onOfflinePressed) : null;
+    final IconData primaryIcon = primaryIsConnect
+        ? Icons.link
+        : Icons.cloud_off;
+    final bool primaryEnabled = primaryIsConnect
+        ? _devicesSelected
+        : widget.canWorkOffline;
+    final VoidCallback? primaryOnPressed = primaryEnabled
+        ? (primaryIsConnect ? _onConnect : widget.onOfflinePressed)
+        : null;
 
     return Padding(
       padding: const EdgeInsets.all(16.0),
@@ -701,187 +736,205 @@ class _DeviceSelectionViewState extends State<_DeviceSelectionView> {
           child: FocusTraversalGroup(
             policy: OrderedTraversalPolicy(),
             child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Expanded(
-                    child: Semantics(
-                      header: true,
-                      child: Text(
-                        "Select your Disting NT from the midi device list, or hit refresh to look for devices again.",
-                        style: theme.textTheme.headlineSmall,
-                      ),
-                    ),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.settings, semanticLabel: 'Settings'),
-                    tooltip: 'Settings',
-                    onPressed: widget.onSettingsPressed,
-                  ),
-                ],
-              ),
-              const SizedBox(height: 24),
-              Row(
-                children: [
-                  DropdownMenu<MidiDevice>(
-                    width: 250,
-                    initialSelection: selectedInputDevice,
-                    enabled: true,
-                    label: const Text("Input MIDI Device"),
-                    dropdownMenuEntries: widget.inputDevices.map((device) {
-                      return DropdownMenuEntry<MidiDevice>(
-                        value: device,
-                        label: device.name,
-                      );
-                    }).toList(),
-                    onSelected: (device) {
-                      setState(() {
-                        selectedInputDevice = device;
-                      });
-                      _maybeProbe();
-                    },
-                  ),
-                  const SizedBox(width: 8),
-                  IconButton(
-                    icon: const Icon(Icons.refresh, semanticLabel: 'Refresh devices'),
-                    tooltip: 'Refresh devices',
-                    onPressed: widget.onRefresh,
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              DropdownMenu<MidiDevice>(
-                width: 250,
-                initialSelection: selectedOutputDevice,
-                enabled: true,
-                label: const Text("Output MIDI Device"),
-                dropdownMenuEntries: widget.outputDevices.map((device) {
-                  return DropdownMenuEntry<MidiDevice>(
-                    value: device,
-                    label: device.name,
-                  );
-                }).toList(),
-                onSelected: (device) {
-                  setState(() {
-                    selectedOutputDevice = device;
-                  });
-                  _maybeProbe();
-                },
-              ),
-              const SizedBox(height: 16),
-              DropdownMenu<int>(
-                width: 250,
-                initialSelection: selectedSysExId,
-                label: const Text("Device ID"),
-                dropdownMenuEntries: List.generate(128, (index) {
-                  return DropdownMenuEntry<int>(
-                    value: index,
-                    label: index.toString(),
-                  );
-                }),
-                onSelected: (id) {
-                  setState(() {
-                    selectedSysExId = id;
-                  });
-                  _maybeProbe();
-                },
-              ),
-              const SizedBox(height: 32),
-              SizedBox(
-                height: 48,
-                child: Row(
-                  key: _splitButtonKey,
-                  mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                  FilledButton.icon(
-                    icon: Icon(primaryIcon),
-                    label: Text(primaryLabel),
-                    onPressed: primaryOnPressed,
-                    style: _hasAlternateAction
-                        ? FilledButton.styleFrom(
-                            shape: const RoundedRectangleBorder(
-                              borderRadius: BorderRadius.only(
-                                topLeft: Radius.circular(20),
-                                bottomLeft: Radius.circular(20),
-                              ),
-                            ),
-                          )
-                        : null,
-                  ),
-                  if (_hasAlternateAction) ...[
-                    ExcludeSemantics(
-                      child: SizedBox(
-                        width: 1,
-                        height: 40,
-                        child: ColoredBox(
-                          color: primaryEnabled
-                              ? colorScheme.onPrimary.withAlpha(80)
-                              : colorScheme.onSurface.withAlpha(30),
+                    Expanded(
+                      child: Semantics(
+                        header: true,
+                        child: Text(
+                          "Select your Disting NT from the midi device list, or hit refresh to look for devices again.",
+                          style: theme.textTheme.headlineSmall,
                         ),
                       ),
                     ),
-                    Tooltip(
-                      message: 'More connection options',
-                      child: FilledButton(
-                        onPressed: primaryEnabled ? _showSplitMenu : null,
-                        style: FilledButton.styleFrom(
-                          padding: const EdgeInsets.symmetric(horizontal: 8),
-                          minimumSize: const Size(40, 40),
-                          shape: const RoundedRectangleBorder(
-                            borderRadius: BorderRadius.only(
-                              topRight: Radius.circular(20),
-                              bottomRight: Radius.circular(20),
+                    IconButton(
+                      icon: const Icon(
+                        Icons.settings,
+                        semanticLabel: 'Settings',
+                      ),
+                      tooltip: 'Settings',
+                      onPressed: widget.onSettingsPressed,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                Row(
+                  children: [
+                    DropdownMenu<MidiDevice>(
+                      width: 250,
+                      initialSelection: selectedInputDevice,
+                      enabled: true,
+                      label: const Text("Input MIDI Device"),
+                      dropdownMenuEntries: widget.inputDevices.map((device) {
+                        return DropdownMenuEntry<MidiDevice>(
+                          value: device,
+                          label: device.name,
+                        );
+                      }).toList(),
+                      onSelected: (device) {
+                        setState(() {
+                          selectedInputDevice = device;
+                        });
+                        _maybeProbe();
+                      },
+                    ),
+                    const SizedBox(width: 8),
+                    IconButton(
+                      icon: const Icon(
+                        Icons.refresh,
+                        semanticLabel: 'Refresh devices',
+                      ),
+                      tooltip: 'Refresh devices',
+                      onPressed: widget.onRefresh,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                DropdownMenu<MidiDevice>(
+                  width: 250,
+                  initialSelection: selectedOutputDevice,
+                  enabled: true,
+                  label: const Text("Output MIDI Device"),
+                  dropdownMenuEntries: widget.outputDevices.map((device) {
+                    return DropdownMenuEntry<MidiDevice>(
+                      value: device,
+                      label: device.name,
+                    );
+                  }).toList(),
+                  onSelected: (device) {
+                    setState(() {
+                      selectedOutputDevice = device;
+                    });
+                    _maybeProbe();
+                  },
+                ),
+                const SizedBox(height: 16),
+                DropdownMenu<int>(
+                  width: 250,
+                  initialSelection: selectedSysExId,
+                  label: const Text("Device ID"),
+                  dropdownMenuEntries: List.generate(128, (index) {
+                    return DropdownMenuEntry<int>(
+                      value: index,
+                      label: index.toString(),
+                    );
+                  }),
+                  onSelected: (id) {
+                    setState(() {
+                      selectedSysExId = id;
+                    });
+                    _maybeProbe();
+                  },
+                ),
+                const SizedBox(height: 32),
+                SizedBox(
+                  height: 48,
+                  child: Row(
+                    key: _splitButtonKey,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      FilledButton.icon(
+                        icon: Icon(primaryIcon),
+                        label: Text(primaryLabel),
+                        onPressed: primaryOnPressed,
+                        style: _hasAlternateAction
+                            ? FilledButton.styleFrom(
+                                shape: const RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.only(
+                                    topLeft: Radius.circular(20),
+                                    bottomLeft: Radius.circular(20),
+                                  ),
+                                ),
+                              )
+                            : null,
+                      ),
+                      if (_hasAlternateAction) ...[
+                        ExcludeSemantics(
+                          child: SizedBox(
+                            width: 1,
+                            height: 40,
+                            child: ColoredBox(
+                              color: primaryEnabled
+                                  ? colorScheme.onPrimary.withAlpha(80)
+                                  : colorScheme.onSurface.withAlpha(30),
                             ),
                           ),
                         ),
-                        child: const Icon(Icons.arrow_drop_down, semanticLabel: 'More connection options'),
-                      ),
-                    ),
-                  ],
-                  AnimatedSize(
-                    duration: const Duration(milliseconds: 300),
-                    curve: Curves.easeInOut,
-                    child: widget.onFirmwarePressed != null && _devicesSelected
-                        ? Padding(
-                            padding: const EdgeInsets.only(left: 12),
-                            child: OutlinedButton.icon(
-                              icon: const Icon(Icons.system_update),
-                              label: const Text("Firmware"),
-                              onPressed: () => widget.onFirmwarePressed
-                                  ?.call(_probedFirmwareVersion, selectedInputDevice, selectedOutputDevice, selectedSysExId),
+                        Tooltip(
+                          message: 'More connection options',
+                          child: FilledButton(
+                            onPressed: primaryEnabled ? _showSplitMenu : null,
+                            style: FilledButton.styleFrom(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                              ),
+                              minimumSize: const Size(40, 40),
+                              shape: const RoundedRectangleBorder(
+                                borderRadius: BorderRadius.only(
+                                  topRight: Radius.circular(20),
+                                  bottomRight: Radius.circular(20),
+                                ),
+                              ),
                             ),
-                          )
-                        : const SizedBox.shrink(),
+                            child: const Icon(
+                              Icons.arrow_drop_down,
+                              semanticLabel: 'More connection options',
+                            ),
+                          ),
+                        ),
+                      ],
+                      AnimatedSize(
+                        duration: const Duration(milliseconds: 300),
+                        curve: Curves.easeInOut,
+                        child:
+                            widget.onFirmwarePressed != null && _devicesSelected
+                            ? Padding(
+                                padding: const EdgeInsets.only(left: 12),
+                                child: OutlinedButton.icon(
+                                  icon: const Icon(Icons.system_update),
+                                  label: const Text("Firmware"),
+                                  onPressed: () =>
+                                      widget.onFirmwarePressed?.call(
+                                        _probedFirmwareVersion,
+                                        selectedInputDevice,
+                                        selectedOutputDevice,
+                                        selectedSysExId,
+                                      ),
+                                ),
+                              )
+                            : const SizedBox.shrink(),
+                      ),
+                    ],
                   ),
-                  ],
                 ),
-              ),
-              const SizedBox(height: 24),
-              const Divider(),
-              const SizedBox(height: 16),
-              Semantics(
-                header: true,
-                child: Text(
-                  "No Disting? Try the demo:",
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: colorScheme.onSurfaceVariant,
+                const SizedBox(height: 24),
+                const Divider(),
+                const SizedBox(height: 16),
+                Semantics(
+                  header: true,
+                  child: Text(
+                    "No Disting? Try the demo:",
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(height: 12),
-              Semantics(
-                hint: 'Try the app with simulated algorithms, no hardware needed',
-                child: OutlinedButton.icon(
-                  icon: const Icon(Icons.play_arrow),
-                  onPressed: widget.onDemoPressed,
-                  label: const Text("Demo Mode"),
+                const SizedBox(height: 12),
+                Semantics(
+                  hint:
+                      'Try the app with simulated algorithms, no hardware needed',
+                  child: OutlinedButton.icon(
+                    icon: const Icon(Icons.play_arrow),
+                    onPressed: widget.onDemoPressed,
+                    label: const Text("Demo Mode"),
+                  ),
                 ),
-              ),
-            ],
-          ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/mcp/tool_registry.dart
+++ b/lib/mcp/tool_registry.dart
@@ -79,14 +79,16 @@ class ToolRegistry {
         ),
         callback: (args, extra) async {
           try {
-            final resultJson = await entry.handler(args).timeout(
-              entry.timeout,
-              onTimeout: () => jsonEncode({
-                'success': false,
-                'error':
-                    'Tool execution timed out after ${entry.timeout.inSeconds} seconds',
-              }),
-            );
+            final resultJson = await entry
+                .handler(args)
+                .timeout(
+                  entry.timeout,
+                  onTimeout: () => jsonEncode({
+                    'success': false,
+                    'error':
+                        'Tool execution timed out after ${entry.timeout.inSeconds} seconds',
+                  }),
+                );
             final image = tryParseImageResult(resultJson);
             if (image != null) {
               return CallToolResult.fromContent([
@@ -132,214 +134,365 @@ class ToolRegistry {
   }
 
   void _registerSearchTools() {
-    _entries.add(ToolRegistryEntry(
-      name: 'search_algorithms',
-      description:
-          'Search for algorithms by name/category. Uses fuzzy matching (70% threshold). Returns up to 10 results sorted by relevance.',
-      inputSchema: {
-        'properties': {
-          'query': {
-            'type': 'string',
-            'description':
-                'Search query: algorithm name, partial name, or category.',
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'search_algorithms',
+        description:
+            'Search for algorithms by name/category. Uses fuzzy matching (70% threshold). Returns up to 10 results sorted by relevance.',
+        inputSchema: {
+          'properties': {
+            'query': {
+              'type': 'string',
+              'description':
+                  'Search query: algorithm name, partial name, or category.',
+            },
           },
+          'required': ['query'],
         },
-        'required': ['query'],
-      },
-      handler: (args) => _algoTools.searchAlgorithms(args),
-      timeout: const Duration(seconds: 5),
-    ));
+        handler: (args) => _algoTools.searchAlgorithms(args),
+        timeout: const Duration(seconds: 5),
+      ),
+    );
 
-    _entries.add(ToolRegistryEntry(
-      name: 'search_parameters',
-      description:
-          'Search for parameters by name within the current preset or a specific slot. Uses exact or partial name matching.',
-      inputSchema: {
-        'properties': {
-          'query': {
-            'type': 'string',
-            'description': 'Parameter name to search for (case-insensitive).',
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'search_parameters',
+        description:
+            'Search for parameters by name within the current preset or a specific slot. Uses exact or partial name matching.',
+        inputSchema: {
+          'properties': {
+            'query': {
+              'type': 'string',
+              'description': 'Parameter name to search for (case-insensitive).',
+            },
+            'scope': {
+              'type': 'string',
+              'description':
+                  'Search scope: "preset" (all slots) or "slot" (specific slot).',
+              'enum': ['preset', 'slot'],
+            },
+            'slot_index': {
+              'type': 'integer',
+              'description':
+                  'Slot index (0-31). Required when scope is "slot".',
+            },
+            'partial_match': {
+              'type': 'boolean',
+              'description':
+                  'If true, find parameters containing the query. Default: false (exact match).',
+            },
           },
-          'scope': {
-            'type': 'string',
-            'description':
-                'Search scope: "preset" (all slots) or "slot" (specific slot).',
-            'enum': ['preset', 'slot'],
-          },
-          'slot_index': {
-            'type': 'integer',
-            'description': 'Slot index (0-31). Required when scope is "slot".',
-          },
-          'partial_match': {
-            'type': 'boolean',
-            'description':
-                'If true, find parameters containing the query. Default: false (exact match).',
-          },
+          'required': ['query', 'scope'],
         },
-        'required': ['query', 'scope'],
-      },
-      handler: (args) => _distingTools.searchParameters(args),
-      timeout: const Duration(seconds: 5),
-    ));
+        handler: (args) => _distingTools.searchParameters(args),
+        timeout: const Duration(seconds: 5),
+      ),
+    );
   }
 
   void _registerShowTools() {
-    _entries.add(ToolRegistryEntry(
-      name: 'show_preset',
-      description:
-          'Show a compact preset overview: preset name and slot list with algorithm names and parameter counts. '
-          'Does NOT include parameter values or mappings. Use show_slot to drill into a specific slot.',
-      inputSchema: {'properties': {}},
-      handler: (_) => _algoTools.showPreset(),
-    ));
-
-    _entries.add(ToolRegistryEntry(
-      name: 'show_slot',
-      description:
-          'Show a slot with its algorithm info and a page of parameter summaries (name, current value, range). '
-          'Does NOT include enum value lists or full mapping details — use show_parameter for those. '
-          'Parameters with mappings show has_mapping: true. Supports pagination via offset/limit.',
-      inputSchema: {
-        'properties': {
-          'slot_index': {
-            'type': 'integer',
-            'minimum': 0,
-            'maximum': 31,
-            'description': 'Slot index (0-31).',
-          },
-          'offset': {
-            'type': 'integer',
-            'minimum': 0,
-            'description': 'Parameter offset for pagination (default: 0).',
-          },
-          'limit': {
-            'type': 'integer',
-            'minimum': 1,
-            'maximum': 100,
-            'description': 'Max parameters to return (default: 10, max: 100).',
-          },
-        },
-        'required': ['slot_index'],
-      },
-      handler: (args) => _algoTools.showSlot(
-        args['slot_index'],
-        offset: (args['offset'] as int?) ?? 0,
-        limit: (args['limit'] as int?) ?? 10,
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'show_preset',
+        description:
+            'Show a compact preset overview: preset name and slot list with algorithm names and parameter counts. '
+            'Does NOT include parameter values or mappings. Use show_slot to drill into a specific slot.',
+        inputSchema: {'properties': {}},
+        handler: (_) => _algoTools.showPreset(),
       ),
-    ));
+    );
 
-    _entries.add(ToolRegistryEntry(
-      name: 'show_parameter',
-      description:
-          'Show a single parameter with its value, range, unit, and enabled mappings.',
-      inputSchema: {
-        'properties': {
-          'slot_index': {
-            'type': 'integer',
-            'minimum': 0,
-            'maximum': 31,
-            'description': 'Slot index (0-31).',
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'show_slot',
+        description:
+            'Show a slot with its algorithm info and a page of parameter summaries (name, current value, range). '
+            'Does NOT include enum value lists or full mapping details — use show_parameter for those. '
+            'Parameters with mappings show has_mapping: true. Supports pagination via offset/limit.',
+        inputSchema: {
+          'properties': {
+            'slot_index': {
+              'type': 'integer',
+              'minimum': 0,
+              'maximum': 31,
+              'description': 'Slot index (0-31).',
+            },
+            'offset': {
+              'type': 'integer',
+              'minimum': 0,
+              'description': 'Parameter offset for pagination (default: 0).',
+            },
+            'limit': {
+              'type': 'integer',
+              'minimum': 1,
+              'maximum': 100,
+              'description':
+                  'Max parameters to return (default: 10, max: 100).',
+            },
           },
-          'parameter_number': {
-            'description':
-                'Parameter identifier: integer number (0-based) or string name.',
-            'oneOf': [
-              {'type': 'string'},
-              {'type': 'integer'},
-            ],
-          },
+          'required': ['slot_index'],
         },
-        'required': ['slot_index', 'parameter_number'],
-      },
-      handler: (args) =>
-          _algoTools.showParameterByIndex(args['slot_index'], args['parameter_number']),
-    ));
+        handler: (args) => _algoTools.showSlot(
+          args['slot_index'],
+          offset: (args['offset'] as int?) ?? 0,
+          limit: (args['limit'] as int?) ?? 10,
+        ),
+      ),
+    );
 
-    _entries.add(ToolRegistryEntry(
-      name: 'show_screen',
-      description:
-          'Capture and return the current device screen as a base64 PNG image.',
-      inputSchema: {
-        'properties': {
-          'display_mode': {
-            'type': 'string',
-            'description':
-                'Optional display mode to switch to before capturing. Options: "parameter" (hardware parameter list), "algorithm" (custom algorithm interface), "overview" (all slots overview), "vu_meters" (VU meter display)',
-            'enum': ['parameter', 'algorithm', 'overview', 'vu_meters'],
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'show_parameter',
+        description:
+            'Show a single parameter with its value, range, unit, and enabled mappings.',
+        inputSchema: {
+          'properties': {
+            'slot_index': {
+              'type': 'integer',
+              'minimum': 0,
+              'maximum': 31,
+              'description': 'Slot index (0-31).',
+            },
+            'parameter_number': {
+              'description':
+                  'Parameter identifier: integer number (0-based) or string name.',
+              'oneOf': [
+                {'type': 'string'},
+                {'type': 'integer'},
+              ],
+            },
           },
+          'required': ['slot_index', 'parameter_number'],
         },
-      },
-      handler: (args) =>
-          _algoTools.showScreen(displayMode: args['display_mode']),
-    ));
+        handler: (args) => _algoTools.showParameterByIndex(
+          args['slot_index'],
+          args['parameter_number'],
+        ),
+      ),
+    );
 
-    _entries.add(ToolRegistryEntry(
-      name: 'show_routing',
-      description:
-          'Show the current signal routing state with input/output bus assignments for all slots.',
-      inputSchema: {'properties': {}},
-      handler: (_) => _algoTools.showRouting(),
-    ));
-
-    _entries.add(ToolRegistryEntry(
-      name: 'show_cpu',
-      description:
-          'Show CPU usage for the device and per-slot usage breakdown.',
-      inputSchema: {'properties': {}},
-      handler: (_) => _algoTools.showCpu(),
-    ));
-  }
-
-  void _registerEditTools() {
-    _entries.add(ToolRegistryEntry(
-      name: 'edit_preset',
-      description:
-          'Edit the entire preset state including name and all slots. WARNING: Replaces the full preset.',
-      inputSchema: {
-        'properties': {
-          'data': {
-            'type': 'object',
-            'description': 'Full preset data with name and slots array.',
-            'properties': {
-              'name': {'type': 'string', 'description': 'Preset name'},
-              'slots': {
-                'type': 'array',
-                'description':
-                    'Array of slot objects with algorithm and parameters',
-              },
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'show_screen',
+        description:
+            'Capture and return the current device screen as a base64 PNG image.',
+        inputSchema: {
+          'properties': {
+            'display_mode': {
+              'type': 'string',
+              'description':
+                  'Optional display mode to switch to before capturing. Options: "parameter" (hardware parameter list), "algorithm" (custom algorithm interface), "overview" (all slots overview), "vu_meters" (VU meter display)',
+              'enum': ['parameter', 'algorithm', 'overview', 'vu_meters'],
             },
           },
         },
-        'required': ['data'],
-      },
-      handler: (args) =>
-          _distingTools.editPreset(args),
-      timeout: const Duration(seconds: 30),
-    ));
+        handler: (args) =>
+            _algoTools.showScreen(displayMode: args['display_mode']),
+      ),
+    );
 
-    _entries.add(ToolRegistryEntry(
-      name: 'edit_slot',
-      description:
-          'Edit a specific slot: change algorithm, set parameters, or rename. Device must be in connected mode.',
-      inputSchema: {
-        'properties': {
-          'slot_index': {
-            'type': 'integer',
-            'minimum': 0,
-            'maximum': 31,
-            'description': 'Slot index (0-31).',
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'show_routing',
+        description:
+            'Show the current signal routing state with input/output bus assignments for all slots.',
+        inputSchema: {'properties': {}},
+        handler: (_) => _algoTools.showRouting(),
+      ),
+    );
+
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'show_cpu',
+        description:
+            'Show CPU usage for the device and per-slot usage breakdown.',
+        inputSchema: {'properties': {}},
+        handler: (_) => _algoTools.showCpu(),
+      ),
+    );
+  }
+
+  void _registerEditTools() {
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'edit_preset',
+        description:
+            'Edit the entire preset state including name and all slots. WARNING: Replaces the full preset.',
+        inputSchema: {
+          'properties': {
+            'data': {
+              'type': 'object',
+              'description': 'Full preset data with name and slots array.',
+              'properties': {
+                'name': {'type': 'string', 'description': 'Preset name'},
+                'slots': {
+                  'type': 'array',
+                  'description':
+                      'Array of slot objects with algorithm and parameters',
+                },
+              },
+            },
           },
-          'data': {
-            'type': 'object',
-            'description':
-                'Slot data with optional algorithm, parameters, and name.',
-            'properties': {
-              'algorithm': {
+          'required': ['data'],
+        },
+        handler: (args) => _distingTools.editPreset(args),
+        timeout: const Duration(seconds: 30),
+      ),
+    );
+
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'edit_slot',
+        description:
+            'Edit a specific slot: change algorithm, set parameters, or rename. Device must be in connected mode.',
+        inputSchema: {
+          'properties': {
+            'slot_index': {
+              'type': 'integer',
+              'minimum': 0,
+              'maximum': 31,
+              'description': 'Slot index (0-31).',
+            },
+            'data': {
+              'type': 'object',
+              'description':
+                  'Slot data with optional algorithm, parameters, and name.',
+              'properties': {
+                'algorithm': {
+                  'type': 'object',
+                  'description':
+                      'Algorithm specification (guid or name, plus optional specifications)',
+                  'properties': {
+                    'guid': {'type': 'string', 'description': 'Algorithm GUID'},
+                    'name': {
+                      'type': 'string',
+                      'description': 'Algorithm name (fuzzy matching)',
+                    },
+                    'specifications': {
+                      'type': 'array',
+                      'description': 'Algorithm-specific specification values',
+                      'items': {'type': 'integer'},
+                    },
+                  },
+                },
+                'name': {'type': 'string', 'description': 'Custom slot name'},
+                'parameters': {
+                  'type': 'array',
+                  'description':
+                      'Array of parameter objects with values and/or mappings',
+                  'items': {
+                    'type': 'object',
+                    'properties': {
+                      'parameter_number': {
+                        'type': 'integer',
+                        'description': 'Parameter index',
+                      },
+                      'value': {
+                        'description':
+                            'Parameter value. For enum parameters, use one of the exact strings from valid_enum_values. For numeric parameters, use a number.',
+                      },
+                      'mapping': {
+                        'type': 'object',
+                        'description':
+                            'Mapping with CV, MIDI, i2c, and performance page fields. Supports partial updates.',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          'required': ['slot_index', 'data'],
+        },
+        handler: (args) => _distingTools.editSlot(args),
+        timeout: const Duration(seconds: 30),
+      ),
+    );
+
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'edit_parameter',
+        description:
+            'Edit a single parameter value and/or mapping. Device must be in connected mode.',
+        inputSchema: {
+          'properties': {
+            'slot_index': {
+              'type': 'integer',
+              'minimum': 0,
+              'maximum': 31,
+              'description': 'Slot index (0-31).',
+            },
+            'parameter_number': {
+              'description':
+                  'Parameter identifier: integer number (0-based) or string name.',
+              'oneOf': [
+                {'type': 'string'},
+                {'type': 'integer'},
+              ],
+            },
+            'value': {
+              'description':
+                  'Parameter value. For enum parameters, use one of the exact strings from valid_enum_values. For numeric parameters, use a number. If omitted, mapping must be provided.',
+            },
+            'mapping': {
+              'type': 'object',
+              'description':
+                  'Parameter mapping with CV, MIDI, i2c, and performance page controls. Supports partial updates.',
+              'properties': {
+                'cv': {
+                  'type': 'object',
+                  'description':
+                      'CV mapping: source, cv_input (0-12), is_unipolar, is_gate, volts, delta',
+                },
+                'midi': {
+                  'type': 'object',
+                  'description':
+                      'MIDI mapping: is_midi_enabled, midi_channel (0-15), midi_cc (0-128), midi_type, is_midi_symmetric, is_midi_relative, midi_min, midi_max',
+                },
+                'i2c': {
+                  'type': 'object',
+                  'description':
+                      'i2c mapping: is_i2c_enabled, i2c_cc (0-255), is_i2c_symmetric, i2c_min, i2c_max',
+                },
+                'performance_page': {
+                  'type': 'integer',
+                  'description':
+                      'Performance page index (0=not assigned, 1-30=page number)',
+                },
+              },
+            },
+          },
+          'required': ['slot_index', 'parameter_number'],
+        },
+        handler: (args) => _distingTools.editParameter(args),
+        timeout: const Duration(seconds: 15),
+      ),
+    );
+  }
+
+  void _registerPresetTools() {
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'new',
+        description:
+            'Create new blank preset or preset with initial algorithms. WARNING: Clears current preset.',
+        inputSchema: {
+          'properties': {
+            'name': {
+              'type': 'string',
+              'description': 'Name for the new preset.',
+            },
+            'algorithms': {
+              'type': 'array',
+              'description':
+                  'Algorithms to add. Each: {name: string} or {guid: string}. Added to slots 0, 1, 2, etc.',
+              'items': {
                 'type': 'object',
-                'description':
-                    'Algorithm specification (guid or name, plus optional specifications)',
                 'properties': {
-                  'guid': {'type': 'string', 'description': 'Algorithm GUID'},
+                  'guid': {
+                    'type': 'string',
+                    'description': 'Algorithm GUID (alternative to name)',
+                  },
                   'name': {
                     'type': 'string',
                     'description': 'Algorithm name (fuzzy matching)',
@@ -351,215 +504,157 @@ class ToolRegistry {
                   },
                 },
               },
-              'name': {'type': 'string', 'description': 'Custom slot name'},
-              'parameters': {
-                'type': 'array',
-                'description':
-                    'Array of parameter objects with values and/or mappings',
-                'items': {
-                  'type': 'object',
-                  'properties': {
-                    'parameter_number': {
-                      'type': 'integer',
-                      'description': 'Parameter index',
-                    },
-                    'value': {
-                      'description':
-                          'Parameter value. For enum parameters, use one of the exact strings from valid_enum_values. For numeric parameters, use a number.',
-                    },
-                    'mapping': {
-                      'type': 'object',
-                      'description':
-                          'Mapping with CV, MIDI, i2c, and performance page fields. Supports partial updates.',
-                    },
-                  },
-                },
-              },
+            },
+          },
+          'required': ['name'],
+        },
+        handler: (args) => _distingTools.newWithAlgorithms(args),
+        timeout: const Duration(seconds: 30),
+      ),
+    );
+
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'save',
+        description: 'Save the current preset to the device.',
+        inputSchema: {'properties': {}},
+        handler: (args) => _distingTools.savePreset(args),
+      ),
+    );
+
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'add',
+        description: 'Add an algorithm to the preset. Requires name or guid.',
+        inputSchema: {
+          'properties': {
+            'name': {
+              'type': 'string',
+              'description':
+                  'Algorithm name (fuzzy matching). Required if no guid.',
+            },
+            'guid': {
+              'type': 'string',
+              'description': 'Algorithm GUID. Required if no name.',
+            },
+            'slot_index': {
+              'type': 'integer',
+              'description':
+                  'Insert position (0-31). Omit for first empty slot.',
+            },
+            'specifications': {
+              'type': 'array',
+              'items': {'type': 'integer'},
+              'description':
+                  'Specification values for algorithms that require them (e.g., channel count, max delay time).',
             },
           },
         },
-        'required': ['slot_index', 'data'],
-      },
-      handler: (args) => _distingTools.editSlot(args),
-      timeout: const Duration(seconds: 30),
-    ));
+        handler: (args) =>
+            _distingTools.addSimple({...args, 'target': 'algorithm'}),
+        timeout: const Duration(seconds: 30),
+      ),
+    );
 
-    _entries.add(ToolRegistryEntry(
-      name: 'edit_parameter',
-      description:
-          'Edit a single parameter value and/or mapping. Device must be in connected mode.',
-      inputSchema: {
-        'properties': {
-          'slot_index': {
-            'type': 'integer',
-            'minimum': 0,
-            'maximum': 31,
-            'description': 'Slot index (0-31).',
-          },
-          'parameter_number': {
-            'description':
-                'Parameter identifier: integer number (0-based) or string name.',
-            'oneOf': [
-              {'type': 'string'},
-              {'type': 'integer'},
-            ],
-          },
-          'value': {
-            'description':
-                'Parameter value. For enum parameters, use one of the exact strings from valid_enum_values. For numeric parameters, use a number. If omitted, mapping must be provided.',
-          },
-          'mapping': {
-            'type': 'object',
-            'description':
-                'Parameter mapping with CV, MIDI, i2c, and performance page controls. Supports partial updates.',
-            'properties': {
-              'cv': {
-                'type': 'object',
-                'description':
-                    'CV mapping: source, cv_input (0-12), is_unipolar, is_gate, volts, delta',
-              },
-              'midi': {
-                'type': 'object',
-                'description':
-                    'MIDI mapping: is_midi_enabled, midi_channel (0-15), midi_cc (0-128), midi_type, is_midi_symmetric, is_midi_relative, midi_min, midi_max',
-              },
-              'i2c': {
-                'type': 'object',
-                'description':
-                    'i2c mapping: is_i2c_enabled, i2c_cc (0-255), is_i2c_symmetric, i2c_min, i2c_max',
-              },
-              'performance_page': {
-                'type': 'integer',
-                'description':
-                    'Performance page index (0=not assigned, 1-30=page number)',
-              },
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'apply_template_to_preset',
+        description:
+            'Apply selected slots from a saved template to the connected device or to a saved local preset.',
+        inputSchema: {
+          'properties': {
+            'template_id': {
+              'type': 'integer',
+              'description': 'Template preset id.',
+            },
+            'template_name': {
+              'type': 'string',
+              'description':
+                  'Alternative to template_id; resolved by exact match, then case-insensitive exact match.',
+            },
+            'slot_indices': {
+              'type': 'array',
+              'items': {'type': 'integer', 'minimum': 0},
+              'description':
+                  'Which template slots to apply. Omit to apply all.',
+            },
+            'target': {
+              'type': 'string',
+              'enum': ['device', 'preset'],
+              'description': 'Where to apply. Default: device.',
+            },
+            'target_preset_id': {
+              'type': 'integer',
+              'description': 'Required when target is "preset".',
+            },
+            'target_preset_name': {
+              'type': 'string',
+              'description': 'Alternative to target_preset_id.',
+            },
+            'insertion_offset': {
+              'type': 'integer',
+              'description':
+                  'Slot index in target. Default: append for device, 0 for preset.',
+            },
+            'overwrite': {
+              'type': 'boolean',
+              'description':
+                  'Replace target slots starting at insertion_offset. Default: false.',
             },
           },
         },
-        'required': ['slot_index', 'parameter_number'],
-      },
-      handler: (args) => _distingTools.editParameter(args),
-      timeout: const Duration(seconds: 15),
-    ));
-  }
+        handler: (args) => _distingTools.applyTemplateToPreset(args),
+        timeout: const Duration(seconds: 120),
+      ),
+    );
 
-  void _registerPresetTools() {
-    _entries.add(ToolRegistryEntry(
-      name: 'new',
-      description:
-          'Create new blank preset or preset with initial algorithms. WARNING: Clears current preset.',
-      inputSchema: {
-        'properties': {
-          'name': {'type': 'string', 'description': 'Name for the new preset.'},
-          'algorithms': {
-            'type': 'array',
-            'description':
-                'Algorithms to add. Each: {name: string} or {guid: string}. Added to slots 0, 1, 2, etc.',
-            'items': {
-              'type': 'object',
-              'properties': {
-                'guid': {
-                  'type': 'string',
-                  'description': 'Algorithm GUID (alternative to name)',
-                },
-                'name': {
-                  'type': 'string',
-                  'description': 'Algorithm name (fuzzy matching)',
-                },
-                'specifications': {
-                  'type': 'array',
-                  'description': 'Algorithm-specific specification values',
-                  'items': {'type': 'integer'},
-                },
-              },
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'remove',
+        description:
+            'Remove the algorithm from a slot, leaving it empty. Succeeds gracefully if slot is already empty.',
+        inputSchema: {
+          'properties': {
+            'slot_index': {
+              'type': 'integer',
+              'description': 'Slot index to clear (0-31).',
             },
           },
+          'required': ['slot_index'],
         },
-        'required': ['name'],
-      },
-      handler: (args) => _distingTools.newWithAlgorithms(args),
-      timeout: const Duration(seconds: 30),
-    ));
+        handler: (args) =>
+            _distingTools.removeSlot({...args, 'target': 'slot'}),
+      ),
+    );
 
-    _entries.add(ToolRegistryEntry(
-      name: 'save',
-      description: 'Save the current preset to the device.',
-      inputSchema: {'properties': {}},
-      handler: (args) => _distingTools.savePreset(args),
-    ));
-
-    _entries.add(ToolRegistryEntry(
-      name: 'add',
-      description: 'Add an algorithm to the preset. Requires name or guid.',
-      inputSchema: {
-        'properties': {
-          'name': {
-            'type': 'string',
-            'description':
-                'Algorithm name (fuzzy matching). Required if no guid.',
+    _entries.add(
+      ToolRegistryEntry(
+        name: 'move_algorithm',
+        description:
+            'Move an algorithm up or down in the slot list. '
+            'Algorithms swap positions with adjacent slots.',
+        inputSchema: {
+          'properties': {
+            'slot_index': {
+              'type': 'integer',
+              'description':
+                  'Current slot index of the algorithm to move (0-31).',
+            },
+            'direction': {
+              'type': 'string',
+              'enum': ['up', 'down'],
+              'description':
+                  'Direction to move: "up" (lower slot number) or "down" (higher slot number).',
+            },
+            'steps': {
+              'type': 'integer',
+              'description': 'Number of positions to move (default: 1).',
+            },
           },
-          'guid': {
-            'type': 'string',
-            'description': 'Algorithm GUID. Required if no name.',
-          },
-          'slot_index': {
-            'type': 'integer',
-            'description': 'Insert position (0-31). Omit for first empty slot.',
-          },
-          'specifications': {
-            'type': 'array',
-            'items': {'type': 'integer'},
-            'description':
-                'Specification values for algorithms that require them (e.g., channel count, max delay time).',
-          },
+          'required': ['slot_index', 'direction'],
         },
-      },
-      handler: (args) =>
-          _distingTools.addSimple({...args, 'target': 'algorithm'}),
-      timeout: const Duration(seconds: 30),
-    ));
-
-    _entries.add(ToolRegistryEntry(
-      name: 'remove',
-      description:
-          'Remove the algorithm from a slot, leaving it empty. Succeeds gracefully if slot is already empty.',
-      inputSchema: {
-        'properties': {
-          'slot_index': {
-            'type': 'integer',
-            'description': 'Slot index to clear (0-31).',
-          },
-        },
-        'required': ['slot_index'],
-      },
-      handler: (args) =>
-          _distingTools.removeSlot({...args, 'target': 'slot'}),
-    ));
-
-    _entries.add(ToolRegistryEntry(
-      name: 'move_algorithm',
-      description:
-          'Move an algorithm up or down in the slot list. '
-          'Algorithms swap positions with adjacent slots.',
-      inputSchema: {
-        'properties': {
-          'slot_index': {
-            'type': 'integer',
-            'description': 'Current slot index of the algorithm to move (0-31).',
-          },
-          'direction': {
-            'type': 'string',
-            'enum': ['up', 'down'],
-            'description': 'Direction to move: "up" (lower slot number) or "down" (higher slot number).',
-          },
-          'steps': {
-            'type': 'integer',
-            'description': 'Number of positions to move (default: 1).',
-          },
-        },
-        'required': ['slot_index', 'direction'],
-      },
-      handler: (args) => _distingTools.moveAlgorithm(args),
-    ));
+        handler: (args) => _distingTools.moveAlgorithm(args),
+      ),
+    );
   }
 }

--- a/lib/mcp/tools/disting_tools.dart
+++ b/lib/mcp/tools/disting_tools.dart
@@ -1185,10 +1185,13 @@ class DistingTools {
 
     final cubit = MetadataSyncCubit(db, _distingCubit);
     var appliedCount = 0;
+    String? failureMessage;
     try {
       final subscription = cubit.stream.listen((state) {
         if (state is InjectingTemplate) {
           appliedCount = state.applied;
+        } else if (state is PresetLoadFailure) {
+          failureMessage = state.error;
         }
       });
       try {
@@ -1197,6 +1200,12 @@ class DistingTools {
           templateSlotIndices: slotIndices,
           manager: _distingCubit.requireDisting(),
         );
+        final finalState = cubit.state;
+        if (finalState is PresetLoadFailure) {
+          failureMessage = finalState.error;
+        } else if (finalState is InjectingTemplate) {
+          appliedCount = finalState.applied;
+        }
       } finally {
         await subscription.cancel();
         await cubit.close();
@@ -1208,6 +1217,17 @@ class DistingTools {
           'error': 'partial_apply',
           'applied_slot_count': appliedCount,
           'message': e.toString(),
+        }),
+      );
+    }
+
+    if (failureMessage != null) {
+      return jsonEncode(
+        convertToSnakeCaseKeys({
+          'success': false,
+          'error': 'partial_apply',
+          'applied_slot_count': appliedCount,
+          'message': failureMessage,
         }),
       );
     }

--- a/lib/mcp/tools/disting_tools.dart
+++ b/lib/mcp/tools/disting_tools.dart
@@ -14,9 +14,12 @@ import 'package:nt_helper/domain/disting_nt_sysex.dart'
 import 'package:nt_helper/models/packed_mapping_data.dart' show MidiMappingType;
 import 'package:nt_helper/cubit/disting_cubit.dart'
     show DistingCubit, DistingStateSynchronized;
+import 'package:nt_helper/db/daos/presets_dao.dart';
+import 'package:nt_helper/db/database.dart';
 // Re-added for Algorithm, ParameterInfo etc.
 import 'package:nt_helper/services/algorithm_metadata_service.dart';
 import 'package:nt_helper/services/disting_controller.dart';
+import 'package:nt_helper/ui/metadata_sync/metadata_sync_cubit.dart';
 import 'package:nt_helper/util/case_converter.dart';
 import 'package:nt_helper/mcp/mcp_constants.dart';
 import 'package:nt_helper/mcp/utils/bus_mapping.dart';
@@ -218,7 +221,6 @@ class DistingTools {
     return null;
   }
 
-
   /// MCP Tool: Gets the entire current preset state.
   /// Parameters: None
   /// Returns:
@@ -278,12 +280,18 @@ class DistingTools {
               paramData['value'] = liveRawValue != null
                   ? _scaleForDisplay(liveRawValue, pInfo.powerOfTen)
                   : null;
-              paramData['min_value'] =
-                  _scaleForDisplay(pInfo.min, pInfo.powerOfTen);
-              paramData['max_value'] =
-                  _scaleForDisplay(pInfo.max, pInfo.powerOfTen);
-              paramData['default_value'] =
-                  _scaleForDisplay(pInfo.defaultValue, pInfo.powerOfTen);
+              paramData['min_value'] = _scaleForDisplay(
+                pInfo.min,
+                pInfo.powerOfTen,
+              );
+              paramData['max_value'] = _scaleForDisplay(
+                pInfo.max,
+                pInfo.powerOfTen,
+              );
+              paramData['default_value'] = _scaleForDisplay(
+                pInfo.defaultValue,
+                pInfo.powerOfTen,
+              );
             }
 
             // Add mapping information (performance page, MIDI, CV, etc.)
@@ -928,8 +936,10 @@ class DistingTools {
               _enumIndexToString(enumValues, liveRawValue) ?? '';
         }
       } else {
-        responseData['value'] =
-            _scaleForDisplay(liveRawValue, paramInfo.powerOfTen);
+        responseData['value'] = _scaleForDisplay(
+          liveRawValue,
+          paramInfo.powerOfTen,
+        );
       }
 
       return jsonEncode(
@@ -1064,6 +1074,311 @@ class DistingTools {
         convertToSnakeCaseKeys(MCPUtils.buildError(e.toString())),
       );
     }
+  }
+
+  /// MCP Tool: applies selected slots from a saved template to the device or
+  /// to another saved local preset.
+  Future<String> applyTemplateToPreset(Map<String, dynamic> params) async {
+    try {
+      final db = _distingCubit.database;
+      final dao = db.presetsDao;
+
+      final templateResolution = await _resolveTemplatePreset(dao, params);
+      if (templateResolution.error != null) {
+        return jsonEncode(convertToSnakeCaseKeys(templateResolution.error!));
+      }
+      final template = templateResolution.details!;
+
+      final slotIndicesOrError = _resolveTemplateSlotIndices(
+        params['slot_indices'],
+        template.slots.length,
+      );
+      if (slotIndicesOrError.error != null) {
+        return jsonEncode(convertToSnakeCaseKeys(slotIndicesOrError.error!));
+      }
+      final slotIndices = slotIndicesOrError.slotIndices!;
+
+      final target = (params['target'] as String?) ?? 'device';
+      if (target != 'device' && target != 'preset') {
+        return jsonEncode(
+          convertToSnakeCaseKeys(
+            MCPUtils.buildError('target must be "device" or "preset".'),
+          ),
+        );
+      }
+
+      if (target == 'device') {
+        return _applyTemplateToDeviceTarget(
+          db: db,
+          template: template,
+          slotIndices: slotIndices,
+        );
+      }
+
+      final targetResolution = await _resolveTargetPreset(dao, params);
+      if (targetResolution.error != null) {
+        return jsonEncode(convertToSnakeCaseKeys(targetResolution.error!));
+      }
+      final targetPreset = targetResolution.preset!;
+      if (targetPreset.isTemplate && targetPreset.id != template.preset.id) {
+        return jsonEncode(
+          convertToSnakeCaseKeys(
+            MCPUtils.buildError(
+              'Target preset must not be a template. Use target_preset_id for the same template only when self-extending.',
+            ),
+          ),
+        );
+      }
+
+      final result = await dao.applyTemplateSlots(
+        templateId: template.preset.id,
+        targetPresetId: targetPreset.id,
+        templateSlotIndices: slotIndices,
+        insertionOffset: (params['insertion_offset'] as int?) ?? 0,
+        overwrite: (params['overwrite'] as bool?) ?? false,
+      );
+
+      return jsonEncode(
+        convertToSnakeCaseKeys({
+          'success': true,
+          'target': 'preset',
+          'target_preset_id': result.targetPresetId,
+          'applied_slot_count': result.insertedSlotIndices.length,
+          'inserted_slot_indices': result.insertedSlotIndices,
+          'skipped_template_slot_indices': result.skippedTemplateSlotIndices,
+          'warning': result.warning,
+        }),
+      );
+    } on TemplateSpaceException catch (e) {
+      return jsonEncode(
+        convertToSnakeCaseKeys({
+          'success': false,
+          'error': 'space',
+          'current': e.current,
+          'applied': e.applied,
+          'limit': e.limit,
+        }),
+      );
+    } catch (e) {
+      return jsonEncode(
+        convertToSnakeCaseKeys(
+          MCPUtils.buildError('Error applying template: ${e.toString()}'),
+        ),
+      );
+    }
+  }
+
+  Future<String> _applyTemplateToDeviceTarget({
+    required AppDatabase db,
+    required FullPresetDetails template,
+    required List<int> slotIndices,
+  }) async {
+    if (_isOfflineMode()) {
+      return jsonEncode(
+        convertToSnakeCaseKeys(
+          MCPUtils.buildError(
+            'Device target requires connected mode; offline mode cannot apply templates to hardware.',
+          ),
+        ),
+      );
+    }
+
+    final cubit = MetadataSyncCubit(db, _distingCubit);
+    var appliedCount = 0;
+    try {
+      final subscription = cubit.stream.listen((state) {
+        if (state is InjectingTemplate) {
+          appliedCount = state.applied;
+        }
+      });
+      try {
+        await cubit.applyTemplateToDevice(
+          template: template,
+          templateSlotIndices: slotIndices,
+          manager: _distingCubit.requireDisting(),
+        );
+      } finally {
+        await subscription.cancel();
+        await cubit.close();
+      }
+    } catch (e) {
+      return jsonEncode(
+        convertToSnakeCaseKeys({
+          'success': false,
+          'error': 'partial_apply',
+          'applied_slot_count': appliedCount,
+          'message': e.toString(),
+        }),
+      );
+    }
+
+    return jsonEncode(
+      convertToSnakeCaseKeys({
+        'success': true,
+        'target': 'device',
+        'target_preset_id': null,
+        'applied_slot_count': slotIndices.length,
+        'inserted_slot_indices': const <int>[],
+        'skipped_template_slot_indices': const <int>[],
+        'warning': null,
+      }),
+    );
+  }
+
+  Future<_TemplateResolution> _resolveTemplatePreset(
+    PresetsDao dao,
+    Map<String, dynamic> params,
+  ) async {
+    final templateId = params['template_id'] as int?;
+    if (templateId != null) {
+      final details = await dao.getFullPresetDetails(templateId);
+      if (details == null) {
+        return _TemplateResolution.error(
+          MCPUtils.buildError('Template preset $templateId not found.'),
+        );
+      }
+      if (!details.preset.isTemplate) {
+        return _TemplateResolution.error(
+          MCPUtils.buildError('Preset $templateId is not a template.'),
+        );
+      }
+      return _TemplateResolution.details(details);
+    }
+
+    final templateName = params['template_name'] as String?;
+    if (templateName == null || templateName.trim().isEmpty) {
+      return _TemplateResolution.error(
+        MCPUtils.buildError('Provide template_id or template_name.'),
+      );
+    }
+
+    final preset = await _resolvePresetByName(
+      dao,
+      templateName,
+      (p) => p.isTemplate,
+      'template',
+    );
+    if (preset.error != null) {
+      return _TemplateResolution.error(preset.error!);
+    }
+    final details = await dao.getFullPresetDetails(preset.preset!.id);
+    if (details == null) {
+      return _TemplateResolution.error(
+        MCPUtils.buildError(
+          'Template "${preset.preset!.name}" could not be loaded.',
+        ),
+      );
+    }
+    return _TemplateResolution.details(details);
+  }
+
+  Future<_PresetResolution> _resolveTargetPreset(
+    PresetsDao dao,
+    Map<String, dynamic> params,
+  ) async {
+    final targetId = params['target_preset_id'] as int?;
+    if (targetId != null) {
+      final preset = await dao.getPresetById(targetId);
+      if (preset == null) {
+        return _PresetResolution.error(
+          MCPUtils.buildError('Target preset $targetId not found.'),
+        );
+      }
+      return _PresetResolution.preset(preset);
+    }
+
+    final targetName = params['target_preset_name'] as String?;
+    if (targetName == null || targetName.trim().isEmpty) {
+      return _PresetResolution.error(
+        MCPUtils.buildError(
+          'target_preset_id or target_preset_name is required when target is "preset".',
+        ),
+      );
+    }
+    return _resolvePresetByName(dao, targetName, (_) => true, 'target preset');
+  }
+
+  Future<_PresetResolution> _resolvePresetByName(
+    PresetsDao dao,
+    String name,
+    bool Function(PresetEntry preset) filter,
+    String label,
+  ) async {
+    final candidates = (await dao.getAllPresets()).where(filter).toList();
+    final exact = candidates.where((p) => p.name == name).toList();
+    if (exact.length == 1) {
+      return _PresetResolution.preset(exact.single);
+    }
+    if (exact.length > 1) {
+      return _PresetResolution.error(
+        MCPUtils.buildError(
+          'Multiple $label presets exactly match "$name": ${_candidateNames(exact)}. Use an id.',
+        ),
+      );
+    }
+
+    final lower = name.toLowerCase();
+    final ci = candidates.where((p) => p.name.toLowerCase() == lower).toList();
+    if (ci.length == 1) {
+      return _PresetResolution.preset(ci.single);
+    }
+    if (ci.isEmpty) {
+      return _PresetResolution.error(
+        MCPUtils.buildError(
+          'No $label preset named "$name". Candidates: ${_candidateNames(candidates)}.',
+        ),
+      );
+    }
+    return _PresetResolution.error(
+      MCPUtils.buildError(
+        'Multiple $label presets case-insensitively match "$name": ${_candidateNames(ci)}. Use an id.',
+      ),
+    );
+  }
+
+  _SlotIndicesResolution _resolveTemplateSlotIndices(
+    Object? raw,
+    int slotCount,
+  ) {
+    if (raw == null) {
+      return _SlotIndicesResolution.slotIndices(
+        List<int>.generate(slotCount, (i) => i),
+      );
+    }
+    if (raw is! List) {
+      return _SlotIndicesResolution.error(
+        MCPUtils.buildError('slot_indices must be an array of integers.'),
+      );
+    }
+
+    final indices = <int>[];
+    for (final item in raw) {
+      if (item is! int) {
+        return _SlotIndicesResolution.error(
+          MCPUtils.buildError('slot_indices must contain only integers.'),
+        );
+      }
+      if (item < 0 || item >= slotCount) {
+        return _SlotIndicesResolution.error(
+          MCPUtils.buildError(
+            'slot_indices value $item out of range [0, $slotCount).',
+          ),
+        );
+      }
+      indices.add(item);
+    }
+    if (indices.isEmpty) {
+      return _SlotIndicesResolution.error(
+        MCPUtils.buildError('slot_indices cannot be empty.'),
+      );
+    }
+    return _SlotIndicesResolution.slotIndices(indices);
+  }
+
+  String _candidateNames(List<PresetEntry> presets) {
+    if (presets.isEmpty) return '(none)';
+    final sorted = presets.map((p) => '"${p.name}" (${p.id})').toList()..sort();
+    return sorted.join(', ');
   }
 
   /// MCP Tool: Moves an algorithm in a specified slot one position up in the slot list.
@@ -2136,7 +2451,9 @@ class DistingTools {
         }
 
         if (matchingParams.length > 1) {
-          final paramNumbers = matchingParams.map((p) => p.parameterNumber).join(', ');
+          final paramNumbers = matchingParams
+              .map((p) => p.parameterNumber)
+              .join(', ');
           return jsonEncode(
             convertToSnakeCaseKeys(
               MCPUtils.buildError(
@@ -2612,12 +2929,18 @@ class DistingTools {
                 paramData['value'] = liveRawValue != null
                     ? _scaleForDisplay(liveRawValue, pInfo.powerOfTen)
                     : null;
-                paramData['min_value'] =
-                    _scaleForDisplay(pInfo.min, pInfo.powerOfTen);
-                paramData['max_value'] =
-                    _scaleForDisplay(pInfo.max, pInfo.powerOfTen);
-                paramData['default_value'] =
-                    _scaleForDisplay(pInfo.defaultValue, pInfo.powerOfTen);
+                paramData['min_value'] = _scaleForDisplay(
+                  pInfo.min,
+                  pInfo.powerOfTen,
+                );
+                paramData['max_value'] = _scaleForDisplay(
+                  pInfo.max,
+                  pInfo.powerOfTen,
+                );
+                paramData['default_value'] = _scaleForDisplay(
+                  pInfo.defaultValue,
+                  pInfo.powerOfTen,
+                );
               }
 
               // Add mapping information
@@ -3170,12 +3493,21 @@ class DistingTools {
                 );
               }
 
-              final rawValue = MCPUtils.scaleToRaw(paramValue, pInfo.powerOfTen);
+              final rawValue = MCPUtils.scaleToRaw(
+                paramValue,
+                pInfo.powerOfTen,
+              );
 
               // Validate against parameter bounds (raw)
               if (rawValue < pInfo.min || rawValue > pInfo.max) {
-                final displayMin = _scaleForDisplay(pInfo.min, pInfo.powerOfTen);
-                final displayMax = _scaleForDisplay(pInfo.max, pInfo.powerOfTen);
+                final displayMin = _scaleForDisplay(
+                  pInfo.min,
+                  pInfo.powerOfTen,
+                );
+                final displayMax = _scaleForDisplay(
+                  pInfo.max,
+                  pInfo.powerOfTen,
+                );
                 return jsonEncode(
                   convertToSnakeCaseKeys(
                     MCPUtils.buildError(
@@ -3596,10 +3928,14 @@ class DistingTools {
           }
           rawValue = MCPUtils.scaleToRaw(value, paramInfo.powerOfTen);
           if (rawValue < paramInfo.min || rawValue > paramInfo.max) {
-            final displayMin =
-                _scaleForDisplay(paramInfo.min, paramInfo.powerOfTen);
-            final displayMax =
-                _scaleForDisplay(paramInfo.max, paramInfo.powerOfTen);
+            final displayMin = _scaleForDisplay(
+              paramInfo.min,
+              paramInfo.powerOfTen,
+            );
+            final displayMax = _scaleForDisplay(
+              paramInfo.max,
+              paramInfo.powerOfTen,
+            );
             return jsonEncode(
               convertToSnakeCaseKeys(
                 MCPUtils.buildError(
@@ -3664,12 +4000,10 @@ class DistingTools {
         if (enumValues != null) {
           result['is_enum'] = true;
           result['valid_enum_values'] = enumValues;
-          result['value'] =
-              _enumIndexToString(enumValues, updatedValue) ?? '';
+          result['value'] = _enumIndexToString(enumValues, updatedValue) ?? '';
         }
       } else {
-        result['value'] =
-            _scaleForDisplay(updatedValue, paramInfo.powerOfTen);
+        result['value'] = _scaleForDisplay(updatedValue, paramInfo.powerOfTen);
       }
 
       // Include mappings if any are enabled
@@ -3710,8 +4044,10 @@ class DistingTools {
             resolved = (cvInput >= 0 && cvInput <= 12) ? cvInput : null;
           } else if (cvInput is String) {
             // Accept "None" → 0, "Input 1"-"Input 12" → 1-12
-            final parsed = BusMapping.parseBus(cvInput,
-                hasExtendedAuxBuses: _hasExtendedAuxBuses);
+            final parsed = BusMapping.parseBus(
+              cvInput,
+              hasExtendedAuxBuses: _hasExtendedAuxBuses,
+            );
             if (parsed != null && parsed >= 0 && parsed <= 12) {
               resolved = parsed;
             }
@@ -4611,10 +4947,14 @@ class DistingTools {
                 matchData['value'] = paramValue != null
                     ? _scaleForDisplay(paramValue.value, param.powerOfTen)
                     : null;
-                matchData['min'] =
-                    _scaleForDisplay(param.min, param.powerOfTen);
-                matchData['max'] =
-                    _scaleForDisplay(param.max, param.powerOfTen);
+                matchData['min'] = _scaleForDisplay(
+                  param.min,
+                  param.powerOfTen,
+                );
+                matchData['max'] = _scaleForDisplay(
+                  param.max,
+                  param.powerOfTen,
+                );
               }
               matches.add(matchData);
             }
@@ -4762,4 +5102,28 @@ class DesiredSlot {
   final Map<String, dynamic>? mapping;
 
   DesiredSlot({this.guid, this.name, this.parameters, this.mapping});
+}
+
+class _TemplateResolution {
+  final FullPresetDetails? details;
+  final Map<String, dynamic>? error;
+
+  const _TemplateResolution.details(this.details) : error = null;
+  const _TemplateResolution.error(this.error) : details = null;
+}
+
+class _PresetResolution {
+  final PresetEntry? preset;
+  final Map<String, dynamic>? error;
+
+  const _PresetResolution.preset(this.preset) : error = null;
+  const _PresetResolution.error(this.error) : preset = null;
+}
+
+class _SlotIndicesResolution {
+  final List<int>? slotIndices;
+  final Map<String, dynamic>? error;
+
+  const _SlotIndicesResolution.slotIndices(this.slotIndices) : error = null;
+  const _SlotIndicesResolution.error(this.error) : slotIndices = null;
 }

--- a/lib/models/template_metadata.dart
+++ b/lib/models/template_metadata.dart
@@ -1,0 +1,163 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+/// Structured metadata stored alongside a template preset.
+///
+/// Persisted as JSON text inside `Presets.templateMetadata`. The class is
+/// deliberately resilient: malformed input never throws — callers always get
+/// back an `empty()` instance. Unknown top-level keys round-trip through
+/// [extras] so older clients do not silently drop fields written by newer
+/// clients.
+@immutable
+class TemplateMetadata {
+  /// Current schema version stored in the JSON payload.
+  static const int currentSchemaVersion = 1;
+
+  static const _kDescription = 'description';
+  static const _kTags = 'tags';
+  static const _kAuthor = 'author';
+  static const _kCreatedAt = 'createdAt';
+  static const _kSchemaVersion = 'schemaVersion';
+
+  static const Set<String> _knownKeys = {
+    _kDescription,
+    _kTags,
+    _kAuthor,
+    _kCreatedAt,
+    _kSchemaVersion,
+  };
+
+  final String? description;
+  final List<String> tags;
+  final String? author;
+  final String? createdAt;
+  final Map<String, dynamic> extras;
+
+  const TemplateMetadata({
+    this.description,
+    this.tags = const [],
+    this.author,
+    this.createdAt,
+    this.extras = const {},
+  });
+
+  factory TemplateMetadata.empty() => const TemplateMetadata();
+
+  bool get isEmpty =>
+      description == null &&
+      tags.isEmpty &&
+      author == null &&
+      createdAt == null &&
+      extras.isEmpty;
+
+  bool get isNotEmpty => !isEmpty;
+
+  /// Decode a JSON string into [TemplateMetadata].
+  ///
+  /// - `null` or empty input → [TemplateMetadata.empty()].
+  /// - Malformed JSON → [TemplateMetadata.empty()] (with a single
+  ///   debug print, deduplicated per process via [_loggedFailures]).
+  /// - Valid JSON with missing known keys → those keys default to
+  ///   null / empty list. Unknown top-level keys are preserved in [extras].
+  factory TemplateMetadata.fromJsonString(String? source) {
+    if (source == null || source.isEmpty) {
+      return TemplateMetadata.empty();
+    }
+
+    dynamic decoded;
+    try {
+      decoded = jsonDecode(source);
+    } catch (_) {
+      _logFailure(source);
+      return TemplateMetadata.empty();
+    }
+
+    if (decoded is! Map<String, dynamic>) {
+      _logFailure(source);
+      return TemplateMetadata.empty();
+    }
+
+    final description = decoded[_kDescription];
+    final author = decoded[_kAuthor];
+    final createdAt = decoded[_kCreatedAt];
+    final rawTags = decoded[_kTags];
+
+    final tags = <String>[];
+    if (rawTags is List) {
+      for (final tag in rawTags) {
+        if (tag == null) {
+          tags.add('');
+        } else if (tag is String) {
+          tags.add(tag);
+        } else {
+          tags.add(tag.toString());
+        }
+      }
+    }
+
+    final extras = <String, dynamic>{};
+    for (final entry in decoded.entries) {
+      if (!_knownKeys.contains(entry.key)) {
+        extras[entry.key] = entry.value;
+      }
+    }
+
+    return TemplateMetadata(
+      description: description is String ? description : null,
+      tags: List.unmodifiable(tags),
+      author: author is String ? author : null,
+      createdAt: createdAt is String ? createdAt : null,
+      extras: Map.unmodifiable(extras),
+    );
+  }
+
+  /// Encode this instance to its JSON text representation.
+  ///
+  /// Known fields always win over [extras] when their keys collide.
+  /// `schemaVersion` is always stamped onto the output so the payload is
+  /// self-describing.
+  String toJsonString() {
+    final Map<String, dynamic> out = <String, dynamic>{};
+
+    extras.forEach((key, value) {
+      if (_knownKeys.contains(key)) return;
+      out[key] = value;
+    });
+
+    if (description != null) out[_kDescription] = description;
+    if (tags.isNotEmpty) out[_kTags] = tags;
+    if (author != null) out[_kAuthor] = author;
+    if (createdAt != null) out[_kCreatedAt] = createdAt;
+    out[_kSchemaVersion] = currentSchemaVersion;
+
+    return jsonEncode(out);
+  }
+
+  TemplateMetadata copyWith({
+    String? description,
+    List<String>? tags,
+    String? author,
+    String? createdAt,
+    Map<String, dynamic>? extras,
+  }) {
+    return TemplateMetadata(
+      description: description ?? this.description,
+      tags: tags ?? this.tags,
+      author: author ?? this.author,
+      createdAt: createdAt ?? this.createdAt,
+      extras: extras ?? this.extras,
+    );
+  }
+
+  static final Set<String> _loggedFailures = <String>{};
+
+  static void _logFailure(String source) {
+    final key = source.length > 32 ? source.substring(0, 32) : source;
+    if (_loggedFailures.add(key)) {
+      debugPrint(
+        'TemplateMetadata: malformed JSON payload ignored (len=${source.length})',
+      );
+    }
+  }
+}

--- a/lib/ui/metadata_sync/metadata_sync_cubit.dart
+++ b/lib/ui/metadata_sync/metadata_sync_cubit.dart
@@ -27,6 +27,10 @@ class MetadataSyncCubit extends Cubit<MetadataSyncState> {
 
   // Cancellation flag for template injection
   bool _isInjectionCancelled = false;
+  // Re-entrance guard for device-side template apply. The UI also disables
+  // the apply button, but this catches MCP/UI races where both paths could
+  // call applyTemplateToDevice concurrently.
+  bool _isInjectionRunning = false;
 
   // Checkpoint keys for SharedPreferences
   static const String _checkpointAlgorithmName =
@@ -677,104 +681,123 @@ class MetadataSyncCubit extends Cubit<MetadataSyncState> {
   /// Injects a template preset into the current device preset by appending
   /// its algorithms to the end without clearing the existing preset.
   ///
-  /// This method:
-  /// - Validates that current preset + template slots ≤ 32
-  /// - Adds each template algorithm sequentially via requestAddAlgorithm()
-  /// - Sets parameter values and mappings for each injected slot
-  /// - Does NOT call requestNewPreset() (preserves current preset)
-  /// - Does NOT call requestSavePreset() (lets user save manually)
-  ///
-  /// Throws [Exception] if slot limit would be exceeded.
-  /// Emits loading/success/failure states to UI.
+  /// Delegates to [applyTemplateToDevice] with all slot indices selected.
   Future<void> injectTemplateToDevice(
     FullPresetDetails template,
     IDistingMidiManager manager,
-  ) async {
-    _isInjectionCancelled = false; // Reset cancellation flag
-    emit(const MetadataSyncState.loadingPreset());
+  ) {
+    return applyTemplateToDevice(
+      template: template,
+      templateSlotIndices:
+          List<int>.generate(template.slots.length, (i) => i),
+      manager: manager,
+    );
+  }
+
+  /// Applies a selected subset of [template] slots to the connected device.
+  ///
+  /// The slots in [templateSlotIndices] (positions within
+  /// `template.slots`, 0-based) are appended after the device's current
+  /// slots in the order given. Duplicates are honoured. The method emits
+  /// [InjectingTemplate] progress states between each algorithm-add.
+  ///
+  /// The supplied [template] is captured by value — concurrent edits to the
+  /// source preset are invisible to the in-flight apply.
+  Future<void> applyTemplateToDevice({
+    required FullPresetDetails template,
+    required List<int> templateSlotIndices,
+    required IDistingMidiManager manager,
+  }) async {
+    if (_isInjectionRunning) {
+      throw StateError(
+        'A template apply is already in progress; cannot start another.',
+      );
+    }
+    _isInjectionRunning = true;
+    _isInjectionCancelled = false;
+
+    final total = templateSlotIndices.length;
+    emit(MetadataSyncState.injectingTemplate(applied: 0, total: total));
 
     try {
-      // Check for empty template
       if (template.slots.isEmpty) {
         throw Exception('Cannot inject empty template');
       }
+      if (templateSlotIndices.isEmpty) {
+        throw Exception('Cannot inject empty template');
+      }
+      for (final i in templateSlotIndices) {
+        if (i < 0 || i >= template.slots.length) {
+          throw Exception(
+            'Template slot index $i out of range [0, ${template.slots.length}).',
+          );
+        }
+      }
 
-      // Check for cancellation early
       if (_isInjectionCancelled) {
         throw Exception(
           'Injection cancelled. Preset may be partially modified.',
         );
       }
 
-      // Validate that all template algorithms have metadata
-      for (int i = 0; i < template.slots.length; i++) {
+      // Pre-flight metadata check on every slot we will apply.
+      for (final i in templateSlotIndices) {
         final slot = template.slots[i];
-        final algorithmGuid = slot.algorithm.guid;
-        final algoDetails = await _metadataDao.getFullAlgorithmDetails(
-          algorithmGuid,
-        );
-        if (algoDetails == null) {
+        final details =
+            await _metadataDao.getFullAlgorithmDetails(slot.algorithm.guid);
+        if (details == null) {
           throw Exception(
-            'Template missing algorithm metadata. '
-            'Sync algorithms first.',
+            'Template missing algorithm metadata. Sync algorithms first.',
           );
         }
       }
 
-      // Validate slot limit before starting injection
+      // Slot limit check.
       int currentSlotCount = 0;
       try {
         currentSlotCount = await manager.requestNumAlgorithmsInPreset() ?? 0;
-      } catch (e) {
-        // In offline/demo mode, assume empty preset
+      } catch (_) {
         currentSlotCount = 0;
       }
-      final templateSlotCount = template.slots.length;
-      final totalSlots = currentSlotCount + templateSlotCount;
-
+      final totalSlots = currentSlotCount + total;
       if (totalSlots > 32) {
         throw Exception(
           'Cannot inject: Would exceed 32 slot limit '
-          '(current: $currentSlotCount, template: $templateSlotCount)',
+          '(current: $currentSlotCount, template: $total)',
         );
       }
 
-      // Track the starting slot index for parameter/mapping application
       final startingSlotIndex = currentSlotCount;
+      int appliedCount = 0;
 
-      // Add all algorithms first (sequentially, not in parallel)
-      for (int i = 0; i < template.slots.length; i++) {
-        // Check for cancellation between algorithms
+      for (var i = 0; i < templateSlotIndices.length; i++) {
         if (_isInjectionCancelled) {
           throw Exception(
-            'Injection cancelled after adding $i of ${template.slots.length} algorithms. '
+            'Injection cancelled after adding $appliedCount of $total algorithms. '
             'Preset may be partially modified.',
           );
         }
 
-        final slot = template.slots[i];
+        final sourceIndex = templateSlotIndices[i];
+        final slot = template.slots[sourceIndex];
         final algorithmGuid = slot.algorithm.guid;
 
         try {
-          // Fetch full details to get specifications and AlgorithmInfo fields
-          final algoDetails = await _metadataDao.getFullAlgorithmDetails(
-            algorithmGuid,
-          );
-          if (algoDetails == null) {
+          final details =
+              await _metadataDao.getFullAlgorithmDetails(algorithmGuid);
+          if (details == null) {
             throw Exception(
               "Algorithm metadata for GUID '$algorithmGuid' not found locally. "
               "Cannot add template slot ${i + 1}.",
             );
           }
 
-          // Prepare AlgorithmInfo and default specifications
-          // Use startingSlotIndex + i as the target slot index
           final targetSlotIndex = startingSlotIndex + i;
           final algorithmInfo = AlgorithmInfo(
             algorithmIndex: targetSlotIndex,
-            guid: algoDetails.algorithm.guid,
-            name: algoDetails.algorithm.name,
-            specifications: algoDetails.specifications
+            guid: details.algorithm.guid,
+            name: details.algorithm.name,
+            specifications: details.specifications
                 .map(
                   (spec) => Specification(
                     name: spec.name,
@@ -786,84 +809,78 @@ class MetadataSyncCubit extends Cubit<MetadataSyncState> {
                 )
                 .toList(),
           );
-          final defaultSpecifications = algoDetails.specifications
-              .map((s) => s.defaultValue)
-              .toList();
+          final defaultSpecifications =
+              details.specifications.map((s) => s.defaultValue).toList();
 
-          await manager.requestAddAlgorithm(algorithmInfo, defaultSpecifications);
-          // Add delay after adding each algorithm
+          await manager.requestAddAlgorithm(
+            algorithmInfo,
+            defaultSpecifications,
+          );
           await Future.delayed(const Duration(milliseconds: 150));
+
+          appliedCount++;
+          emit(MetadataSyncState.injectingTemplate(
+            applied: appliedCount,
+            total: total,
+          ));
         } catch (algorithmError) {
-          // Report partial injection failure with specific algorithm that failed
           throw Exception(
             'Failed to inject algorithm "${slot.algorithm.name}" '
-            '(${i + 1} of ${template.slots.length}). '
-            'Preset may be partially modified. '
+            '(${i + 1} of $total). '
+            'Preset may be partially modified after $appliedCount slot(s). '
             'Error: ${algorithmError.toString()}',
           );
         }
       }
 
-      // Set parameters and mappings for each injected slot
-      for (int i = 0; i < template.slots.length; i++) {
-        final slot = template.slots[i];
+      // Set parameters and mappings for each injected slot, mirroring source
+      // slot data 1:1.
+      for (var i = 0; i < templateSlotIndices.length; i++) {
+        final sourceIndex = templateSlotIndices[i];
+        final slot = template.slots[sourceIndex];
         final targetSlotIndex = startingSlotIndex + i;
         final algorithmGuid = slot.algorithm.guid;
-        if (kDebugMode) {}
 
-        // Send the slot name to the device
-        await manager.requestSendSlotName(targetSlotIndex, slot.algorithm.name);
-
-        // Fetch metadata again to get parameter names for logging
-        final algoDetails = await _metadataDao.getFullAlgorithmDetails(
-          algorithmGuid,
+        await manager.requestSendSlotName(
+          targetSlotIndex,
+          slot.algorithm.name,
         );
-        if (algoDetails == null) {
-          continue; // Skip configuration for this slot if metadata missing
+
+        final details =
+            await _metadataDao.getFullAlgorithmDetails(algorithmGuid);
+        if (details == null) {
+          continue;
         }
 
-        // Send Parameter Values
-        if (kDebugMode) {}
         for (final paramEntry in slot.parameterValues.entries) {
           final parameterNumber = paramEntry.key;
           final value = paramEntry.value;
 
-          // Find parameter name for logging (optional, but helpful)
-          final paramMetadata = algoDetails.parameters.firstWhereOrNull(
+          final paramMetadata = details.parameters.firstWhereOrNull(
             (p) => p.parameter.parameterNumber == parameterNumber,
           );
           paramMetadata?.parameter.name ?? 'Unnamed';
 
-          if (kDebugMode) {}
-          // Use setParameterValue
           await manager.setParameterValue(
             targetSlotIndex,
             parameterNumber,
             value,
           );
-          // Optional small delay between parameter sends
           await Future.delayed(const Duration(milliseconds: 20));
         }
 
-        // Send Mappings
-        if (kDebugMode) {}
         for (final mappingEntry in slot.mappings.entries) {
           final parameterNumber = mappingEntry.key;
           final mappingData = mappingEntry.value;
-
-          if (kDebugMode) {}
-          // Use requestSetMapping
           await manager.requestSetMapping(
             targetSlotIndex,
             parameterNumber,
             mappingData,
           );
-          // Optional small delay
           await Future.delayed(const Duration(milliseconds: 20));
         }
       }
 
-      // Add a final delay after all commands are sent
       await Future.delayed(const Duration(milliseconds: 100));
 
       emit(
@@ -872,32 +889,68 @@ class MetadataSyncCubit extends Cubit<MetadataSyncState> {
           "Save manually when ready.",
         ),
       );
-      // Reload local data after success to ensure UI is in ViewingLocalData state
       await loadLocalData();
     } catch (e) {
-
-      // Provide specific error messages based on exception type
       String errorMessage;
-
-      // Check for connection-related errors
       if (e.toString().contains('connection') ||
           e.toString().contains('Connection') ||
           e.toString().contains('disconnect') ||
           e.toString().contains('MIDI') ||
           e.toString().contains('timeout')) {
         errorMessage =
-          'Connection lost during injection. Preset may be partially modified. '
-          'Reconnect your device and check the preset.';
+            'Connection lost during injection. Preset may be partially modified. '
+            'Reconnect your device and check the preset.';
       } else if (e.toString().contains('metadata') ||
-                 e.toString().contains('not found locally')) {
+          e.toString().contains('not found locally')) {
         errorMessage =
-          'Template missing algorithm metadata. '
-          'Go to Settings > Sync Algorithms to download latest metadata.';
+            'Template missing algorithm metadata. '
+            'Go to Settings > Sync Algorithms to download latest metadata.';
       } else {
         errorMessage = "Error injecting template: ${e.toString()}";
       }
-
       emit(MetadataSyncState.presetLoadFailure(errorMessage));
+    } finally {
+      _isInjectionRunning = false;
+    }
+  }
+
+  /// Copies a subset of slots from a saved template into another saved
+  /// preset (the *target*), without touching the connected device. Thin
+  /// orchestration over [PresetsDao.applyTemplateSlots].
+  ///
+  /// On success the cubit emits [ViewingLocalData] so list-driven UIs
+  /// refresh. [TemplateSpaceException] from the DAO is caught and
+  /// re-emitted as [MetadataSyncFailure] with a human-readable message.
+  Future<ApplyTemplateSlotsResult> applyTemplateToPreset({
+    required int templateId,
+    required int targetPresetId,
+    required List<int> templateSlotIndices,
+    required int insertionOffset,
+    bool overwrite = false,
+  }) async {
+    try {
+      final result = await _presetsDao.applyTemplateSlots(
+        templateId: templateId,
+        targetPresetId: targetPresetId,
+        templateSlotIndices: templateSlotIndices,
+        insertionOffset: insertionOffset,
+        overwrite: overwrite,
+      );
+      await loadLocalData();
+      return result;
+    } on TemplateSpaceException catch (e) {
+      emit(
+        MetadataSyncState.metadataSyncFailure(
+          'Cannot apply template: ${e.current} existing + ${e.applied} new '
+          'would exceed the ${e.limit}-slot limit.',
+        ),
+      );
+      rethrow;
+    } catch (e) {
+      emit(MetadataSyncState.metadataSyncFailure(
+        'Failed to apply template: $e',
+      ));
+      rethrow;
     }
   }
 }

--- a/lib/ui/metadata_sync/metadata_sync_cubit.freezed.dart
+++ b/lib/ui/metadata_sync/metadata_sync_cubit.freezed.dart
@@ -61,7 +61,7 @@ extension MetadataSyncStatePatterns on MetadataSyncState {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( Idle value)?  idle,TResult Function( SyncingMetadata value)?  syncingMetadata,TResult Function( CheckpointFound value)?  checkpointFound,TResult Function( MetadataSyncSuccess value)?  metadataSyncSuccess,TResult Function( MetadataSyncFailure value)?  metadataSyncFailure,TResult Function( SavingPreset value)?  savingPreset,TResult Function( LoadingPreset value)?  loadingPreset,TResult Function( PresetSaveSuccess value)?  presetSaveSuccess,TResult Function( PresetSaveFailure value)?  presetSaveFailure,TResult Function( PresetLoadSuccess value)?  presetLoadSuccess,TResult Function( PresetLoadFailure value)?  presetLoadFailure,TResult Function( DeletingPreset value)?  deletingPreset,TResult Function( PresetDeleteSuccess value)?  presetDeleteSuccess,TResult Function( PresetDeleteFailure value)?  presetDeleteFailure,TResult Function( ViewingLocalData value)?  viewingLocalData,TResult Function( Failure value)?  failure,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( Idle value)?  idle,TResult Function( SyncingMetadata value)?  syncingMetadata,TResult Function( CheckpointFound value)?  checkpointFound,TResult Function( MetadataSyncSuccess value)?  metadataSyncSuccess,TResult Function( MetadataSyncFailure value)?  metadataSyncFailure,TResult Function( SavingPreset value)?  savingPreset,TResult Function( LoadingPreset value)?  loadingPreset,TResult Function( InjectingTemplate value)?  injectingTemplate,TResult Function( PresetSaveSuccess value)?  presetSaveSuccess,TResult Function( PresetSaveFailure value)?  presetSaveFailure,TResult Function( PresetLoadSuccess value)?  presetLoadSuccess,TResult Function( PresetLoadFailure value)?  presetLoadFailure,TResult Function( DeletingPreset value)?  deletingPreset,TResult Function( PresetDeleteSuccess value)?  presetDeleteSuccess,TResult Function( PresetDeleteFailure value)?  presetDeleteFailure,TResult Function( ViewingLocalData value)?  viewingLocalData,TResult Function( Failure value)?  failure,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case Idle() when idle != null:
@@ -71,7 +71,8 @@ return checkpointFound(_that);case MetadataSyncSuccess() when metadataSyncSucces
 return metadataSyncSuccess(_that);case MetadataSyncFailure() when metadataSyncFailure != null:
 return metadataSyncFailure(_that);case SavingPreset() when savingPreset != null:
 return savingPreset(_that);case LoadingPreset() when loadingPreset != null:
-return loadingPreset(_that);case PresetSaveSuccess() when presetSaveSuccess != null:
+return loadingPreset(_that);case InjectingTemplate() when injectingTemplate != null:
+return injectingTemplate(_that);case PresetSaveSuccess() when presetSaveSuccess != null:
 return presetSaveSuccess(_that);case PresetSaveFailure() when presetSaveFailure != null:
 return presetSaveFailure(_that);case PresetLoadSuccess() when presetLoadSuccess != null:
 return presetLoadSuccess(_that);case PresetLoadFailure() when presetLoadFailure != null:
@@ -98,7 +99,7 @@ return failure(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( Idle value)  idle,required TResult Function( SyncingMetadata value)  syncingMetadata,required TResult Function( CheckpointFound value)  checkpointFound,required TResult Function( MetadataSyncSuccess value)  metadataSyncSuccess,required TResult Function( MetadataSyncFailure value)  metadataSyncFailure,required TResult Function( SavingPreset value)  savingPreset,required TResult Function( LoadingPreset value)  loadingPreset,required TResult Function( PresetSaveSuccess value)  presetSaveSuccess,required TResult Function( PresetSaveFailure value)  presetSaveFailure,required TResult Function( PresetLoadSuccess value)  presetLoadSuccess,required TResult Function( PresetLoadFailure value)  presetLoadFailure,required TResult Function( DeletingPreset value)  deletingPreset,required TResult Function( PresetDeleteSuccess value)  presetDeleteSuccess,required TResult Function( PresetDeleteFailure value)  presetDeleteFailure,required TResult Function( ViewingLocalData value)  viewingLocalData,required TResult Function( Failure value)  failure,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( Idle value)  idle,required TResult Function( SyncingMetadata value)  syncingMetadata,required TResult Function( CheckpointFound value)  checkpointFound,required TResult Function( MetadataSyncSuccess value)  metadataSyncSuccess,required TResult Function( MetadataSyncFailure value)  metadataSyncFailure,required TResult Function( SavingPreset value)  savingPreset,required TResult Function( LoadingPreset value)  loadingPreset,required TResult Function( InjectingTemplate value)  injectingTemplate,required TResult Function( PresetSaveSuccess value)  presetSaveSuccess,required TResult Function( PresetSaveFailure value)  presetSaveFailure,required TResult Function( PresetLoadSuccess value)  presetLoadSuccess,required TResult Function( PresetLoadFailure value)  presetLoadFailure,required TResult Function( DeletingPreset value)  deletingPreset,required TResult Function( PresetDeleteSuccess value)  presetDeleteSuccess,required TResult Function( PresetDeleteFailure value)  presetDeleteFailure,required TResult Function( ViewingLocalData value)  viewingLocalData,required TResult Function( Failure value)  failure,}){
 final _that = this;
 switch (_that) {
 case Idle():
@@ -108,7 +109,8 @@ return checkpointFound(_that);case MetadataSyncSuccess():
 return metadataSyncSuccess(_that);case MetadataSyncFailure():
 return metadataSyncFailure(_that);case SavingPreset():
 return savingPreset(_that);case LoadingPreset():
-return loadingPreset(_that);case PresetSaveSuccess():
+return loadingPreset(_that);case InjectingTemplate():
+return injectingTemplate(_that);case PresetSaveSuccess():
 return presetSaveSuccess(_that);case PresetSaveFailure():
 return presetSaveFailure(_that);case PresetLoadSuccess():
 return presetLoadSuccess(_that);case PresetLoadFailure():
@@ -131,7 +133,7 @@ return failure(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( Idle value)?  idle,TResult? Function( SyncingMetadata value)?  syncingMetadata,TResult? Function( CheckpointFound value)?  checkpointFound,TResult? Function( MetadataSyncSuccess value)?  metadataSyncSuccess,TResult? Function( MetadataSyncFailure value)?  metadataSyncFailure,TResult? Function( SavingPreset value)?  savingPreset,TResult? Function( LoadingPreset value)?  loadingPreset,TResult? Function( PresetSaveSuccess value)?  presetSaveSuccess,TResult? Function( PresetSaveFailure value)?  presetSaveFailure,TResult? Function( PresetLoadSuccess value)?  presetLoadSuccess,TResult? Function( PresetLoadFailure value)?  presetLoadFailure,TResult? Function( DeletingPreset value)?  deletingPreset,TResult? Function( PresetDeleteSuccess value)?  presetDeleteSuccess,TResult? Function( PresetDeleteFailure value)?  presetDeleteFailure,TResult? Function( ViewingLocalData value)?  viewingLocalData,TResult? Function( Failure value)?  failure,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( Idle value)?  idle,TResult? Function( SyncingMetadata value)?  syncingMetadata,TResult? Function( CheckpointFound value)?  checkpointFound,TResult? Function( MetadataSyncSuccess value)?  metadataSyncSuccess,TResult? Function( MetadataSyncFailure value)?  metadataSyncFailure,TResult? Function( SavingPreset value)?  savingPreset,TResult? Function( LoadingPreset value)?  loadingPreset,TResult? Function( InjectingTemplate value)?  injectingTemplate,TResult? Function( PresetSaveSuccess value)?  presetSaveSuccess,TResult? Function( PresetSaveFailure value)?  presetSaveFailure,TResult? Function( PresetLoadSuccess value)?  presetLoadSuccess,TResult? Function( PresetLoadFailure value)?  presetLoadFailure,TResult? Function( DeletingPreset value)?  deletingPreset,TResult? Function( PresetDeleteSuccess value)?  presetDeleteSuccess,TResult? Function( PresetDeleteFailure value)?  presetDeleteFailure,TResult? Function( ViewingLocalData value)?  viewingLocalData,TResult? Function( Failure value)?  failure,}){
 final _that = this;
 switch (_that) {
 case Idle() when idle != null:
@@ -141,7 +143,8 @@ return checkpointFound(_that);case MetadataSyncSuccess() when metadataSyncSucces
 return metadataSyncSuccess(_that);case MetadataSyncFailure() when metadataSyncFailure != null:
 return metadataSyncFailure(_that);case SavingPreset() when savingPreset != null:
 return savingPreset(_that);case LoadingPreset() when loadingPreset != null:
-return loadingPreset(_that);case PresetSaveSuccess() when presetSaveSuccess != null:
+return loadingPreset(_that);case InjectingTemplate() when injectingTemplate != null:
+return injectingTemplate(_that);case PresetSaveSuccess() when presetSaveSuccess != null:
 return presetSaveSuccess(_that);case PresetSaveFailure() when presetSaveFailure != null:
 return presetSaveFailure(_that);case PresetLoadSuccess() when presetLoadSuccess != null:
 return presetLoadSuccess(_that);case PresetLoadFailure() when presetLoadFailure != null:
@@ -167,7 +170,7 @@ return failure(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  idle,TResult Function( double progress,  String mainMessage,  String subMessage,  int? algorithmsProcessed,  int? totalAlgorithms)?  syncingMetadata,TResult Function( String algorithmName,  int algorithmIndex)?  checkpointFound,TResult Function( String message)?  metadataSyncSuccess,TResult Function( String error)?  metadataSyncFailure,TResult Function()?  savingPreset,TResult Function()?  loadingPreset,TResult Function( String message)?  presetSaveSuccess,TResult Function( String error)?  presetSaveFailure,TResult Function( String message)?  presetLoadSuccess,TResult Function( String error)?  presetLoadFailure,TResult Function()?  deletingPreset,TResult Function( String message)?  presetDeleteSuccess,TResult Function( String error)?  presetDeleteFailure,TResult Function( List<AlgorithmEntry> algorithms,  Map<String, int> parameterCounts,  List<PresetEntry> presets)?  viewingLocalData,TResult Function( String error)?  failure,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  idle,TResult Function( double progress,  String mainMessage,  String subMessage,  int? algorithmsProcessed,  int? totalAlgorithms)?  syncingMetadata,TResult Function( String algorithmName,  int algorithmIndex)?  checkpointFound,TResult Function( String message)?  metadataSyncSuccess,TResult Function( String error)?  metadataSyncFailure,TResult Function()?  savingPreset,TResult Function()?  loadingPreset,TResult Function( int applied,  int total)?  injectingTemplate,TResult Function( String message)?  presetSaveSuccess,TResult Function( String error)?  presetSaveFailure,TResult Function( String message)?  presetLoadSuccess,TResult Function( String error)?  presetLoadFailure,TResult Function()?  deletingPreset,TResult Function( String message)?  presetDeleteSuccess,TResult Function( String error)?  presetDeleteFailure,TResult Function( List<AlgorithmEntry> algorithms,  Map<String, int> parameterCounts,  List<PresetEntry> presets)?  viewingLocalData,TResult Function( String error)?  failure,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case Idle() when idle != null:
 return idle();case SyncingMetadata() when syncingMetadata != null:
@@ -176,7 +179,8 @@ return checkpointFound(_that.algorithmName,_that.algorithmIndex);case MetadataSy
 return metadataSyncSuccess(_that.message);case MetadataSyncFailure() when metadataSyncFailure != null:
 return metadataSyncFailure(_that.error);case SavingPreset() when savingPreset != null:
 return savingPreset();case LoadingPreset() when loadingPreset != null:
-return loadingPreset();case PresetSaveSuccess() when presetSaveSuccess != null:
+return loadingPreset();case InjectingTemplate() when injectingTemplate != null:
+return injectingTemplate(_that.applied,_that.total);case PresetSaveSuccess() when presetSaveSuccess != null:
 return presetSaveSuccess(_that.message);case PresetSaveFailure() when presetSaveFailure != null:
 return presetSaveFailure(_that.error);case PresetLoadSuccess() when presetLoadSuccess != null:
 return presetLoadSuccess(_that.message);case PresetLoadFailure() when presetLoadFailure != null:
@@ -203,7 +207,7 @@ return failure(_that.error);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  idle,required TResult Function( double progress,  String mainMessage,  String subMessage,  int? algorithmsProcessed,  int? totalAlgorithms)  syncingMetadata,required TResult Function( String algorithmName,  int algorithmIndex)  checkpointFound,required TResult Function( String message)  metadataSyncSuccess,required TResult Function( String error)  metadataSyncFailure,required TResult Function()  savingPreset,required TResult Function()  loadingPreset,required TResult Function( String message)  presetSaveSuccess,required TResult Function( String error)  presetSaveFailure,required TResult Function( String message)  presetLoadSuccess,required TResult Function( String error)  presetLoadFailure,required TResult Function()  deletingPreset,required TResult Function( String message)  presetDeleteSuccess,required TResult Function( String error)  presetDeleteFailure,required TResult Function( List<AlgorithmEntry> algorithms,  Map<String, int> parameterCounts,  List<PresetEntry> presets)  viewingLocalData,required TResult Function( String error)  failure,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  idle,required TResult Function( double progress,  String mainMessage,  String subMessage,  int? algorithmsProcessed,  int? totalAlgorithms)  syncingMetadata,required TResult Function( String algorithmName,  int algorithmIndex)  checkpointFound,required TResult Function( String message)  metadataSyncSuccess,required TResult Function( String error)  metadataSyncFailure,required TResult Function()  savingPreset,required TResult Function()  loadingPreset,required TResult Function( int applied,  int total)  injectingTemplate,required TResult Function( String message)  presetSaveSuccess,required TResult Function( String error)  presetSaveFailure,required TResult Function( String message)  presetLoadSuccess,required TResult Function( String error)  presetLoadFailure,required TResult Function()  deletingPreset,required TResult Function( String message)  presetDeleteSuccess,required TResult Function( String error)  presetDeleteFailure,required TResult Function( List<AlgorithmEntry> algorithms,  Map<String, int> parameterCounts,  List<PresetEntry> presets)  viewingLocalData,required TResult Function( String error)  failure,}) {final _that = this;
 switch (_that) {
 case Idle():
 return idle();case SyncingMetadata():
@@ -212,7 +216,8 @@ return checkpointFound(_that.algorithmName,_that.algorithmIndex);case MetadataSy
 return metadataSyncSuccess(_that.message);case MetadataSyncFailure():
 return metadataSyncFailure(_that.error);case SavingPreset():
 return savingPreset();case LoadingPreset():
-return loadingPreset();case PresetSaveSuccess():
+return loadingPreset();case InjectingTemplate():
+return injectingTemplate(_that.applied,_that.total);case PresetSaveSuccess():
 return presetSaveSuccess(_that.message);case PresetSaveFailure():
 return presetSaveFailure(_that.error);case PresetLoadSuccess():
 return presetLoadSuccess(_that.message);case PresetLoadFailure():
@@ -235,7 +240,7 @@ return failure(_that.error);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  idle,TResult? Function( double progress,  String mainMessage,  String subMessage,  int? algorithmsProcessed,  int? totalAlgorithms)?  syncingMetadata,TResult? Function( String algorithmName,  int algorithmIndex)?  checkpointFound,TResult? Function( String message)?  metadataSyncSuccess,TResult? Function( String error)?  metadataSyncFailure,TResult? Function()?  savingPreset,TResult? Function()?  loadingPreset,TResult? Function( String message)?  presetSaveSuccess,TResult? Function( String error)?  presetSaveFailure,TResult? Function( String message)?  presetLoadSuccess,TResult? Function( String error)?  presetLoadFailure,TResult? Function()?  deletingPreset,TResult? Function( String message)?  presetDeleteSuccess,TResult? Function( String error)?  presetDeleteFailure,TResult? Function( List<AlgorithmEntry> algorithms,  Map<String, int> parameterCounts,  List<PresetEntry> presets)?  viewingLocalData,TResult? Function( String error)?  failure,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  idle,TResult? Function( double progress,  String mainMessage,  String subMessage,  int? algorithmsProcessed,  int? totalAlgorithms)?  syncingMetadata,TResult? Function( String algorithmName,  int algorithmIndex)?  checkpointFound,TResult? Function( String message)?  metadataSyncSuccess,TResult? Function( String error)?  metadataSyncFailure,TResult? Function()?  savingPreset,TResult? Function()?  loadingPreset,TResult? Function( int applied,  int total)?  injectingTemplate,TResult? Function( String message)?  presetSaveSuccess,TResult? Function( String error)?  presetSaveFailure,TResult? Function( String message)?  presetLoadSuccess,TResult? Function( String error)?  presetLoadFailure,TResult? Function()?  deletingPreset,TResult? Function( String message)?  presetDeleteSuccess,TResult? Function( String error)?  presetDeleteFailure,TResult? Function( List<AlgorithmEntry> algorithms,  Map<String, int> parameterCounts,  List<PresetEntry> presets)?  viewingLocalData,TResult? Function( String error)?  failure,}) {final _that = this;
 switch (_that) {
 case Idle() when idle != null:
 return idle();case SyncingMetadata() when syncingMetadata != null:
@@ -244,7 +249,8 @@ return checkpointFound(_that.algorithmName,_that.algorithmIndex);case MetadataSy
 return metadataSyncSuccess(_that.message);case MetadataSyncFailure() when metadataSyncFailure != null:
 return metadataSyncFailure(_that.error);case SavingPreset() when savingPreset != null:
 return savingPreset();case LoadingPreset() when loadingPreset != null:
-return loadingPreset();case PresetSaveSuccess() when presetSaveSuccess != null:
+return loadingPreset();case InjectingTemplate() when injectingTemplate != null:
+return injectingTemplate(_that.applied,_that.total);case PresetSaveSuccess() when presetSaveSuccess != null:
 return presetSaveSuccess(_that.message);case PresetSaveFailure() when presetSaveFailure != null:
 return presetSaveFailure(_that.error);case PresetLoadSuccess() when presetLoadSuccess != null:
 return presetLoadSuccess(_that.message);case PresetLoadFailure() when presetLoadFailure != null:
@@ -676,6 +682,80 @@ String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
 
 
 
+
+/// @nodoc
+
+
+class InjectingTemplate with DiagnosticableTreeMixin implements MetadataSyncState {
+  const InjectingTemplate({required this.applied, required this.total});
+  
+
+ final  int applied;
+ final  int total;
+
+/// Create a copy of MetadataSyncState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$InjectingTemplateCopyWith<InjectingTemplate> get copyWith => _$InjectingTemplateCopyWithImpl<InjectingTemplate>(this, _$identity);
+
+
+@override
+void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+  properties
+    ..add(DiagnosticsProperty('type', 'MetadataSyncState.injectingTemplate'))
+    ..add(DiagnosticsProperty('applied', applied))..add(DiagnosticsProperty('total', total));
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is InjectingTemplate&&(identical(other.applied, applied) || other.applied == applied)&&(identical(other.total, total) || other.total == total));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,applied,total);
+
+@override
+String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
+  return 'MetadataSyncState.injectingTemplate(applied: $applied, total: $total)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $InjectingTemplateCopyWith<$Res> implements $MetadataSyncStateCopyWith<$Res> {
+  factory $InjectingTemplateCopyWith(InjectingTemplate value, $Res Function(InjectingTemplate) _then) = _$InjectingTemplateCopyWithImpl;
+@useResult
+$Res call({
+ int applied, int total
+});
+
+
+
+
+}
+/// @nodoc
+class _$InjectingTemplateCopyWithImpl<$Res>
+    implements $InjectingTemplateCopyWith<$Res> {
+  _$InjectingTemplateCopyWithImpl(this._self, this._then);
+
+  final InjectingTemplate _self;
+  final $Res Function(InjectingTemplate) _then;
+
+/// Create a copy of MetadataSyncState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? applied = null,Object? total = null,}) {
+  return _then(InjectingTemplate(
+applied: null == applied ? _self.applied : applied // ignore: cast_nullable_to_non_nullable
+as int,total: null == total ? _self.total : total // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
 
 /// @nodoc
 

--- a/lib/ui/metadata_sync/metadata_sync_page.dart
+++ b/lib/ui/metadata_sync/metadata_sync_page.dart
@@ -286,10 +286,36 @@ class MetadataSyncPage extends StatelessWidget {
                                     _showExportDialog(metaCtx);
                                     break;
                                   case 'template_manager':
+                                    final metadataCubit = metaCtx
+                                        .read<MetadataSyncCubit>();
                                     Navigator.of(metaCtx).push(
                                       MaterialPageRoute(
-                                        builder: (_) =>
-                                            const TemplateManagerScreen(),
+                                        builder: (_) => TemplateManagerScreen(
+                                          onApplyDevice:
+                                              (
+                                                template,
+                                                selectedIndices,
+                                              ) async {
+                                                await metadataCubit
+                                                    .applyTemplateToDevice(
+                                                      template: template,
+                                                      templateSlotIndices:
+                                                          selectedIndices,
+                                                      manager: distingCubit
+                                                          .requireDisting(),
+                                                    );
+                                                final state =
+                                                    metadataCubit.state;
+                                                if (state
+                                                    case PresetLoadFailure(
+                                                      error: final error,
+                                                    )) {
+                                                  throw StateError(error);
+                                                }
+                                              },
+                                          onCancelDeviceApply:
+                                              metadataCubit.cancelInjection,
+                                        ),
                                       ),
                                     );
                                     break;
@@ -1241,11 +1267,35 @@ class _TemplateListView extends StatelessWidget {
                     icon: const Icon(Icons.dashboard_customize),
                     onPressed: isOperationInProgress
                         ? null
-                        : () => Navigator.of(context).push(
-                            MaterialPageRoute(
-                              builder: (_) => const TemplateManagerScreen(),
-                            ),
-                          ),
+                        : () {
+                            final metadataCubit = context
+                                .read<MetadataSyncCubit>();
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (_) => TemplateManagerScreen(
+                                  onApplyDevice:
+                                      (template, selectedIndices) async {
+                                        await metadataCubit
+                                            .applyTemplateToDevice(
+                                              template: template,
+                                              templateSlotIndices:
+                                                  selectedIndices,
+                                              manager: distingCubit
+                                                  .requireDisting(),
+                                            );
+                                        final state = metadataCubit.state;
+                                        if (state case PresetLoadFailure(
+                                          error: final error,
+                                        )) {
+                                          throw StateError(error);
+                                        }
+                                      },
+                                  onCancelDeviceApply:
+                                      metadataCubit.cancelInjection,
+                                ),
+                              ),
+                            );
+                          },
                   ),
                 ],
               ),

--- a/lib/ui/metadata_sync/metadata_sync_page.dart
+++ b/lib/ui/metadata_sync/metadata_sync_page.dart
@@ -15,6 +15,7 @@ import 'package:nt_helper/ui/widgets/algorithm_export_dialog.dart';
 import 'package:nt_helper/ui/widgets/debug_metadata_export_dialog.dart';
 import 'package:nt_helper/ui/widgets/digit_shortcut_blocker.dart';
 import 'package:nt_helper/ui/widgets/template_preview_dialog.dart';
+import 'package:nt_helper/ui/template_manager/template_manager_screen.dart';
 
 class MetadataSyncAnnouncementListener extends StatelessWidget {
   final Widget child;
@@ -284,6 +285,14 @@ class MetadataSyncPage extends StatelessWidget {
                                   case 'export_algorithms':
                                     _showExportDialog(metaCtx);
                                     break;
+                                  case 'template_manager':
+                                    Navigator.of(metaCtx).push(
+                                      MaterialPageRoute(
+                                        builder: (_) =>
+                                            const TemplateManagerScreen(),
+                                      ),
+                                    );
+                                    break;
                                   case 'debug_export_full':
                                     if (kDebugMode) {
                                       _showDebugFullExportDialog(metaCtx);
@@ -312,6 +321,17 @@ class MetadataSyncPage extends StatelessWidget {
                                       Icon(Icons.download, size: 20),
                                       SizedBox(width: 12),
                                       Text('Export Algorithm Details'),
+                                    ],
+                                  ),
+                                ),
+                                PopupMenuItem<String>(
+                                  value: 'template_manager',
+                                  enabled: !isBusy,
+                                  child: const Row(
+                                    children: [
+                                      Icon(Icons.dashboard_customize, size: 20),
+                                      SizedBox(width: 12),
+                                      Text('Template Manager...'),
                                     ],
                                   ),
                                 ),
@@ -1205,98 +1225,137 @@ class _TemplateListView extends StatelessWidget {
           );
         }
 
-        return ListView.separated(
-          itemCount: templates.length,
-          separatorBuilder: (context, index) => const Divider(height: 1),
-          itemBuilder: (context, index) {
-            final template = templates[index];
-            final preset = template.preset;
-            final formattedDate = preset.lastModified.toLocal().toString();
-
-            final bool isCurrentlyLoadedOffline = false;
-
-            // Determine button states
-            final bool canLoad = !isOperationInProgress;
-            final bool canDelete = !isOperationInProgress;
-
-            return ListTile(
-              key: ValueKey(preset.id),
-              selected: isCurrentlyLoadedOffline,
-              selectedTileColor: Theme.of(
-                context,
-              ).colorScheme.primaryContainer.withValues(alpha: 0.3),
-              leading: Icon(
-                Icons.star,
-                color: Theme.of(context).colorScheme.tertiary,
-              ),
-              title: Text(preset.name.trim()),
-              subtitle: Text("Saved: $formattedDate"),
-              trailing: Row(
-                mainAxisSize: MainAxisSize.min,
+        return Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 4, 4, 4),
+              child: Row(
                 children: [
-                  // Inject Button
-                  IconButton(
-                    icon: Icon(
-                      Icons.add_circle_outline,
-                      color: canLoad
-                          ? Theme.of(context).colorScheme.secondary
-                          : Colors.grey,
-                      semanticLabel: isOffline
-                          ? 'Inject Template (Offline)'
-                          : 'Inject Template',
-                    ),
-                    tooltip: isOffline
-                        ? 'Inject Template (Offline)'
-                        : 'Inject Template',
-                    onPressed: canLoad
-                        ? () async => await _showInjectDialog(
-                            context,
-                            template,
-                            distingCubit,
-                            metadataSyncCubit,
-                          )
-                        : null,
+                  Text(
+                    '${templates.length} template${templates.length == 1 ? '' : 's'}',
+                    style: Theme.of(context).textTheme.titleSmall,
                   ),
-                  // Load Button
+                  const Spacer(),
                   IconButton(
-                    icon: Icon(
-                      isOffline ? Icons.edit_note : Icons.upload_file_outlined,
-                      color: canLoad
-                          ? Theme.of(context).colorScheme.primary
-                          : Colors.grey,
-                      semanticLabel: isOffline
-                          ? 'Load Preset Offline'
-                          : 'Send to NT',
-                    ),
-                    tooltip: isOffline ? 'Load Preset Offline' : 'Send to NT',
-                    onPressed: canLoad
-                        ? () => _showLoadConfirmationDialog(
-                            context,
-                            template,
-                            isOffline,
-                            distingCubit,
-                            metadataSyncCubit,
-                          )
-                        : null,
-                  ),
-                  // Delete Button
-                  IconButton(
-                    icon: Icon(
-                      Icons.delete_outline,
-                      color: canDelete
-                          ? Theme.of(context).colorScheme.error
-                          : Colors.grey,
-                      semanticLabel: 'Delete Template',
-                    ),
-                    tooltip: 'Delete Template',
-                    onPressed: canDelete
-                        ? () => _showDeleteConfirmationDialog(context, preset)
-                        : null,
+                    tooltip: 'Open Template Manager',
+                    icon: const Icon(Icons.dashboard_customize),
+                    onPressed: isOperationInProgress
+                        ? null
+                        : () => Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) => const TemplateManagerScreen(),
+                            ),
+                          ),
                   ),
                 ],
               ),
-            );
-          },
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: ListView.separated(
+                itemCount: templates.length,
+                separatorBuilder: (context, index) => const Divider(height: 1),
+                itemBuilder: (context, index) {
+                  final template = templates[index];
+                  final preset = template.preset;
+                  final formattedDate = preset.lastModified
+                      .toLocal()
+                      .toString();
+
+                  final bool isCurrentlyLoadedOffline = false;
+
+                  // Determine button states
+                  final bool canLoad = !isOperationInProgress;
+                  final bool canDelete = !isOperationInProgress;
+
+                  return ListTile(
+                    key: ValueKey(preset.id),
+                    selected: isCurrentlyLoadedOffline,
+                    selectedTileColor: Theme.of(
+                      context,
+                    ).colorScheme.primaryContainer.withValues(alpha: 0.3),
+                    leading: Icon(
+                      Icons.star,
+                      color: Theme.of(context).colorScheme.tertiary,
+                    ),
+                    title: Text(preset.name.trim()),
+                    subtitle: Text("Saved: $formattedDate"),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        // Inject Button
+                        IconButton(
+                          icon: Icon(
+                            Icons.add_circle_outline,
+                            color: canLoad
+                                ? Theme.of(context).colorScheme.secondary
+                                : Colors.grey,
+                            semanticLabel: isOffline
+                                ? 'Inject Template (Offline)'
+                                : 'Inject Template',
+                          ),
+                          tooltip: isOffline
+                              ? 'Inject Template (Offline)'
+                              : 'Inject Template',
+                          onPressed: canLoad
+                              ? () async => await _showInjectDialog(
+                                  context,
+                                  template,
+                                  distingCubit,
+                                  metadataSyncCubit,
+                                )
+                              : null,
+                        ),
+                        // Load Button
+                        IconButton(
+                          icon: Icon(
+                            isOffline
+                                ? Icons.edit_note
+                                : Icons.upload_file_outlined,
+                            color: canLoad
+                                ? Theme.of(context).colorScheme.primary
+                                : Colors.grey,
+                            semanticLabel: isOffline
+                                ? 'Load Preset Offline'
+                                : 'Send to NT',
+                          ),
+                          tooltip: isOffline
+                              ? 'Load Preset Offline'
+                              : 'Send to NT',
+                          onPressed: canLoad
+                              ? () => _showLoadConfirmationDialog(
+                                  context,
+                                  template,
+                                  isOffline,
+                                  distingCubit,
+                                  metadataSyncCubit,
+                                )
+                              : null,
+                        ),
+                        // Delete Button
+                        IconButton(
+                          icon: Icon(
+                            Icons.delete_outline,
+                            color: canDelete
+                                ? Theme.of(context).colorScheme.error
+                                : Colors.grey,
+                            semanticLabel: 'Delete Template',
+                          ),
+                          tooltip: 'Delete Template',
+                          onPressed: canDelete
+                              ? () => _showDeleteConfirmationDialog(
+                                  context,
+                                  preset,
+                                )
+                              : null,
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
         );
       },
     );

--- a/lib/ui/metadata_sync/metadata_sync_state.dart
+++ b/lib/ui/metadata_sync/metadata_sync_state.dart
@@ -25,6 +25,13 @@ sealed class MetadataSyncState with _$MetadataSyncState {
   // --- Preset Management Specific States ---
   const factory MetadataSyncState.savingPreset() = SavingPreset;
   const factory MetadataSyncState.loadingPreset() = LoadingPreset;
+  // Progress emission for a multi-slot template injection. `applied` is the
+  // number of template slots already sent to the device; `total` is the total
+  // requested. UI dialogs render `Adding $applied of $total…`.
+  const factory MetadataSyncState.injectingTemplate({
+    required int applied,
+    required int total,
+  }) = InjectingTemplate;
   const factory MetadataSyncState.presetSaveSuccess(String message) =
       PresetSaveSuccess;
   const factory MetadataSyncState.presetSaveFailure(String error) =

--- a/lib/ui/performance_screen.dart
+++ b/lib/ui/performance_screen.dart
@@ -188,7 +188,7 @@ class _PerformanceScreenState extends State<PerformanceScreen> {
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       buildDefaultDragHandles: false,
       itemCount: sortedParams.length,
-      onReorder: (oldIndex, newIndex) =>
+      onReorderItem: (oldIndex, newIndex) =>
           _onReorder(sortedParams, oldIndex, newIndex),
       itemBuilder: (context, index) {
         final item = sortedParams[index];
@@ -350,15 +350,20 @@ class _PerformanceScreenState extends State<PerformanceScreen> {
                         parameters: sortedParams,
                         layoutMode: _layoutMode,
                         slots: state.slots,
-                        onParameterChanged: (slotIndex, parameterNumber,
-                            value, userIsChanging) {
-                          context.read<DistingCubit>().updateParameterValue(
-                            algorithmIndex: slotIndex,
-                            parameterNumber: parameterNumber,
-                            value: value,
-                            userIsChangingTheValue: userIsChanging,
-                          );
-                        },
+                        onParameterChanged:
+                            (
+                              slotIndex,
+                              parameterNumber,
+                              value,
+                              userIsChanging,
+                            ) {
+                              context.read<DistingCubit>().updateParameterValue(
+                                algorithmIndex: slotIndex,
+                                parameterNumber: parameterNumber,
+                                value: value,
+                                userIsChangingTheValue: userIsChanging,
+                              );
+                            },
                       ),
                     ),
                   ],
@@ -390,15 +395,15 @@ class _PerformanceScreenState extends State<PerformanceScreen> {
             child: HardwarePreviewWidget(
               perfPageItems: enabledItems,
               slots: state.slots,
-              onParameterChanged: (slotIndex, parameterNumber, value,
-                  userIsChanging) {
-                context.read<DistingCubit>().updateParameterValue(
-                  algorithmIndex: slotIndex,
-                  parameterNumber: parameterNumber,
-                  value: value,
-                  userIsChangingTheValue: userIsChanging,
-                );
-              },
+              onParameterChanged:
+                  (slotIndex, parameterNumber, value, userIsChanging) {
+                    context.read<DistingCubit>().updateParameterValue(
+                      algorithmIndex: slotIndex,
+                      parameterNumber: parameterNumber,
+                      value: value,
+                      userIsChangingTheValue: userIsChanging,
+                    );
+                  },
             ),
           ),
         ],

--- a/lib/ui/template_manager/create_template_from_preset_dialog.dart
+++ b/lib/ui/template_manager/create_template_from_preset_dialog.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:nt_helper/db/daos/presets_dao.dart';
+import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/models/packed_mapping_data.dart';
+import 'package:nt_helper/models/template_metadata.dart';
+import 'package:nt_helper/ui/template_manager/template_slot_selection_list.dart';
+
+class CreateTemplateFromPresetDialog extends StatefulWidget {
+  final AppDatabase? database;
+  final FullPresetDetails source;
+
+  const CreateTemplateFromPresetDialog({
+    super.key,
+    this.database,
+    required this.source,
+  });
+
+  static Future<void> show(
+    BuildContext context, {
+    required FullPresetDetails source,
+  }) {
+    return showDialog<void>(
+      context: context,
+      builder: (context) => Dialog(
+        child: SizedBox(
+          width: 720,
+          height: 640,
+          child: CreateTemplateFromPresetDialog(source: source),
+        ),
+      ),
+    );
+  }
+
+  @override
+  State<CreateTemplateFromPresetDialog> createState() =>
+      _CreateTemplateFromPresetDialogState();
+}
+
+class _CreateTemplateFromPresetDialogState
+    extends State<CreateTemplateFromPresetDialog> {
+  late final TextEditingController _nameController;
+  late final TextEditingController _categoryController;
+  late final TextEditingController _descriptionController;
+  late final TextEditingController _tagsController;
+  late final TextEditingController _authorController;
+  Set<int> _selected = {};
+  bool _creating = false;
+  String? _error;
+
+  AppDatabase get _database => widget.database ?? context.read<AppDatabase>();
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(
+      text: '${widget.source.preset.name} Template',
+    );
+    _categoryController = TextEditingController(
+      text: widget.source.preset.category ?? '',
+    );
+    _descriptionController = TextEditingController();
+    _tagsController = TextEditingController();
+    _authorController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _categoryController.dispose();
+    _descriptionController.dispose();
+    _tagsController.dispose();
+    _authorController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _create() async {
+    final selected = _selected.toList()..sort();
+    final name = _nameController.text.trim();
+    if (name.isEmpty || selected.isEmpty || _creating) return;
+
+    setState(() {
+      _creating = true;
+      _error = null;
+    });
+
+    try {
+      final metadata = TemplateMetadata(
+        description: _nullIfEmpty(_descriptionController.text),
+        tags: _tagsController.text
+            .split(',')
+            .map((tag) => tag.trim())
+            .where((tag) => tag.isNotEmpty)
+            .toList(growable: false),
+        author: _nullIfEmpty(_authorController.text),
+      );
+
+      final copiedSlots = <FullPresetSlot>[];
+      for (var outputIndex = 0; outputIndex < selected.length; outputIndex++) {
+        final sourceSlot = widget.source.slots[selected[outputIndex]];
+        copiedSlots.add(
+          FullPresetSlot(
+            slot: PresetSlotEntry(
+              id: -1,
+              presetId: -1,
+              slotIndex: outputIndex,
+              algorithmGuid: sourceSlot.slot.algorithmGuid,
+              customName: sourceSlot.slot.customName,
+            ),
+            algorithm: sourceSlot.algorithm,
+            parameterValues: Map<int, int>.from(sourceSlot.parameterValues),
+            parameterStringValues: Map<int, String>.from(
+              sourceSlot.parameterStringValues,
+            ),
+            mappings: Map<int, PackedMappingData>.from(sourceSlot.mappings),
+          ),
+        );
+      }
+
+      await _database.presetsDao.saveFullPreset(
+        FullPresetDetails(
+          preset: PresetEntry(
+            id: -1,
+            name: name,
+            lastModified: DateTime.now(),
+            isTemplate: true,
+            category: _nullIfEmpty(_categoryController.text),
+            templateMetadata: metadata.toJsonString(),
+          ),
+          slots: copiedSlots,
+        ),
+        isTemplate: true,
+      );
+
+      if (!mounted) return;
+      if (Navigator.of(context).canPop()) {
+        Navigator.of(context).pop();
+      } else {
+        setState(() => _creating = false);
+      }
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _creating = false;
+        _error = error.toString();
+      });
+    }
+  }
+
+  String? _nullIfEmpty(String value) {
+    final trimmed = value.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final canCreate =
+        _selected.isNotEmpty && _nameController.text.trim().isNotEmpty;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create Template')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                SizedBox(
+                  width: 220,
+                  child: TextField(
+                    key: const ValueKey('template-name'),
+                    controller: _nameController,
+                    decoration: const InputDecoration(labelText: 'Name'),
+                    onChanged: (_) => setState(() {}),
+                  ),
+                ),
+                SizedBox(
+                  width: 180,
+                  child: TextField(
+                    key: const ValueKey('template-category'),
+                    controller: _categoryController,
+                    decoration: const InputDecoration(labelText: 'Category'),
+                  ),
+                ),
+                SizedBox(
+                  width: 260,
+                  child: TextField(
+                    key: const ValueKey('template-description'),
+                    controller: _descriptionController,
+                    decoration: const InputDecoration(labelText: 'Description'),
+                  ),
+                ),
+                SizedBox(
+                  width: 180,
+                  child: TextField(
+                    key: const ValueKey('template-tags'),
+                    controller: _tagsController,
+                    decoration: const InputDecoration(labelText: 'Tags'),
+                  ),
+                ),
+                SizedBox(
+                  width: 160,
+                  child: TextField(
+                    key: const ValueKey('template-author'),
+                    controller: _authorController,
+                    decoration: const InputDecoration(labelText: 'Author'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Text(
+                _error!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ),
+          Expanded(
+            child: TemplateSlotSelectionList(
+              template: widget.source,
+              selectedIndices: _selected,
+              onSelectionChanged: (next) => setState(() => _selected = next),
+            ),
+          ),
+          const Divider(height: 1),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                FilledButton(
+                  onPressed: canCreate && !_creating ? _create : null,
+                  child: _creating
+                      ? const SizedBox.square(
+                          dimension: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Create template'),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/template_manager/template_apply_dialog.dart
+++ b/lib/ui/template_manager/template_apply_dialog.dart
@@ -23,6 +23,7 @@ class TemplateApplyDialog extends StatefulWidget {
 
   static Future<void> show(
     BuildContext context, {
+    AppDatabase? database,
     required FullPresetDetails template,
     required Set<int> selectedIndices,
     Future<void> Function()? onApplyDevice,
@@ -35,6 +36,7 @@ class TemplateApplyDialog extends StatefulWidget {
         child: SizedBox(
           width: 560,
           child: TemplateApplyDialog(
+            database: database,
             template: template,
             selectedIndices: selectedIndices,
             onApplyDevice: onApplyDevice,
@@ -153,7 +155,7 @@ class _TemplateApplyDialogState extends State<TemplateApplyDialog> {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 Text(
-                  'Apply Template',
+                  'Apply template slots',
                   style: Theme.of(context).textTheme.titleLarge,
                 ),
                 const SizedBox(height: 12),
@@ -185,7 +187,7 @@ class _TemplateApplyDialogState extends State<TemplateApplyDialog> {
                   snapshot.connectionState == ConnectionState.waiting
                       ? const LinearProgressIndicator()
                       : DropdownButtonFormField<int>(
-                          value: _targetPresetId,
+                          initialValue: _targetPresetId,
                           decoration: const InputDecoration(
                             labelText: 'Target preset',
                             border: OutlineInputBorder(),

--- a/lib/ui/template_manager/template_apply_dialog.dart
+++ b/lib/ui/template_manager/template_apply_dialog.dart
@@ -1,0 +1,260 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:nt_helper/db/daos/presets_dao.dart';
+import 'package:nt_helper/db/database.dart';
+
+enum _TemplateApplyTarget { device, preset }
+
+class TemplateApplyDialog extends StatefulWidget {
+  final AppDatabase? database;
+  final FullPresetDetails template;
+  final Set<int> selectedIndices;
+  final Future<void> Function()? onApplyDevice;
+  final VoidCallback? onCancelDeviceApply;
+
+  const TemplateApplyDialog({
+    super.key,
+    this.database,
+    required this.template,
+    required this.selectedIndices,
+    this.onApplyDevice,
+    this.onCancelDeviceApply,
+  });
+
+  static Future<void> show(
+    BuildContext context, {
+    required FullPresetDetails template,
+    required Set<int> selectedIndices,
+    Future<void> Function()? onApplyDevice,
+    VoidCallback? onCancelDeviceApply,
+  }) {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => Dialog(
+        child: SizedBox(
+          width: 560,
+          child: TemplateApplyDialog(
+            template: template,
+            selectedIndices: selectedIndices,
+            onApplyDevice: onApplyDevice,
+            onCancelDeviceApply: onCancelDeviceApply,
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  State<TemplateApplyDialog> createState() => _TemplateApplyDialogState();
+}
+
+class _TemplateApplyDialogState extends State<TemplateApplyDialog> {
+  late Future<List<FullPresetDetails>> _targetsFuture;
+  _TemplateApplyTarget _target = _TemplateApplyTarget.preset;
+  int? _targetPresetId;
+  bool _inFlight = false;
+  bool _overwrite = false;
+  String? _message;
+  String? _error;
+
+  AppDatabase get _database => widget.database ?? context.read<AppDatabase>();
+
+  @override
+  void initState() {
+    super.initState();
+    _targetsFuture = _database.presetsDao.getNonTemplates();
+  }
+
+  @override
+  void dispose() {
+    if (_inFlight && _target == _TemplateApplyTarget.device) {
+      widget.onCancelDeviceApply?.call();
+    }
+    super.dispose();
+  }
+
+  Future<void> _apply(List<FullPresetDetails> targets) async {
+    if (_inFlight || widget.selectedIndices.isEmpty) return;
+    setState(() {
+      _inFlight = true;
+      _message = null;
+      _error = null;
+    });
+
+    try {
+      if (_target == _TemplateApplyTarget.device) {
+        await (widget.onApplyDevice?.call() ?? Future<void>.value());
+        if (!mounted) return;
+        setState(() {
+          _message = _appliedMessage(widget.selectedIndices.length);
+        });
+      } else {
+        final targetId =
+            _targetPresetId ??
+            (targets.isEmpty ? null : targets.first.preset.id);
+        if (targetId == null) {
+          throw StateError('No target preset available.');
+        }
+        final target = targets.firstWhere((t) => t.preset.id == targetId);
+        final selected = widget.selectedIndices.toList()..sort();
+        final result = await _database.presetsDao.applyTemplateSlots(
+          templateId: widget.template.preset.id,
+          targetPresetId: targetId,
+          templateSlotIndices: selected,
+          insertionOffset: target.slots.length,
+          overwrite: _overwrite,
+        );
+        if (!mounted) return;
+        final applied = result.insertedSlotIndices.length;
+        setState(() {
+          _message = result.warning == null
+              ? _appliedMessage(applied)
+              : '${_appliedMessage(applied)} ${result.warning}';
+        });
+      }
+    } on TemplateSpaceException catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _error =
+            '${error.current} existing + ${error.applied} selected exceeds the '
+            '${error.limit}-slot limit.';
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _error = error.toString());
+    } finally {
+      if (mounted) {
+        setState(() => _inFlight = false);
+      }
+    }
+  }
+
+  String _appliedMessage(int count) {
+    return 'Applied $count ${count == 1 ? 'slot' : 'slots'}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<FullPresetDetails>>(
+      future: _targetsFuture,
+      builder: (context, snapshot) {
+        final targets = snapshot.data ?? const <FullPresetDetails>[];
+        if (_targetPresetId == null && targets.isNotEmpty) {
+          _targetPresetId = targets.first.preset.id;
+        }
+
+        return PopScope(
+          canPop: !_inFlight,
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'Apply Template',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  '${widget.selectedIndices.length} selected from '
+                  '${widget.template.preset.name}',
+                ),
+                const SizedBox(height: 12),
+                SegmentedButton<_TemplateApplyTarget>(
+                  segments: const [
+                    ButtonSegment(
+                      value: _TemplateApplyTarget.preset,
+                      icon: Icon(Icons.library_music_outlined),
+                      label: Text('Local preset'),
+                    ),
+                    ButtonSegment(
+                      value: _TemplateApplyTarget.device,
+                      icon: Icon(Icons.memory),
+                      label: Text('Current device'),
+                    ),
+                  ],
+                  selected: {_target},
+                  onSelectionChanged: _inFlight
+                      ? null
+                      : (next) => setState(() => _target = next.single),
+                ),
+                const SizedBox(height: 12),
+                if (_target == _TemplateApplyTarget.preset)
+                  snapshot.connectionState == ConnectionState.waiting
+                      ? const LinearProgressIndicator()
+                      : DropdownButtonFormField<int>(
+                          value: _targetPresetId,
+                          decoration: const InputDecoration(
+                            labelText: 'Target preset',
+                            border: OutlineInputBorder(),
+                          ),
+                          items: [
+                            for (final target in targets)
+                              DropdownMenuItem(
+                                value: target.preset.id,
+                                child: Text(target.preset.name),
+                              ),
+                          ],
+                          onChanged: _inFlight
+                              ? null
+                              : (value) => setState(() {
+                                  _targetPresetId = value;
+                                }),
+                        ),
+                const SizedBox(height: 8),
+                SwitchListTile(
+                  contentPadding: EdgeInsets.zero,
+                  value: _overwrite,
+                  onChanged: _inFlight
+                      ? null
+                      : (value) => setState(() => _overwrite = value),
+                  title: const Text('Replace existing slots'),
+                ),
+                if (_message != null)
+                  Text(
+                    _message!,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                  ),
+                if (_error != null)
+                  Text(
+                    _error!,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
+                const SizedBox(height: 12),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    if (_inFlight && _target == _TemplateApplyTarget.device)
+                      TextButton(
+                        onPressed: widget.onCancelDeviceApply,
+                        child: const Text('Cancel'),
+                      ),
+                    const SizedBox(width: 8),
+                    FilledButton.icon(
+                      icon: _inFlight
+                          ? const SizedBox.square(
+                              dimension: 18,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.playlist_add),
+                      label: const Text('Apply selected'),
+                      onPressed: _inFlight || widget.selectedIndices.isEmpty
+                          ? null
+                          : () => _apply(targets),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/template_manager/template_apply_dialog.dart
+++ b/lib/ui/template_manager/template_apply_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:collection/collection.dart';
 import 'package:nt_helper/db/daos/presets_dao.dart';
 import 'package:nt_helper/db/database.dart';
 
@@ -57,6 +58,7 @@ class _TemplateApplyDialogState extends State<TemplateApplyDialog> {
   int? _targetPresetId;
   bool _inFlight = false;
   bool _overwrite = false;
+  int _insertionOffset = 0;
   String? _message;
   String? _error;
 
@@ -86,7 +88,11 @@ class _TemplateApplyDialogState extends State<TemplateApplyDialog> {
 
     try {
       if (_target == _TemplateApplyTarget.device) {
-        await (widget.onApplyDevice?.call() ?? Future<void>.value());
+        final applyDevice = widget.onApplyDevice;
+        if (applyDevice == null) {
+          throw StateError('Current device apply is unavailable.');
+        }
+        await applyDevice();
         if (!mounted) return;
         setState(() {
           _message = _appliedMessage(widget.selectedIndices.length);
@@ -104,7 +110,7 @@ class _TemplateApplyDialogState extends State<TemplateApplyDialog> {
           templateId: widget.template.preset.id,
           targetPresetId: targetId,
           templateSlotIndices: selected,
-          insertionOffset: target.slots.length,
+          insertionOffset: _normalizedInsertionOffset(target),
           overwrite: _overwrite,
         );
         if (!mounted) return;
@@ -136,6 +142,33 @@ class _TemplateApplyDialogState extends State<TemplateApplyDialog> {
     return 'Applied $count ${count == 1 ? 'slot' : 'slots'}';
   }
 
+  String _slotOffsetLabel(FullPresetDetails target, int offset) {
+    if (offset >= target.slots.length) {
+      return 'End (${target.slots.length})';
+    }
+    return 'Slot $offset';
+  }
+
+  int _normalizedInsertionOffset(FullPresetDetails target) {
+    final maxOffset = _maxInsertionOffset(target);
+    if (_insertionOffset > maxOffset) return maxOffset;
+    return _insertionOffset;
+  }
+
+  int _maxInsertionOffset(FullPresetDetails target) {
+    if (_overwrite && target.slots.isNotEmpty) {
+      return target.slots.length - 1;
+    }
+    return target.slots.length;
+  }
+
+  FullPresetDetails? _selectedTarget(List<FullPresetDetails> targets) {
+    final targetId =
+        _targetPresetId ?? (targets.isEmpty ? null : targets.first.preset.id);
+    if (targetId == null) return null;
+    return targets.firstWhereOrNull((target) => target.preset.id == targetId);
+  }
+
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<List<FullPresetDetails>>(
@@ -144,6 +177,11 @@ class _TemplateApplyDialogState extends State<TemplateApplyDialog> {
         final targets = snapshot.data ?? const <FullPresetDetails>[];
         if (_targetPresetId == null && targets.isNotEmpty) {
           _targetPresetId = targets.first.preset.id;
+        }
+        final selectedTarget = _selectedTarget(targets);
+        if (selectedTarget != null &&
+            _insertionOffset > _maxInsertionOffset(selectedTarget)) {
+          _insertionOffset = _maxInsertionOffset(selectedTarget);
         }
 
         return PopScope(
@@ -165,8 +203,8 @@ class _TemplateApplyDialogState extends State<TemplateApplyDialog> {
                 ),
                 const SizedBox(height: 12),
                 SegmentedButton<_TemplateApplyTarget>(
-                  segments: const [
-                    ButtonSegment(
+                  segments: [
+                    const ButtonSegment(
                       value: _TemplateApplyTarget.preset,
                       icon: Icon(Icons.library_music_outlined),
                       label: Text('Local preset'),
@@ -175,12 +213,17 @@ class _TemplateApplyDialogState extends State<TemplateApplyDialog> {
                       value: _TemplateApplyTarget.device,
                       icon: Icon(Icons.memory),
                       label: Text('Current device'),
+                      enabled: widget.onApplyDevice != null,
                     ),
                   ],
                   selected: {_target},
                   onSelectionChanged: _inFlight
                       ? null
-                      : (next) => setState(() => _target = next.single),
+                      : (next) => setState(() {
+                          _target = next.single;
+                          _message = null;
+                          _error = null;
+                        }),
                 ),
                 const SizedBox(height: 12),
                 if (_target == _TemplateApplyTarget.preset)
@@ -203,17 +246,50 @@ class _TemplateApplyDialogState extends State<TemplateApplyDialog> {
                               ? null
                               : (value) => setState(() {
                                   _targetPresetId = value;
+                                  _insertionOffset = 0;
                                 }),
                         ),
-                const SizedBox(height: 8),
-                SwitchListTile(
-                  contentPadding: EdgeInsets.zero,
-                  value: _overwrite,
-                  onChanged: _inFlight
-                      ? null
-                      : (value) => setState(() => _overwrite = value),
-                  title: const Text('Replace existing slots'),
-                ),
+                if (_target == _TemplateApplyTarget.preset &&
+                    selectedTarget != null) ...[
+                  const SizedBox(height: 8),
+                  DropdownButtonFormField<int>(
+                    initialValue: _normalizedInsertionOffset(selectedTarget),
+                    decoration: const InputDecoration(
+                      labelText: 'Start slot',
+                      border: OutlineInputBorder(),
+                    ),
+                    items: [
+                      for (
+                        var i = 0;
+                        i <= _maxInsertionOffset(selectedTarget);
+                        i++
+                      )
+                        DropdownMenuItem(
+                          value: i,
+                          child: Text(_slotOffsetLabel(selectedTarget, i)),
+                        ),
+                    ],
+                    onChanged: _inFlight
+                        ? null
+                        : (value) => setState(() {
+                            _insertionOffset = value ?? 0;
+                          }),
+                  ),
+                  const SizedBox(height: 8),
+                  SwitchListTile(
+                    contentPadding: EdgeInsets.zero,
+                    value: _overwrite,
+                    onChanged: _inFlight
+                        ? null
+                        : (value) => setState(() {
+                            _overwrite = value;
+                            _insertionOffset = _normalizedInsertionOffset(
+                              selectedTarget,
+                            );
+                          }),
+                    title: const Text('Replace existing slots'),
+                  ),
+                ],
                 if (_message != null)
                   Text(
                     _message!,

--- a/lib/ui/template_manager/template_manager_screen.dart
+++ b/lib/ui/template_manager/template_manager_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:nt_helper/db/daos/presets_dao.dart';
 import 'package:nt_helper/db/database.dart';
 import 'package:nt_helper/models/template_metadata.dart';
+import 'package:nt_helper/ui/template_manager/template_apply_dialog.dart';
 import 'package:nt_helper/ui/template_manager/template_slot_selection_list.dart';
 
 class TemplateManagerScreen extends StatefulWidget {
@@ -81,6 +82,7 @@ class _TemplateManagerScreenState extends State<TemplateManagerScreen> {
                 },
               );
               final detail = _TemplateManagerDetail(
+                database: _database,
                 template: selected,
                 selectedSlots: _selectedSlots,
                 onSelectionChanged: (next) {
@@ -227,11 +229,13 @@ class _TemplateListTile extends StatelessWidget {
 }
 
 class _TemplateManagerDetail extends StatelessWidget {
+  final AppDatabase database;
   final FullPresetDetails template;
   final Set<int> selectedSlots;
   final ValueChanged<Set<int>> onSelectionChanged;
 
   const _TemplateManagerDetail({
+    required this.database,
     required this.template,
     required this.selectedSlots,
     required this.onSelectionChanged,
@@ -306,7 +310,14 @@ class _TemplateManagerDetail extends StatelessWidget {
               FilledButton.icon(
                 icon: const Icon(Icons.playlist_add),
                 label: const Text('Apply selected'),
-                onPressed: selectedSlots.isEmpty ? null : () {},
+                onPressed: selectedSlots.isEmpty
+                    ? null
+                    : () => TemplateApplyDialog.show(
+                        context,
+                        database: database,
+                        template: template,
+                        selectedIndices: selectedSlots,
+                      ),
               ),
             ],
           ),

--- a/lib/ui/template_manager/template_manager_screen.dart
+++ b/lib/ui/template_manager/template_manager_screen.dart
@@ -1,0 +1,317 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:nt_helper/db/daos/presets_dao.dart';
+import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/models/template_metadata.dart';
+import 'package:nt_helper/ui/template_manager/template_slot_selection_list.dart';
+
+class TemplateManagerScreen extends StatefulWidget {
+  final AppDatabase? database;
+
+  const TemplateManagerScreen({super.key, this.database});
+
+  @override
+  State<TemplateManagerScreen> createState() => _TemplateManagerScreenState();
+}
+
+class _TemplateManagerScreenState extends State<TemplateManagerScreen> {
+  late Future<List<FullPresetDetails>> _templatesFuture;
+  FullPresetDetails? _selected;
+  Set<int> _selectedSlots = {};
+
+  AppDatabase get _database => widget.database ?? context.read<AppDatabase>();
+
+  @override
+  void initState() {
+    super.initState();
+    _templatesFuture = _database.presetsDao.getTemplates();
+  }
+
+  void _refresh() {
+    setState(() {
+      _templatesFuture = _database.presetsDao.getTemplates();
+      _selected = null;
+      _selectedSlots = {};
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Template Manager'),
+        actions: [
+          IconButton(
+            tooltip: 'Refresh templates',
+            icon: const Icon(Icons.refresh),
+            onPressed: _refresh,
+          ),
+        ],
+      ),
+      body: FutureBuilder<List<FullPresetDetails>>(
+        future: _templatesFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(
+              child: Text('Error loading templates: ${snapshot.error}'),
+            );
+          }
+
+          final templates = snapshot.data ?? const <FullPresetDetails>[];
+          if (templates.isEmpty) {
+            return const Center(child: Text('No templates found.'));
+          }
+          final selected = _selected ?? templates.first;
+          _selected ??= selected;
+
+          return LayoutBuilder(
+            builder: (context, constraints) {
+              final narrow = constraints.maxWidth < 720;
+              final list = _TemplateManagerList(
+                templates: templates,
+                selectedId: selected.preset.id,
+                onSelected: (template) {
+                  setState(() {
+                    _selected = template;
+                    _selectedSlots = {};
+                  });
+                },
+              );
+              final detail = _TemplateManagerDetail(
+                template: selected,
+                selectedSlots: _selectedSlots,
+                onSelectionChanged: (next) {
+                  setState(() => _selectedSlots = next);
+                },
+              );
+
+              if (narrow) {
+                return Column(
+                  children: [
+                    SizedBox(height: 220, child: list),
+                    const Divider(height: 1),
+                    Expanded(child: detail),
+                  ],
+                );
+              }
+              return Row(
+                children: [
+                  SizedBox(width: 320, child: list),
+                  const VerticalDivider(width: 1),
+                  Expanded(child: detail),
+                ],
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _TemplateManagerList extends StatelessWidget {
+  final List<FullPresetDetails> templates;
+  final int selectedId;
+  final ValueChanged<FullPresetDetails> onSelected;
+
+  const _TemplateManagerList({
+    required this.templates,
+    required this.selectedId,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final grouped = <String, List<FullPresetDetails>>{};
+    for (final template in templates) {
+      final category = template.preset.category?.trim();
+      grouped
+          .putIfAbsent(
+            category == null || category.isEmpty ? 'Uncategorized' : category,
+            () => [],
+          )
+          .add(template);
+    }
+    final categories = grouped.keys.toList()..sort();
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(8),
+          child: Row(
+            children: [
+              IconButton(
+                tooltip: 'New from current preset',
+                icon: const Icon(Icons.add),
+                onPressed: null,
+              ),
+              IconButton(
+                tooltip: 'Edit metadata',
+                icon: const Icon(Icons.edit_outlined),
+                onPressed: null,
+              ),
+              IconButton(
+                tooltip: 'Delete template',
+                icon: const Icon(Icons.delete_outline),
+                onPressed: null,
+              ),
+              const Spacer(),
+              Text(
+                '${templates.length}',
+                style: Theme.of(context).textTheme.labelLarge,
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: ListView(
+            children: [
+              for (final category in categories) ...[
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 14, 16, 6),
+                  child: Text(
+                    category,
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                ),
+                for (final template
+                    in grouped[category]!
+                      ..sort((a, b) => a.preset.name.compareTo(b.preset.name)))
+                  _TemplateListTile(
+                    template: template,
+                    selected: template.preset.id == selectedId,
+                    onTap: () => onSelected(template),
+                  ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TemplateListTile extends StatelessWidget {
+  final FullPresetDetails template;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _TemplateListTile({
+    required this.template,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final metadata = TemplateMetadata.fromJsonString(
+      template.preset.templateMetadata,
+    );
+    final firstTag = metadata.tags.isEmpty ? null : metadata.tags.first;
+
+    return ListTile(
+      selected: selected,
+      leading: const Icon(Icons.star_outline),
+      title: Text(template.preset.name),
+      subtitle: Text('${template.slots.length} slots'),
+      trailing: firstTag == null
+          ? null
+          : Chip(label: Text(firstTag), visualDensity: VisualDensity.compact),
+      onTap: onTap,
+    );
+  }
+}
+
+class _TemplateManagerDetail extends StatelessWidget {
+  final FullPresetDetails template;
+  final Set<int> selectedSlots;
+  final ValueChanged<Set<int>> onSelectionChanged;
+
+  const _TemplateManagerDetail({
+    required this.template,
+    required this.selectedSlots,
+    required this.onSelectionChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final metadata = TemplateMetadata.fromJsonString(
+      template.preset.templateMetadata,
+    );
+    final tags = metadata.tags.join(', ');
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 14, 16, 10),
+          child: Wrap(
+            spacing: 16,
+            runSpacing: 8,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              Text(
+                template.preset.name,
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              if ((template.preset.category ?? '').isNotEmpty)
+                Text('Category: ${template.preset.category!}'),
+              if (tags.isNotEmpty) Chip(label: Text(tags)),
+              if ((metadata.author ?? '').isNotEmpty)
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(Icons.person_outline, size: 18),
+                    const SizedBox(width: 6),
+                    Text(metadata.author!),
+                  ],
+                ),
+            ],
+          ),
+        ),
+        if ((metadata.description ?? '').isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 10),
+            child: Text(metadata.description!),
+          ),
+        const Divider(height: 1),
+        Expanded(
+          child: TemplateSlotSelectionList(
+            template: template,
+            selectedIndices: selectedSlots,
+            onSelectionChanged: onSelectionChanged,
+          ),
+        ),
+        const Divider(height: 1),
+        Padding(
+          padding: const EdgeInsets.all(12),
+          child: Wrap(
+            spacing: 12,
+            runSpacing: 8,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            alignment: WrapAlignment.spaceBetween,
+            children: [
+              SegmentedButton<bool>(
+                segments: const [
+                  ButtonSegment(value: false, label: Text('Insert')),
+                  ButtonSegment(value: true, label: Text('Replace')),
+                ],
+                selected: const {false},
+                onSelectionChanged: (_) {},
+              ),
+              FilledButton.icon(
+                icon: const Icon(Icons.playlist_add),
+                label: const Text('Apply selected'),
+                onPressed: selectedSlots.isEmpty ? null : () {},
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/template_manager/template_manager_screen.dart
+++ b/lib/ui/template_manager/template_manager_screen.dart
@@ -6,10 +6,23 @@ import 'package:nt_helper/models/template_metadata.dart';
 import 'package:nt_helper/ui/template_manager/template_apply_dialog.dart';
 import 'package:nt_helper/ui/template_manager/template_slot_selection_list.dart';
 
+typedef TemplateDeviceApplyCallback =
+    Future<void> Function(
+      FullPresetDetails template,
+      List<int> selectedIndices,
+    );
+
 class TemplateManagerScreen extends StatefulWidget {
   final AppDatabase? database;
+  final TemplateDeviceApplyCallback? onApplyDevice;
+  final VoidCallback? onCancelDeviceApply;
 
-  const TemplateManagerScreen({super.key, this.database});
+  const TemplateManagerScreen({
+    super.key,
+    this.database,
+    this.onApplyDevice,
+    this.onCancelDeviceApply,
+  });
 
   @override
   State<TemplateManagerScreen> createState() => _TemplateManagerScreenState();
@@ -85,6 +98,8 @@ class _TemplateManagerScreenState extends State<TemplateManagerScreen> {
                 database: _database,
                 template: selected,
                 selectedSlots: _selectedSlots,
+                onApplyDevice: widget.onApplyDevice,
+                onCancelDeviceApply: widget.onCancelDeviceApply,
                 onSelectionChanged: (next) {
                   setState(() => _selectedSlots = next);
                 },
@@ -232,12 +247,16 @@ class _TemplateManagerDetail extends StatelessWidget {
   final AppDatabase database;
   final FullPresetDetails template;
   final Set<int> selectedSlots;
+  final TemplateDeviceApplyCallback? onApplyDevice;
+  final VoidCallback? onCancelDeviceApply;
   final ValueChanged<Set<int>> onSelectionChanged;
 
   const _TemplateManagerDetail({
     required this.database,
     required this.template,
     required this.selectedSlots,
+    this.onApplyDevice,
+    this.onCancelDeviceApply,
     required this.onSelectionChanged,
   });
 
@@ -293,33 +312,27 @@ class _TemplateManagerDetail extends StatelessWidget {
         const Divider(height: 1),
         Padding(
           padding: const EdgeInsets.all(12),
-          child: Wrap(
-            spacing: 12,
-            runSpacing: 8,
-            crossAxisAlignment: WrapCrossAlignment.center,
-            alignment: WrapAlignment.spaceBetween,
-            children: [
-              SegmentedButton<bool>(
-                segments: const [
-                  ButtonSegment(value: false, label: Text('Insert')),
-                  ButtonSegment(value: true, label: Text('Replace')),
-                ],
-                selected: const {false},
-                onSelectionChanged: (_) {},
-              ),
-              FilledButton.icon(
-                icon: const Icon(Icons.playlist_add),
-                label: const Text('Apply selected'),
-                onPressed: selectedSlots.isEmpty
-                    ? null
-                    : () => TemplateApplyDialog.show(
+          child: Align(
+            alignment: Alignment.centerRight,
+            child: FilledButton.icon(
+              icon: const Icon(Icons.playlist_add),
+              label: const Text('Apply selected'),
+              onPressed: selectedSlots.isEmpty
+                  ? null
+                  : () {
+                      final selected = selectedSlots.toList()..sort();
+                      TemplateApplyDialog.show(
                         context,
                         database: database,
                         template: template,
                         selectedIndices: selectedSlots,
-                      ),
-              ),
-            ],
+                        onApplyDevice: onApplyDevice == null
+                            ? null
+                            : () => onApplyDevice!(template, selected),
+                        onCancelDeviceApply: onCancelDeviceApply,
+                      );
+                    },
+            ),
           ),
         ),
       ],

--- a/lib/ui/template_manager/template_slot_selection_list.dart
+++ b/lib/ui/template_manager/template_slot_selection_list.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:nt_helper/db/daos/presets_dao.dart';
+
+class TemplateSlotSelectionList extends StatefulWidget {
+  final FullPresetDetails template;
+  final Set<int> selectedIndices;
+  final ValueChanged<Set<int>> onSelectionChanged;
+  final int currentTargetSlotCount;
+  final int maxSlots;
+
+  const TemplateSlotSelectionList({
+    super.key,
+    required this.template,
+    required this.selectedIndices,
+    required this.onSelectionChanged,
+    this.currentTargetSlotCount = 0,
+    this.maxSlots = 32,
+  });
+
+  @override
+  State<TemplateSlotSelectionList> createState() =>
+      _TemplateSlotSelectionListState();
+}
+
+class _TemplateSlotSelectionListState extends State<TemplateSlotSelectionList> {
+  late final TextEditingController _searchController;
+  String _query = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _searchController = TextEditingController();
+    _searchController.addListener(() {
+      setState(() {
+        _query = _searchController.text.trim().toLowerCase();
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  List<int> get _visibleIndices {
+    final indices = <int>[];
+    for (var i = 0; i < widget.template.slots.length; i++) {
+      final slot = widget.template.slots[i];
+      final haystack = [
+        slot.algorithm.name,
+        slot.algorithm.guid,
+        slot.slot.customName ?? '',
+      ].join(' ').toLowerCase();
+      if (_query.isEmpty || haystack.contains(_query)) {
+        indices.add(i);
+      }
+    }
+    return indices;
+  }
+
+  void _setSelected(Set<int> next) {
+    widget.onSelectionChanged(Set<int>.unmodifiable(next));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final visible = _visibleIndices;
+    final selectedCount = widget.selectedIndices.length;
+    final total = widget.currentTargetSlotCount + selectedCount;
+    final overLimit = total > widget.maxSlots;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 12, 12, 8),
+          child: TextField(
+            controller: _searchController,
+            decoration: const InputDecoration(
+              prefixIcon: Icon(Icons.search),
+              labelText: 'Search slots',
+              border: OutlineInputBorder(),
+              isDense: true,
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  '$selectedCount selected + ${widget.currentTargetSlotCount} current = $total / ${widget.maxSlots}',
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: overLimit
+                        ? theme.colorScheme.error
+                        : theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+              IconButton(
+                tooltip: 'Select all visible slots',
+                icon: const Icon(Icons.select_all),
+                onPressed: visible.isEmpty
+                    ? null
+                    : () {
+                        _setSelected({...widget.selectedIndices, ...visible});
+                      },
+              ),
+              IconButton(
+                tooltip: 'Select none',
+                icon: const Icon(Icons.deselect),
+                onPressed: widget.selectedIndices.isEmpty
+                    ? null
+                    : () => _setSelected({}),
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: visible.isEmpty
+              ? const Center(child: Text('No slots match'))
+              : ListView.builder(
+                  itemCount: visible.length,
+                  itemBuilder: (context, rowIndex) {
+                    final templateIndex = visible[rowIndex];
+                    final slot = widget.template.slots[templateIndex];
+                    final checked = widget.selectedIndices.contains(
+                      templateIndex,
+                    );
+                    final subtitleParts = <String>[
+                      'Slot ${slot.slot.slotIndex}',
+                      '${slot.parameterValues.length} params',
+                      '${slot.mappings.length} mappings',
+                    ];
+                    final customName = slot.slot.customName;
+                    if (customName != null && customName.isNotEmpty) {
+                      subtitleParts.insert(1, customName);
+                    }
+
+                    return CheckboxListTile(
+                      key: ValueKey('template-slot-$templateIndex'),
+                      value: checked,
+                      onChanged: (value) {
+                        final next = {...widget.selectedIndices};
+                        if (value == true) {
+                          next.add(templateIndex);
+                        } else {
+                          next.remove(templateIndex);
+                        }
+                        _setSelected(next);
+                      },
+                      title: Text(slot.algorithm.name),
+                      subtitle: Text(subtitleParts.join(' · ')),
+                      secondary: Text(
+                        '${slot.slot.slotIndex}',
+                        style: theme.textTheme.titleMedium,
+                      ),
+                      controlAffinity: ListTileControlAffinity.leading,
+                    );
+                  },
+                ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/widgets/parameter_list_view.dart
+++ b/lib/ui/widgets/parameter_list_view.dart
@@ -15,47 +15,49 @@ class ParameterListView extends StatelessWidget {
     return FocusTraversalGroup(
       policy: OrderedTraversalPolicy(),
       child: ListView.builder(
-      cacheExtent: double.infinity,
-      padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
-      itemCount: slot.parameters.length,
-      itemBuilder: (context, index) {
-        // Use safe access with bounds checking
-        final parameter = slot.parameters.elementAtOrNull(index);
-        final value = slot.values.elementAtOrNull(index);
-        final enumStrings = slot.enums.elementAtOrNull(index);
-        final mapping = slot.mappings.elementAtOrNull(index);
-        final valueString = slot.valueStrings.elementAtOrNull(index);
+        // ignore: deprecated_member_use
+        cacheExtent: double.infinity,
+        padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+        itemCount: slot.parameters.length,
+        itemBuilder: (context, index) {
+          // Use safe access with bounds checking
+          final parameter = slot.parameters.elementAtOrNull(index);
+          final value = slot.values.elementAtOrNull(index);
+          final enumStrings = slot.enums.elementAtOrNull(index);
+          final mapping = slot.mappings.elementAtOrNull(index);
+          final valueString = slot.valueStrings.elementAtOrNull(index);
 
-        // Skip this parameter if we don't have essential data
-        // Note: valueString and enumStrings can be empty/filler for many parameters
-        if (parameter == null || value == null) {
-          return const SizedBox.shrink();
-        }
+          // Skip this parameter if we don't have essential data
+          // Note: valueString and enumStrings can be empty/filler for many parameters
+          if (parameter == null || value == null) {
+            return const SizedBox.shrink();
+          }
 
-        // Use filler/empty data if not available
-        final safeEnumStrings = enumStrings ?? ParameterEnumStrings.filler();
-        final safeValueString = valueString ?? ParameterValueString.filler();
+          // Use filler/empty data if not available
+          final safeEnumStrings = enumStrings ?? ParameterEnumStrings.filler();
+          final safeValueString = valueString ?? ParameterValueString.filler();
 
-        // For string-type parameters, don't fetch unit - they use value strings
-        // The registry handles firmware version differences automatically
-        final shouldShowUnit =
-            !ParameterEditorRegistry.isStringTypeUnit(parameter.unit);
-        final unit = shouldShowUnit ? parameter.getUnitString(units) : null;
+          // For string-type parameters, don't fetch unit - they use value strings
+          // The registry handles firmware version differences automatically
+          final shouldShowUnit = !ParameterEditorRegistry.isStringTypeUnit(
+            parameter.unit,
+          );
+          final unit = shouldShowUnit ? parameter.getUnitString(units) : null;
 
-        return FocusTraversalOrder(
-          order: NumericFocusOrder(index.toDouble()),
-          child: ParameterEditorView(
-            slot: slot,
-            parameterInfo: parameter,
-            value: value,
-            enumStrings: safeEnumStrings,
-            mapping: mapping,
-            valueString: safeValueString,
-            unit: unit,
-          ),
-        );
-      },
-    ),
+          return FocusTraversalOrder(
+            order: NumericFocusOrder(index.toDouble()),
+            child: ParameterEditorView(
+              slot: slot,
+              parameterInfo: parameter,
+              value: value,
+              enumStrings: safeEnumStrings,
+              mapping: mapping,
+              valueString: safeValueString,
+              unit: unit,
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/ui/widgets/step_sequencer/parameter_pages_view.dart
+++ b/lib/ui/widgets/step_sequencer/parameter_pages_view.dart
@@ -48,7 +48,8 @@ class _ParameterPagesViewState extends State<ParameterPagesView>
     ParameterPageAssigner.buildCustomUISet(widget.slot.parameters);
 
     // Parameters handled by custom Step Sequencer UI (to exclude)
-    final customUIParameters = ParameterPageAssigner.getStepSequencerCustomUIParameters();
+    final customUIParameters =
+        ParameterPageAssigner.getStepSequencerCustomUIParameters();
 
     // Filter firmware pages to only include parameters not in custom UI
     _availableFirmwarePages = firmwarePages
@@ -56,10 +57,7 @@ class _ParameterPagesViewState extends State<ParameterPagesView>
           final filteredParams = page.parameters
               .where((paramNum) => !customUIParameters.contains(paramNum))
               .toList();
-          return ParameterPage(
-            name: page.name,
-            parameters: filteredParams,
-          );
+          return ParameterPage(name: page.name, parameters: filteredParams);
         })
         .where((page) => page.parameters.isNotEmpty)
         .toList();
@@ -99,7 +97,10 @@ class _ParameterPagesViewState extends State<ParameterPagesView>
         appBar: AppBar(
           title: const Text('Parameter Pages'),
           leading: IconButton(
-            icon: const Icon(Icons.close, semanticLabel: 'Close parameter pages'),
+            icon: const Icon(
+              Icons.close,
+              semanticLabel: 'Close parameter pages',
+            ),
             onPressed: () => Navigator.of(context).pop(),
           ),
           bottom: TabBar(
@@ -130,7 +131,10 @@ class _ParameterPagesViewState extends State<ParameterPagesView>
             appBar: AppBar(
               title: const Text('Parameter Pages'),
               leading: IconButton(
-                icon: const Icon(Icons.close, semanticLabel: 'Close parameter pages'),
+                icon: const Icon(
+                  Icons.close,
+                  semanticLabel: 'Close parameter pages',
+                ),
                 onPressed: () => Navigator.of(context).pop(),
               ),
               bottom: TabBar(
@@ -235,29 +239,32 @@ class _ParameterPageContent extends StatelessWidget {
       builder: (context, state) {
         // Get current slot and unit strings to refresh parameter values
         final data = state.maybeWhen(
-          synchronized: (
-            disting,
-            distingVersion,
-            firmwareVersion,
-            presetName,
-            algorithms,
-            slots,
-            unitStrings,
-            inputDevice,
-            outputDevice,
-            loading,
-            offline,
-            screenshot,
-            demo,
-            videoStream,
-            availableFirmwareUpdate,
-            perfPageItems,
-            isDirty,
-            renameConfirmationName,
-          ) {
-            final currentSlot = slotIndex < slots.length ? slots[slotIndex] : slot;
-            return (currentSlot, unitStrings);
-          },
+          synchronized:
+              (
+                disting,
+                distingVersion,
+                firmwareVersion,
+                presetName,
+                algorithms,
+                slots,
+                unitStrings,
+                inputDevice,
+                outputDevice,
+                loading,
+                offline,
+                screenshot,
+                demo,
+                videoStream,
+                availableFirmwareUpdate,
+                perfPageItems,
+                isDirty,
+                renameConfirmationName,
+              ) {
+                final currentSlot = slotIndex < slots.length
+                    ? slots[slotIndex]
+                    : slot;
+                return (currentSlot, unitStrings);
+              },
           orElse: () => (slot, <String>[]),
         );
 
@@ -266,6 +273,7 @@ class _ParameterPageContent extends StatelessWidget {
 
         // Use the familiar parameter editor UI
         return ListView.builder(
+          // ignore: deprecated_member_use
           cacheExtent: double.infinity,
           padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
           itemCount: parameterNumbers.length,
@@ -277,7 +285,9 @@ class _ParameterPageContent extends StatelessWidget {
             final value = currentSlot.values.elementAtOrNull(paramNum);
             final enumStrings = currentSlot.enums.elementAtOrNull(paramNum);
             final mapping = currentSlot.mappings.elementAtOrNull(paramNum);
-            final valueString = currentSlot.valueStrings.elementAtOrNull(paramNum);
+            final valueString = currentSlot.valueStrings.elementAtOrNull(
+              paramNum,
+            );
 
             // Skip if we don't have essential data
             if (parameter == null || value == null) {
@@ -285,14 +295,19 @@ class _ParameterPageContent extends StatelessWidget {
             }
 
             // Use filler/empty data if not available
-            final safeEnumStrings = enumStrings ?? ParameterEnumStrings.filler();
-            final safeValueString = valueString ?? ParameterValueString.filler();
+            final safeEnumStrings =
+                enumStrings ?? ParameterEnumStrings.filler();
+            final safeValueString =
+                valueString ?? ParameterValueString.filler();
 
             // For string-type parameters, don't fetch unit - they use value strings
             // The registry handles firmware version differences automatically
-            final shouldShowUnit =
-                !ParameterEditorRegistry.isStringTypeUnit(parameter.unit);
-            final unit = shouldShowUnit ? parameter.getUnitString(unitStrings) : null;
+            final shouldShowUnit = !ParameterEditorRegistry.isStringTypeUnit(
+              parameter.unit,
+            );
+            final unit = shouldShowUnit
+                ? parameter.getUnitString(unitStrings)
+                : null;
 
             // Use the familiar ParameterEditorView widget
             return ParameterEditorView(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -728,10 +728,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   midi:
     dependency: "direct overridden"
     description:
@@ -1310,26 +1310,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   tuple:
     dependency: transitive
     description:

--- a/specs/2026-05-22_multi-algorithm-templates.md
+++ b/specs/2026-05-22_multi-algorithm-templates.md
@@ -1,0 +1,369 @@
+# Multi-Algorithm Template System
+
+## Context
+
+Today's "template" feature is binary: every preset marked `isTemplate = true` (`lib/db/tables.dart:136`) is treated as an indivisible kit. Users can either:
+
+- **Load** the whole template into the device (replaces preset state via `loadPresetToDevice` / `loadPresetOffline`), or
+- **Inject** the whole template into the device, appending every slot of the template after the current slots (`MetadataSyncCubit.injectTemplateToDevice`, `lib/ui/metadata_sync/metadata_sync_cubit.dart:689`).
+
+Both flows are all-or-nothing. A user with a 10-slot template containing a delay, a chorus, and a reverb cannot ask for "just the delay and reverb." They cannot organize their library beyond the alphabetical order of preset names. They cannot annotate a template with its purpose or author.
+
+The goal of this spec is to make templates **partially applicable** (pick which slots), **organizable** (category + structured metadata), and **scriptable** (an MCP tool that mirrors `injectTemplateToDevice` but accepts a slot selection). The full-template injection path (`injectTemplateToDevice`) stays as a no-arg degenerate case.
+
+All work happens against the schema described in `lib/db/database.dart` (schema version 11 today, targeting 12) and the DAO surface in `lib/db/daos/presets_dao.dart`.
+
+---
+
+## Approach
+
+### 1. Database — schema v12
+
+**File:** `lib/db/tables.dart` (table definition) + `lib/db/database.dart` (migration step)
+
+Add two columns to `Presets`:
+
+```dart
+@DataClassName('PresetEntry')
+class Presets extends Table {
+  IntColumn  get id            => integer().autoIncrement()();
+  TextColumn get name          => text()();
+  DateTimeColumn get lastModified => dateTime().withDefault(currentDateAndTime)();
+  BoolColumn get isTemplate    => boolean().withDefault(const Constant(false))();
+  TextColumn get category      => text().nullable()();             // NEW
+  TextColumn get templateMetadata => text().nullable()();          // NEW — JSON text
+}
+```
+
+- `category` is a free-form short string ("Drums", "Voice", "Generative", …). Nullable. Empty string normalized to null on write. SQLite has no enum so we keep it free-form; the UI suggests existing categories via autocomplete.
+- `templateMetadata` is JSON serialized as text (SQLite has no `jsonb`). Schema:
+  ```json
+  {
+    "description": "string?",
+    "tags": ["string"],
+    "author": "string?",
+    "createdAt": "ISO-8601 string?",   // distinct from lastModified; survives renames
+    "schemaVersion": 1                  // internal — for forward evolution
+  }
+  ```
+  Unknown top-level keys are preserved on read by stashing them on the `TemplateMetadata.extras` field; on write, `extras` are merged back into the JSON object. Reads behave as follows:
+  - **`null` or empty string** → `TemplateMetadata.empty()` (no log).
+  - **Valid JSON but missing keys** → known keys default to null/empty list; unknown keys go to `extras`.
+  - **Malformed JSON** → return `TemplateMetadata.empty()` (no `extras` recovery — the bytes are lost). Emit a single `debugPrint` per offending preset id per process (debounced via a small in-memory set on the converter).
+  All values are UTF-8; the database column is `TEXT` which Drift treats as UTF-8 by default. Strings round-trip including null bytes and high-codepoint characters.
+
+Both columns are **only meaningful when `isTemplate = true`**. We do not enforce that constraint at the DB level (it would complicate the upgrade); the UI surfaces them in the Template Manager only.
+
+#### Migration step (database.dart `onUpgrade`)
+
+```dart
+if (from <= 11) {
+  try { await m.addColumn(presets, presets.category); } catch (_) {}
+  try { await m.addColumn(presets, presets.templateMetadata); } catch (_) {}
+}
+```
+
+Both columns are nullable with no default, so existing rows remain untouched. Bump `schemaVersion` to `12`. The `try/catch (_)` pattern matches the prevailing style for resilience against partial upgrades.
+
+Add a Drift schema test mirroring `test/db/io_flags_migration_test.dart` that:
+
+- Asserts `schemaVersion == 12`.
+- Verifies a fresh DB has both columns and they accept `null`.
+- Verifies a v11 → v12 in-place upgrade preserves existing template rows and adds the columns. (Use Drift's `m.runMigrationSteps` with a manually-constructed v11 schema or the existing schema snapshot tooling if present; if not, the freshly created v12 schema is sufficient and we note the limitation.)
+
+### 2. DAO — `applyTemplateSlots`
+
+**File:** `lib/db/daos/presets_dao.dart`
+
+Add the partial-application method. The DAO-side name keeps the "Slots" suffix (it operates on slot rows); cubit-side names use "ToPreset" / "ToDevice" (they describe outcomes). The two layers are intentionally named differently to make the layering obvious in code search.
+
+```dart
+Future<ApplyTemplateSlotsResult> applyTemplateSlots({
+  required int templateId,
+  required int targetPresetId,
+  required List<int> templateSlotIndices,   // 0-based positions WITHIN the template
+  required int insertionOffset,             // target slot index where the first copied slot lands
+  bool overwrite = false,                   // false = insert and shift; true = replace at offset
+});
+```
+
+Return value:
+
+```dart
+class ApplyTemplateSlotsResult {
+  final int targetPresetId;
+  final List<int> insertedSlotIndices;          // new slotIndex values in the target preset
+  final List<int> skippedTemplateSlotIndices;   // requested but not applied (e.g., missing algorithm)
+  final String? warning;                        // user-facing, non-fatal
+}
+```
+
+#### Semantics
+
+- **Argument validation (pre-transaction).**
+  - Empty `templateSlotIndices` → throw `ArgumentError` (UI must prevent this).
+  - Any index outside `[0, template.slots.length)` → `ArgumentError`.
+  - Negative `insertionOffset` → `ArgumentError`.
+  - `templateSlotIndices` may contain duplicates; duplicates expand to multiple copies in output order.
+- **Transactional snapshot (first DB read inside `transaction()`).** Even when `templateId != targetPresetId`, read the source template's slots, params, strings, mappings, and routings into memory **first**, so subsequent writes to the target cannot disturb the data being copied. This snapshot is also what self-application uses.
+- **Space check (after snapshot, before any writes).** Read all `PresetSlots` for `targetPresetId`. Let `existing = count`. The applied count is `templateSlotIndices.length`. In `overwrite = false` (insert) mode, `existing + applied` must be ≤ 32. In `overwrite = true` (replace) mode, `max(existing, insertionOffset + applied)` must be ≤ 32. If either limit is exceeded, throw `TemplateSpaceException` with the diagnostic numbers (current/applied/total/limit). The UI catches and renders.
+- **Algorithm availability.** Every template slot's `algorithmGuid` must exist in the local `algorithms` table. Missing guids cause that slot to be added to `skippedTemplateSlotIndices` with the warning string populated; the rest still apply. (Mirrors the metadata-availability check in `injectTemplateToDevice`.) The applied count for the space check uses `templateSlotIndices.length - skippedCount`.
+- **Insertion offset clamping.** `insertionOffset` is clamped to `[0, existing]` based on the **pre-write** `existing` count. In insert mode, values past `existing` effectively append.
+- **Insert mode (`overwrite = false`).** Shift any existing target slots with `slotIndex >= insertionOffset` upward by `applied` (= non-skipped count). Then insert the copied slots starting at `insertionOffset`.
+- **Replace mode (`overwrite = true`).** For each `i` in `0..applied-1`, the target slot at `insertionOffset + i` is replaced. If a position is empty, just insert. No shifting.
+- **Explicit child-row cleanup in replace mode.** The current schema declares `onDelete: KeyAction.cascade` only on `PresetParameterValues` and `PresetParameterStringValues` (`lib/db/tables.dart:156, 172`); `PresetMappings` and `PresetRoutings` do **not** cascade. So replace-mode deletion of a target `PresetSlots` row must be preceded by explicit `delete()` calls on both non-cascading child tables, scoped to that slot id. The implementation reuses the same `batch.deleteWhere` pattern already in `saveFullPreset` (`lib/db/daos/presets_dao.dart:284–296`) and extends it to include `presetRoutings`.
+- **Slot copy fidelity.** Each copied slot duplicates:
+  - `algorithmGuid`, `customName` (verbatim — including null);
+  - all `PresetParameterValues` rows;
+  - all `PresetParameterStringValues` rows;
+  - all `PresetMappings` rows (including `perfPageIndex`);
+  - `PresetRoutings` row, if present.
+  New rows reference the newly-inserted slot's `id`. All packed mapping bytes round-trip via the existing `PackedMappingDataConverter` — we never decode/re-encode. `customName` strings are copied verbatim; we do not truncate or validate length (the firmware imposes its own limit, which the existing send-slot-name path already handles).
+- **Atomicity.** The whole operation runs in a single `transaction()`. On any exception, no partial mutation is visible. `lastModified` on the target preset is bumped to `DateTime.now()`.
+- **Idempotency.** Repeated calls with the same arguments append additional copies — they are not deduplicated. The UI must guard against double-clicks (loading state on the dialog, button disabled during apply).
+
+#### `TemplateSpaceException`
+
+A dedicated exception type so the cubit/UI can distinguish space failures from generic errors. Defined in `lib/db/daos/presets_dao.dart` alongside the DAO.
+
+```dart
+class TemplateSpaceException implements Exception {
+  final int current;
+  final int applied;
+  final int limit;
+  TemplateSpaceException({required this.current, required this.applied, this.limit = 32});
+  @override String toString() => 'Cannot apply: $current + $applied > $limit slots';
+}
+```
+
+#### Unit tests (`test/db/daos/presets_dao_test.dart`)
+
+- Apply 3 of 5 template slots, insert mode, into an empty target → target has 3 slots in indices 0..2 with correct params/mappings.
+- Apply into the middle of a 4-slot target → shifts subsequent slots correctly; their `id` and child rows survive.
+- Replace mode at offset 2 of a 4-slot target → slots 2..N replaced; the previously-present `PresetMappings` and `PresetRoutings` rows for the replaced slots are gone (regression guard for the explicit child-row cleanup).
+- Apply 30 slots into a 5-slot target → throws `TemplateSpaceException`, no mutation (asserted via row counts on every involved table).
+- Apply a template containing an algorithm whose guid is not in `algorithms` → that slot is skipped, others succeed, warning populated, space check uses non-skipped count.
+- Self-application: `templateId == targetPresetId`, all slots → produces 2× slot count with correctly copied params/mappings (the in-memory snapshot pattern is the unit under test).
+- Apply with duplicate indices `[2, 2, 2]` → produces 3 identical copies of slot 2 in the target.
+- Apply with `insertionOffset = 999` into a 4-slot target, insert mode → clamps to append; target has 4 + applied slots.
+- Empty `templateSlotIndices` → throws `ArgumentError`; we treat empty selection as a programmer error since the UI must prevent it.
+
+### 3. Cubit — wiring
+
+**File:** `lib/ui/metadata_sync/metadata_sync_cubit.dart`
+
+Add two thin orchestration methods that wrap the DAO and (where applicable) the device:
+
+```dart
+Future<ApplyTemplateSlotsResult> applyTemplateToPreset({
+  required int templateId,
+  required int targetPresetId,
+  required List<int> templateSlotIndices,
+  required int insertionOffset,
+  bool overwrite = false,
+});
+
+Future<void> applyTemplateToDevice({
+  required FullPresetDetails template,
+  required List<int> templateSlotIndices,
+  required IDistingMidiManager manager,
+});
+```
+
+- `applyTemplateToPreset` calls the new DAO method and emits `viewingLocalData` on success. The DAO `ApplyTemplateSlotsResult` flows out unchanged so the UI can render `skippedTemplateSlotIndices` and any `warning`. A `TemplateSpaceException` is caught at this layer and re-emitted as `metadataSyncFailure(formattedMessage)`. The DAO transaction is not cancellable; the UI disables the apply button for the duration and surfaces a spinner.
+- `applyTemplateToDevice` is a **refactor of the existing `injectTemplateToDevice` body** to take an explicit slot-index list:
+  - The existing `_isInjectionCancelled` flag, initialization, and check sites stay. Setting `_isInjectionCancelled = false` at entry means a previously-cancelled state from a prior run does not bleed into the next call.
+  - The method is **not re-entrant**: a guard at the top short-circuits with a thrown exception if a prior `applyTemplateToDevice` is still running (tracked by a new private `_isInjectionRunning` boolean, paired with a `try/finally`). The UI disables the button in any case; this guard catches MCP/UI races.
+  - Stale-template guard: `FullPresetDetails template` is captured by value at call time; the method does not re-fetch the template from the DB during the apply. Any concurrent edit to the source template is invisible to the in-flight apply (consistent with current behavior).
+  - Progress emission: between algorithm-add operations, emit a new state `MetadataSyncState.injectingTemplate(applied, total)` (added to the state union) so the dialog can render `Adding 2 of 5…`. Existing `loadingPreset` is replaced by the first `injectingTemplate(0, total)` emission. The final success path still emits `presetLoadSuccess`.
+  - Per-slot device error: if a single `requestAddAlgorithm` / `setParameterValue` call throws, the method throws as today; the caught error message includes how many slots were applied before the failure (so the user knows the device is in a partially-modified state). No automatic rollback — the device is not transactional.
+  - The existing `injectTemplateToDevice(template, manager)` becomes a one-liner that calls the new method with `[0..template.slots.length-1]`. Its public signature, callers, and existing tests remain valid.
+
+This is the minimum surface change to support partial injection without forking the device protocol.
+
+### 4. UI — Template Manager view
+
+**File:** `lib/ui/template_manager/template_manager_screen.dart` (new) + small entry points in `lib/ui/metadata_sync/metadata_sync_page.dart` and `lib/disting_app.dart`.
+
+The existing **Templates** tab in `metadata_sync_page.dart` (line 821, `_TemplateListView`) **stays**. It is the quick "load / inject / delete" surface. We add a new full-screen route — the *Template Manager* — for organization and partial application.
+
+#### Entry points
+
+- A new menu item under the existing settings/template menu: "Template Manager…" pushes `MaterialPageRoute(builder: (_) => const TemplateManagerScreen())`.
+- An icon button in the Templates tab header that opens the same route.
+
+#### Layout
+
+A two-pane screen (single column on narrow):
+
+- **Left pane — template list.** `FutureBuilder` over `presetsDao.getTemplates()`. Grouped by `category` (templates with null category fall under "Uncategorized"). Each row shows name, slot count, and a small badge with the first tag. Selecting a template populates the right pane. A toolbar above the list offers: New from current preset, Edit metadata, Delete, Refresh.
+- **Right pane — template detail + apply.**
+  - Header: name (editable inline), category dropdown (suggestions from existing categories + free-text), description text field, tags chip input, author text field.
+  - Slot table: `slotIndex`, algorithm name, customName, parameter count, mapping count. Each row has a leading checkbox. "Select all" and "Select none" controls live in the table header. Search field filters by algorithm name.
+  - Apply controls:
+    - **Target** dropdown: "Current device preset", "New local preset…", or any existing non-template preset.
+    - **Insertion offset** numeric field (default = current target slot count = append). Hidden when target is "New local preset…".
+    - **Mode** segmented control: Insert (default) / Replace.
+    - **Apply selected** button (disabled when zero checked or space check would fail). A small live readout shows `selected × current + selected ≤ 32 ✓` style status.
+
+#### Apply flow
+
+`TemplateApplyDialog.show(context, …)` confirms the action and routes:
+
+- Target = current device → `metadataSyncCubit.applyTemplateToDevice(template, selectedIndices, manager)`.
+- Target = existing local preset → `metadataSyncCubit.applyTemplateToPreset(templateId, targetId, selectedIndices, offset, overwrite)`.
+- Target = new local preset → creates an empty preset via `presetsDao.saveFullPreset` with an empty slot list, then applies.
+
+The dialog handles four states (idle / loading-with-progress / partial-success / error):
+
+- **Idle** — confirmation summary with selected count, target, offset, and mode.
+- **Loading-with-progress** — `BlocBuilder` over `MetadataSyncState.injectingTemplate(applied, total)` renders a linear progress bar with `applied / total`. A **Cancel** button calls `metadataSyncCubit.cancelInjection()` for the device path; for the preset path the button is hidden because the DAO transaction is not interruptible.
+- **Partial-success** — surfaced when `ApplyTemplateSlotsResult.skippedTemplateSlotIndices` is non-empty: shows the warning string and an enumerated list of skipped algorithm names. The user explicitly dismisses; the apply already committed.
+- **Error** — shows the formatted message. `TemplateSpaceException` is rendered with the diagnostic numbers prominently.
+
+Apply-button safeguards (to address rapid double-tap / re-entrance):
+
+- The button is disabled the moment the user taps it; re-enabled only after the operation resolves (success, partial, or error). Tracked via local `bool _inFlight` state.
+- A `PopScope(canPop: !_inFlight)` blocks back-button dismissal while the device apply is running (preset apply completes in a single transaction and is fast — no special handling needed).
+- If the route pops while the device apply is still running (e.g., the dialog hosts a long-running apply and the user force-closes via navigator), the cancel flag is set in `dispose()` so the cubit terminates cleanly. The user sees the partial-success or error state on the underlying screen via the `MetadataSyncState` listener.
+
+#### Create-template dialog
+
+`CreateTemplateFromPresetDialog.show(context, sourcePreset)` is a separate dialog reached from the toolbar's "New from current preset" action. It:
+
+1. Loads the source preset details at open time:
+   - If the source is the live device, it calls the existing read path used by `synchronized_screen` to materialize a `FullPresetDetails` snapshot **once at open**. Subsequent live edits to the device while the dialog is open are not reflected. A small "Refresh" button at the top of the slot list re-snapshots on demand. (We accept staleness as the cost of letting the user think — the alternative is a constantly-shifting checkbox list.)
+   - If the source is a saved local preset, it calls `presetsDao.getFullPresetDetails`.
+2. Shows a slot table with checkboxes (re-using the same widget as the manager's slot table — extracted into `TemplateSlotSelectionList`).
+3. Prompts for name, category, description, tags, author.
+4. On confirm, deep-copies the selected slots into a new `PresetEntry` with `isTemplate = true` and the entered metadata, via the existing `saveFullPreset(... isTemplate: true)`. The new `category` and `templateMetadata` columns are set via the `PresetEntry` companion (Drift regenerates `PresetsCompanion` to include them once `build_runner` runs in the worktree — running `dart run build_runner build --delete-conflicting-outputs` is a prerequisite before `flutter analyze`, per CLAUDE.md).
+
+The `TemplateSlotSelectionList` widget is the partial-selection analogue of `CollectionExpansionPanel` (`lib/ui/widgets/collection_expansion_panel.dart`): search field, select-all/none, checkbox rows. It is extracted because both the Template Manager right pane and the Create-from-preset dialog use the exact same slot picker; inlining the same ~100 lines twice would invite drift between the two callers.
+
+#### Widget tests
+
+`test/ui/template_manager/`:
+
+- `template_manager_screen_test.dart` — renders, groups by category, filters by search.
+- `template_slot_selection_list_test.dart` — checkbox toggling, select all / none, space-check readout.
+- `template_apply_dialog_test.dart` — happy path, space failure, cancellation.
+- `create_template_from_preset_dialog_test.dart` — emits expected `FullPresetDetails` payload to a captured DAO mock.
+
+### 5. MCP tool — `apply_template_to_preset`
+
+**Files:** `lib/mcp/tools/disting_tools.dart` (handler) + `lib/mcp/tool_registry.dart` (registration in `_registerPresetTools()` or a new `_registerTemplateTools()`).
+
+Input schema:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "template_id":    {"type": "integer", "description": "Template preset id."},
+    "template_name":  {"type": "string",  "description": "Alternative to template_id; resolved by exact match, then case-insensitive."},
+    "slot_indices":   {"type": "array",  "items": {"type": "integer", "minimum": 0}, "description": "Which template slots to apply. Omit to apply all."},
+    "target":         {"type": "string", "enum": ["device", "preset"], "description": "Where to apply. Default: device."},
+    "target_preset_id":   {"type": "integer", "description": "Required when target is 'preset'."},
+    "target_preset_name": {"type": "string",  "description": "Alternative to target_preset_id."},
+    "insertion_offset":   {"type": "integer", "description": "Slot index in target. Default: append (device) or 0 (new preset)."},
+    "overwrite":      {"type": "boolean", "description": "Replace target slots starting at insertion_offset. Default: false."}
+  },
+  "required": []
+}
+```
+
+Handler:
+
+- Resolves the template:
+  - `template_id` → looked up directly; row must have `isTemplate = true` or error.
+  - else `template_name` → case-sensitive exact match first; if zero matches, fall back to case-insensitive exact match; if zero or more than one match, return an error listing the candidate names and asking the caller to use `template_id`.
+  - Returns the standard `MCPUtils.buildError` envelope on failure.
+- Validates `slot_indices` are within `[0, template.slots.length)`. Default = all. Duplicates allowed (pass through to DAO).
+- Branches by `target`:
+  - `device`: calls `metadataSyncCubit.applyTemplateToDevice(template, selectedIndices, manager)` after refusing offline mode (returns an error explaining that device mode is required).
+  - `preset`: resolves target preset by id or name (same algorithm as template resolution; `isTemplate` constraint reversed — target preset must have `isTemplate = false`, unless the target is the same id as the source for self-extension). Calls `applyTemplateToPreset`. Cross-template application via MCP is forbidden for simplicity.
+- Response payload mirrors the DAO result. Field names in the response are the snake_case of the Dart fields, but `inserted_slot_indices.length` is also surfaced as `applied_slot_count` for ergonomics:
+  ```json
+  {
+    "success": true,
+    "target": "device|preset",
+    "target_preset_id": 42,
+    "applied_slot_count": 3,
+    "inserted_slot_indices": [5, 6, 7],
+    "skipped_template_slot_indices": [1],
+    "warning": "Slot 1 (guid abc) skipped: algorithm metadata missing locally."
+  }
+  ```
+  On `TemplateSpaceException`: `{"success": false, "error": "space", "current": N, "applied": M, "limit": 32}` so the caller can reason about it without parsing prose.
+- All keys via `convertToSnakeCaseKeys`. Timeout: 30 s for `target == "preset"` (matches `edit_preset`/`new`); 120 s for `target == "device"` because each algorithm-add can take 0.5–10 s for community plugins.
+- Partial-success on device: if the device path throws mid-apply, return `{"success": false, "error": "partial_apply", "applied_slot_count": N, "message": "..."}`. The caller is expected to inspect the device state via `show_preset` to confirm.
+
+MCP doc updates:
+
+- Append a section to `docs/mcp-api-guide.md` describing the new tool.
+- Cross-link from `docs/mcp-mapping-guide.md` if relevant.
+
+### 6. Existing-behavior shims & migration safety
+
+- `injectTemplateToDevice` keeps its public signature. Internally it becomes:
+  ```dart
+  Future<void> injectTemplateToDevice(template, manager) =>
+      applyTemplateToDevice(
+        template: template,
+        templateSlotIndices: List.generate(template.slots.length, (i) => i),
+        manager: manager,
+      );
+  ```
+- `TemplatePreviewDialog` and the `_TemplateListView` "Inject Template" path keep working unchanged.
+- `saveFullPreset` keeps its current signature; the new columns are pulled from `details.preset` via the standard companion path (Drift regenerates the companions to include `category` and `templateMetadata` after `build_runner` runs in the worktree).
+
+---
+
+## Critical Files
+
+| File | Change |
+|---|---|
+| `lib/db/tables.dart` | Add `category` + `templateMetadata` to `Presets`. |
+| `lib/db/database.dart` | Bump `schemaVersion` to 12. Add migration step. |
+| `lib/db/daos/presets_dao.dart` | Add `applyTemplateSlots`, `ApplyTemplateSlotsResult`, `TemplateSpaceException`. |
+| `lib/models/template_metadata.dart` (new) | `TemplateMetadata` data class: `description`, `tags`, `author`, `createdAt`, `extras` map. Includes `fromJsonString(String?)` / `toJsonString()` static helpers used by callers when reading/writing the `templateMetadata` text column. No Drift `TypeConverter` — the column stores raw JSON text so existing queries and the schema test work without converter wiring, and the conversion happens at the cubit/DAO call sites. |
+| `lib/ui/metadata_sync/metadata_sync_cubit.dart` | Add `applyTemplateToPreset` + `applyTemplateToDevice`. Refactor `injectTemplateToDevice` to delegate. |
+| `lib/ui/template_manager/template_manager_screen.dart` (new) | Two-pane template manager. |
+| `lib/ui/template_manager/template_slot_selection_list.dart` (new) | Reusable slot picker widget. |
+| `lib/ui/template_manager/template_apply_dialog.dart` (new) | Apply confirmation + progress dialog. |
+| `lib/ui/template_manager/create_template_from_preset_dialog.dart` (new) | Create-from-current dialog. |
+| `lib/ui/metadata_sync/metadata_sync_page.dart` | Add toolbar button entry to Template Manager. |
+| `lib/disting_app.dart` | Add menu route. |
+| `lib/mcp/tools/disting_tools.dart` | Add `applyTemplateToPreset` handler. |
+| `lib/mcp/tool_registry.dart` | Register `apply_template_to_preset`. |
+| `docs/mcp-api-guide.md` | Document the new tool. |
+| `test/db/migrations/v11_to_v12_template_metadata_test.dart` (new) | Schema test. |
+| `test/db/daos/presets_dao_test.dart` | Add `applyTemplateSlots` cases. |
+| `test/ui/template_manager/*` (new) | Widget tests for new dialogs/screen. |
+| `test/mcp/tools/apply_template_tool_test.dart` (new) | Tool happy path + error envelopes. |
+
+## No changes to
+
+- `lib/cubit/disting_cubit.dart` and any of its delegates/mixins. Templates remain a metadata-sync surface; the main cubit orchestrates the device, not template application.
+- `lib/core/routing/` — the copy preserves routing rows verbatim; no routing logic touched.
+- `lib/services/mcp_server_service.dart` other than picking up the new entry from the registry.
+- The existing `_TemplateListView` Inject / Load / Delete buttons — no behavioral changes.
+
+---
+
+## Open questions (documented, not punted)
+
+1. **Category vs. tags.** We keep both. `category` is a single string for grouping in the manager left pane; `tags` is a flexible list inside `templateMetadata`. If user feedback shows they overlap, we can collapse later — additive design now.
+2. **Cross-device portability.** Out of scope. Templates remain device-local. Exporting templates to JSON/file is a follow-up.
+3. **Schema-versioning the metadata JSON.** Included a `schemaVersion: 1` field so we can evolve without another DB migration.
+4. **Worktree generated files.** `dart run build_runner build --delete-conflicting-outputs` must be run in the worktree before `flutter analyze` / `flutter test`, both for the Drift companions (new `category` / `templateMetadata` columns) and the Mockito mocks for the new cubit method. This is the same constraint already documented in `CLAUDE.md` — repeating it here so the executing engineer doesn't trip over Drift "column not found" errors on first build.
+5. **No cancellation for the preset path.** `applyTemplateToPreset` runs inside a Drift transaction and cannot be cancelled mid-flight. This is deliberate: SQLite operations on this workload are sub-second, and adding cooperative cancellation would couple the DAO to UI lifecycle. If a future preset becomes very large (>1000 slots — implausible given the 32-slot device limit), revisit.
+
+## Out of scope
+
+- Multi-template merge (applying slots from N templates at once). The UI applies one template at a time.
+- Reordering / renumbering slots within a template (the existing preset editor handles that on the saved-as-template preset).
+- Template export/import as JSON files.
+- Sharing templates across users / cloud storage.
+- Changes to the existing `_TemplateListView` Inject button (still applies the whole template).
+- Performance pages — the perf-page index is preserved per-slot via the existing `PackedMappingData` round-trip; no new perf-page logic.

--- a/test/db/daos/apply_template_slots_test.dart
+++ b/test/db/daos/apply_template_slots_test.dart
@@ -1,0 +1,828 @@
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/db/daos/presets_dao.dart';
+import 'package:nt_helper/models/packed_mapping_data.dart';
+
+PackedMappingData _mapping({
+  int source = 1,
+  int delta = 10,
+  int perfPageIndex = 0,
+  int midiCC = 64,
+}) {
+  return PackedMappingData(
+    source: source,
+    cvInput: 2,
+    isUnipolar: false,
+    isGate: false,
+    volts: 5,
+    delta: delta,
+    midiChannel: 1,
+    midiMappingType: MidiMappingType.cc,
+    midiCC: midiCC,
+    isMidiEnabled: true,
+    isMidiSymmetric: false,
+    isMidiRelative: false,
+    midiMin: 0,
+    midiMax: 127,
+    i2cCC: 32,
+    isI2cEnabled: false,
+    isI2cSymmetric: false,
+    i2cMin: 0,
+    i2cMax: 16383,
+    perfPageIndex: perfPageIndex,
+    version: 5,
+  );
+}
+
+FullPresetSlot _slot({
+  required int slotIndex,
+  required String guid,
+  String? customName,
+  Map<int, int>? values,
+  Map<int, String>? strings,
+  Map<int, PackedMappingData>? mappings,
+}) {
+  return FullPresetSlot(
+    slot: PresetSlotEntry(
+      id: -1,
+      presetId: -1,
+      slotIndex: slotIndex,
+      algorithmGuid: guid,
+      customName: customName,
+    ),
+    algorithm: AlgorithmEntry(
+      guid: guid,
+      name: 'Alg $guid',
+      numSpecifications: 0,
+      pluginFilePath: null,
+    ),
+    parameterValues: values ?? {},
+    parameterStringValues: strings ?? {},
+    mappings: mappings ?? {},
+  );
+}
+
+Future<int> _savePreset(
+  AppDatabase db,
+  String name, {
+  bool isTemplate = false,
+  List<FullPresetSlot> slots = const [],
+}) async {
+  return db.presetsDao.saveFullPreset(
+    FullPresetDetails(
+      preset: PresetEntry(
+        id: -1,
+        name: name,
+        lastModified: DateTime.now(),
+        isTemplate: false,
+      ),
+      slots: slots,
+    ),
+    isTemplate: isTemplate,
+  );
+}
+
+Future<void> _seedAlgorithm(AppDatabase db, String guid) async {
+  await db.metadataDao.upsertAlgorithms([
+    AlgorithmEntry(
+      guid: guid,
+      name: 'Alg $guid',
+      numSpecifications: 0,
+      pluginFilePath: null,
+    ),
+  ]);
+}
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('PresetsDao.applyTemplateSlots — argument validation', () {
+    test('empty templateSlotIndices throws ArgumentError', () async {
+      await _seedAlgorithm(db, 'AAAA');
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [_slot(slotIndex: 0, guid: 'AAAA')],
+      );
+      final targetId = await _savePreset(db, 'Target');
+
+      expect(
+        () => db.presetsDao.applyTemplateSlots(
+          templateId: templateId,
+          targetPresetId: targetId,
+          templateSlotIndices: const [],
+          insertionOffset: 0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('index out of range throws ArgumentError', () async {
+      await _seedAlgorithm(db, 'AAAA');
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [_slot(slotIndex: 0, guid: 'AAAA')],
+      );
+      final targetId = await _savePreset(db, 'Target');
+
+      expect(
+        () => db.presetsDao.applyTemplateSlots(
+          templateId: templateId,
+          targetPresetId: targetId,
+          templateSlotIndices: const [3],
+          insertionOffset: 0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('negative insertionOffset throws ArgumentError', () async {
+      await _seedAlgorithm(db, 'AAAA');
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [_slot(slotIndex: 0, guid: 'AAAA')],
+      );
+      final targetId = await _savePreset(db, 'Target');
+
+      expect(
+        () => db.presetsDao.applyTemplateSlots(
+          templateId: templateId,
+          targetPresetId: targetId,
+          templateSlotIndices: const [0],
+          insertionOffset: -1,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('unknown templateId throws StateError', () async {
+      final targetId = await _savePreset(db, 'Target');
+      expect(
+        () => db.presetsDao.applyTemplateSlots(
+          templateId: 9999,
+          targetPresetId: targetId,
+          templateSlotIndices: const [0],
+          insertionOffset: 0,
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('unknown targetPresetId throws StateError', () async {
+      await _seedAlgorithm(db, 'AAAA');
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [_slot(slotIndex: 0, guid: 'AAAA')],
+      );
+      expect(
+        () => db.presetsDao.applyTemplateSlots(
+          templateId: templateId,
+          targetPresetId: 9999,
+          templateSlotIndices: const [0],
+          insertionOffset: 0,
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+
+  group('PresetsDao.applyTemplateSlots — insert mode', () {
+    test('applies 3 of 5 slots into empty target', () async {
+      for (final g in const ['AAAA', 'BBBB', 'CCCC', 'DDDD', 'EEEE']) {
+        await _seedAlgorithm(db, g);
+      }
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [
+          _slot(
+            slotIndex: 0,
+            guid: 'AAAA',
+            values: {1: 11},
+            strings: {2: 'a-string'},
+            mappings: {3: _mapping(source: 11)},
+          ),
+          _slot(slotIndex: 1, guid: 'BBBB', values: {1: 22}),
+          _slot(slotIndex: 2, guid: 'CCCC', values: {1: 33}),
+          _slot(slotIndex: 3, guid: 'DDDD'),
+          _slot(slotIndex: 4, guid: 'EEEE'),
+        ],
+      );
+      final targetId = await _savePreset(db, 'Target');
+
+      final result = await db.presetsDao.applyTemplateSlots(
+        templateId: templateId,
+        targetPresetId: targetId,
+        templateSlotIndices: const [0, 2, 4],
+        insertionOffset: 0,
+      );
+
+      expect(result.targetPresetId, targetId);
+      expect(result.skippedTemplateSlotIndices, isEmpty);
+      expect(result.insertedSlotIndices, [0, 1, 2]);
+
+      final loaded = await db.presetsDao.getFullPresetDetails(targetId);
+      expect(loaded, isNotNull);
+      expect(loaded!.slots, hasLength(3));
+      expect(loaded.slots[0].algorithm.guid, 'AAAA');
+      expect(loaded.slots[0].parameterValues[1], 11);
+      expect(loaded.slots[0].parameterStringValues[2], 'a-string');
+      expect(loaded.slots[0].mappings[3]?.source, 11);
+      expect(loaded.slots[1].algorithm.guid, 'CCCC');
+      expect(loaded.slots[1].parameterValues[1], 33);
+      expect(loaded.slots[2].algorithm.guid, 'EEEE');
+    });
+
+    test('inserts into middle and shifts existing slots upward', () async {
+      for (final g in const ['AAAA', 'BBBB', 'CCCC', 'DDDD']) {
+        await _seedAlgorithm(db, g);
+      }
+      await _seedAlgorithm(db, 'TARG');
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [
+          _slot(slotIndex: 0, guid: 'AAAA'),
+          _slot(slotIndex: 1, guid: 'BBBB'),
+        ],
+      );
+      final targetId = await _savePreset(
+        db,
+        'Target',
+        slots: [
+          _slot(slotIndex: 0, guid: 'TARG', values: {1: 100}),
+          _slot(slotIndex: 1, guid: 'TARG', values: {1: 200}),
+          _slot(slotIndex: 2, guid: 'TARG', values: {1: 300}),
+          _slot(slotIndex: 3, guid: 'TARG', values: {1: 400}),
+        ],
+      );
+
+      final result = await db.presetsDao.applyTemplateSlots(
+        templateId: templateId,
+        targetPresetId: targetId,
+        templateSlotIndices: const [0, 1],
+        insertionOffset: 2,
+      );
+
+      expect(result.insertedSlotIndices, [2, 3]);
+      final loaded = await db.presetsDao.getFullPresetDetails(targetId);
+      expect(loaded!.slots, hasLength(6));
+      expect(loaded.slots[0].algorithm.guid, 'TARG');
+      expect(loaded.slots[0].parameterValues[1], 100);
+      expect(loaded.slots[1].algorithm.guid, 'TARG');
+      expect(loaded.slots[1].parameterValues[1], 200);
+      expect(loaded.slots[2].algorithm.guid, 'AAAA');
+      expect(loaded.slots[3].algorithm.guid, 'BBBB');
+      expect(loaded.slots[4].algorithm.guid, 'TARG');
+      expect(loaded.slots[4].parameterValues[1], 300);
+      expect(loaded.slots[5].algorithm.guid, 'TARG');
+      expect(loaded.slots[5].parameterValues[1], 400);
+    });
+
+    test('insertionOffset past end clamps to append', () async {
+      await _seedAlgorithm(db, 'AAAA');
+      await _seedAlgorithm(db, 'TARG');
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [_slot(slotIndex: 0, guid: 'AAAA')],
+      );
+      final targetId = await _savePreset(
+        db,
+        'Target',
+        slots: [
+          _slot(slotIndex: 0, guid: 'TARG'),
+          _slot(slotIndex: 1, guid: 'TARG'),
+          _slot(slotIndex: 2, guid: 'TARG'),
+          _slot(slotIndex: 3, guid: 'TARG'),
+        ],
+      );
+
+      final result = await db.presetsDao.applyTemplateSlots(
+        templateId: templateId,
+        targetPresetId: targetId,
+        templateSlotIndices: const [0],
+        insertionOffset: 999,
+      );
+
+      expect(result.insertedSlotIndices, [4]);
+      final loaded = await db.presetsDao.getFullPresetDetails(targetId);
+      expect(loaded!.slots, hasLength(5));
+      expect(loaded.slots[4].algorithm.guid, 'AAAA');
+    });
+
+    test('duplicate indices produce multiple copies in order', () async {
+      await _seedAlgorithm(db, 'AAAA');
+      await _seedAlgorithm(db, 'BBBB');
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [
+          _slot(slotIndex: 0, guid: 'AAAA'),
+          _slot(slotIndex: 1, guid: 'BBBB', customName: 'two', values: {7: 77}),
+          _slot(slotIndex: 2, guid: 'AAAA'),
+        ],
+      );
+      final targetId = await _savePreset(db, 'Target');
+
+      await db.presetsDao.applyTemplateSlots(
+        templateId: templateId,
+        targetPresetId: targetId,
+        templateSlotIndices: const [1, 1, 1],
+        insertionOffset: 0,
+      );
+
+      final loaded = await db.presetsDao.getFullPresetDetails(targetId);
+      expect(loaded!.slots, hasLength(3));
+      for (final s in loaded.slots) {
+        expect(s.algorithm.guid, 'BBBB');
+        expect(s.slot.customName, 'two');
+        expect(s.parameterValues[7], 77);
+      }
+    });
+
+    test('bumps target preset lastModified timestamp', () async {
+      await _seedAlgorithm(db, 'AAAA');
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [_slot(slotIndex: 0, guid: 'AAAA')],
+      );
+      final targetId = await _savePreset(db, 'Target');
+      final before =
+          (await db.presetsDao.getPresetById(targetId))!.lastModified;
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      await db.presetsDao.applyTemplateSlots(
+        templateId: templateId,
+        targetPresetId: targetId,
+        templateSlotIndices: const [0],
+        insertionOffset: 0,
+      );
+
+      final after =
+          (await db.presetsDao.getPresetById(targetId))!.lastModified;
+      expect(
+        after.isAfter(before) || after.isAtSameMomentAs(before),
+        isTrue,
+      );
+    });
+  });
+
+  group('PresetsDao.applyTemplateSlots — replace mode', () {
+    test('replaces slots at offset and removes mapping/routing of replaced',
+        () async {
+      await _seedAlgorithm(db, 'AAAA');
+      await _seedAlgorithm(db, 'TARG');
+
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [
+          _slot(slotIndex: 0, guid: 'AAAA', values: {1: 1}),
+          _slot(slotIndex: 1, guid: 'AAAA', values: {1: 2}),
+        ],
+      );
+      final targetId = await _savePreset(
+        db,
+        'Target',
+        slots: [
+          _slot(slotIndex: 0, guid: 'TARG', values: {9: 100}),
+          _slot(slotIndex: 1, guid: 'TARG', values: {9: 200}),
+          _slot(
+            slotIndex: 2,
+            guid: 'TARG',
+            mappings: {3: _mapping(source: 99, delta: 7)},
+          ),
+          _slot(slotIndex: 3, guid: 'TARG'),
+        ],
+      );
+
+      // Snapshot the slot ids that will be replaced so we can verify their
+      // child rows are gone.
+      final targetSlots = await (db.select(db.presetSlots)
+            ..where((s) => s.presetId.equals(targetId))
+            ..orderBy([(s) => OrderingTerm.asc(s.slotIndex)]))
+          .get();
+      final slotIdsBeforeReplace = {
+        for (final s in targetSlots) s.slotIndex: s.id,
+      };
+
+      // Add a routing row for the slot at index 2 so we can confirm it
+      // is deleted on replace (PresetRoutings does not cascade).
+      await db.into(db.presetRoutings).insert(
+            PresetRoutingsCompanion.insert(
+              presetSlotId: Value(slotIdsBeforeReplace[2]!),
+              routingInfoJson: const [1, 2, 3],
+            ),
+          );
+
+      final result = await db.presetsDao.applyTemplateSlots(
+        templateId: templateId,
+        targetPresetId: targetId,
+        templateSlotIndices: const [0, 1],
+        insertionOffset: 2,
+        overwrite: true,
+      );
+
+      expect(result.insertedSlotIndices, [2, 3]);
+      final loaded = await db.presetsDao.getFullPresetDetails(targetId);
+      expect(loaded!.slots, hasLength(4));
+      expect(loaded.slots[0].algorithm.guid, 'TARG');
+      expect(loaded.slots[1].algorithm.guid, 'TARG');
+      expect(loaded.slots[2].algorithm.guid, 'AAAA');
+      expect(loaded.slots[2].parameterValues[1], 1);
+      expect(loaded.slots[3].algorithm.guid, 'AAAA');
+      expect(loaded.slots[3].parameterValues[1], 2);
+
+      // Verify the orphaned PresetMappings and PresetRoutings of the replaced
+      // slots are gone — those slot ids no longer exist.
+      final mappingsLeft = await (db.select(db.presetMappings)
+            ..where((m) => m.presetSlotId.equals(slotIdsBeforeReplace[2]!)))
+          .get();
+      expect(mappingsLeft, isEmpty);
+      final routingsLeft = await (db.select(db.presetRoutings)
+            ..where((r) => r.presetSlotId.equals(slotIdsBeforeReplace[2]!)))
+          .get();
+      expect(routingsLeft, isEmpty);
+    });
+
+    test('replace into empty positions still inserts', () async {
+      await _seedAlgorithm(db, 'AAAA');
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [
+          _slot(slotIndex: 0, guid: 'AAAA'),
+          _slot(slotIndex: 1, guid: 'AAAA'),
+        ],
+      );
+      final targetId = await _savePreset(db, 'Target');
+
+      final result = await db.presetsDao.applyTemplateSlots(
+        templateId: templateId,
+        targetPresetId: targetId,
+        templateSlotIndices: const [0, 1],
+        insertionOffset: 0,
+        overwrite: true,
+      );
+
+      expect(result.insertedSlotIndices, [0, 1]);
+      final loaded = await db.presetsDao.getFullPresetDetails(targetId);
+      expect(loaded!.slots, hasLength(2));
+    });
+  });
+
+  group('PresetsDao.applyTemplateSlots — space exception', () {
+    test(
+      'insert mode beyond 32 slots throws TemplateSpaceException with diagnostics',
+      () async {
+        await _seedAlgorithm(db, 'AAAA');
+        await _seedAlgorithm(db, 'TARG');
+        // Template with 30 slots
+        final templateSlots = List<FullPresetSlot>.generate(
+          30,
+          (i) => _slot(slotIndex: i, guid: 'AAAA'),
+        );
+        final templateId = await _savePreset(
+          db,
+          'Tmpl',
+          isTemplate: true,
+          slots: templateSlots,
+        );
+
+        // Target with 5 existing slots
+        final targetSlots = List<FullPresetSlot>.generate(
+          5,
+          (i) => _slot(slotIndex: i, guid: 'TARG'),
+        );
+        final targetId = await _savePreset(
+          db,
+          'Target',
+          slots: targetSlots,
+        );
+
+        try {
+          await db.presetsDao.applyTemplateSlots(
+            templateId: templateId,
+            targetPresetId: targetId,
+            templateSlotIndices: List<int>.generate(30, (i) => i),
+            insertionOffset: 5,
+          );
+          fail('expected TemplateSpaceException');
+        } on TemplateSpaceException catch (e) {
+          expect(e.current, 5);
+          expect(e.applied, 30);
+          expect(e.limit, 32);
+        }
+
+        final loaded = await db.presetsDao.getFullPresetDetails(targetId);
+        expect(loaded!.slots, hasLength(5),
+            reason: 'no slots should be added on failure');
+        // No new param/mapping/routing rows beyond original
+        final allParamValues = await db.select(db.presetParameterValues).get();
+        expect(allParamValues, isEmpty);
+      },
+    );
+
+    test('replace mode beyond 32 slots throws TemplateSpaceException',
+        () async {
+      await _seedAlgorithm(db, 'AAAA');
+      await _seedAlgorithm(db, 'TARG');
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: List<FullPresetSlot>.generate(
+          10,
+          (i) => _slot(slotIndex: i, guid: 'AAAA'),
+        ),
+      );
+      final targetId = await _savePreset(
+        db,
+        'Target',
+        slots: List<FullPresetSlot>.generate(
+          5,
+          (i) => _slot(slotIndex: i, guid: 'TARG'),
+        ),
+      );
+
+      expect(
+        () => db.presetsDao.applyTemplateSlots(
+          templateId: templateId,
+          targetPresetId: targetId,
+          templateSlotIndices: List<int>.generate(10, (i) => i),
+          insertionOffset: 25,
+          overwrite: true,
+        ),
+        throwsA(isA<TemplateSpaceException>()),
+      );
+    });
+  });
+
+  group('PresetsDao.applyTemplateSlots — missing algorithm metadata', () {
+    test('skips slots without local algorithm rows and populates warning',
+        () async {
+      await _seedAlgorithm(db, 'AAAA');
+      await _seedAlgorithm(db, 'GHST');
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [
+          _slot(slotIndex: 0, guid: 'AAAA'),
+          _slot(slotIndex: 1, guid: 'GHST'),
+          _slot(slotIndex: 2, guid: 'AAAA'),
+        ],
+      );
+      // Now remove GHST from algorithms to simulate missing metadata locally.
+      await (db.delete(db.algorithms)
+            ..where((a) => a.guid.equals('GHST')))
+          .go();
+
+      final targetId = await _savePreset(db, 'Target');
+
+      final result = await db.presetsDao.applyTemplateSlots(
+        templateId: templateId,
+        targetPresetId: targetId,
+        templateSlotIndices: const [0, 1, 2],
+        insertionOffset: 0,
+      );
+
+      expect(result.skippedTemplateSlotIndices, [1]);
+      expect(result.insertedSlotIndices, [0, 1]);
+      expect(result.warning, isNotNull);
+      expect(result.warning, contains('GHST'));
+
+      final loaded = await db.presetsDao.getFullPresetDetails(targetId);
+      expect(loaded!.slots, hasLength(2));
+      expect(loaded.slots.every((s) => s.algorithm.guid == 'AAAA'), isTrue);
+    });
+
+    test('space check uses non-skipped count', () async {
+      await _seedAlgorithm(db, 'AAAA');
+      await _seedAlgorithm(db, 'GHST');
+      // Template has 30 slots — 20 of them are GHST (will skip).
+      final templateSlots = <FullPresetSlot>[];
+      for (var i = 0; i < 30; i++) {
+        templateSlots.add(
+          _slot(slotIndex: i, guid: i < 20 ? 'GHST' : 'AAAA'),
+        );
+      }
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: templateSlots,
+      );
+      await (db.delete(db.algorithms)
+            ..where((a) => a.guid.equals('GHST')))
+          .go();
+
+      // Target with 25 existing slots — 25 + 10 (non-skipped) = 35 > 32 → still fails.
+      final targetId = await _savePreset(
+        db,
+        'Target',
+        slots: List<FullPresetSlot>.generate(
+          25,
+          (i) => _slot(slotIndex: i, guid: 'AAAA'),
+        ),
+      );
+
+      expect(
+        () => db.presetsDao.applyTemplateSlots(
+          templateId: templateId,
+          targetPresetId: targetId,
+          templateSlotIndices: List<int>.generate(30, (i) => i),
+          insertionOffset: 25,
+        ),
+        throwsA(isA<TemplateSpaceException>().having(
+          (e) => e.applied,
+          'applied',
+          10,
+        )),
+      );
+
+      // Now with 22 existing — 22 + 10 = 32 → should succeed.
+      final targetId2 = await _savePreset(
+        db,
+        'Target 2',
+        slots: List<FullPresetSlot>.generate(
+          22,
+          (i) => _slot(slotIndex: i, guid: 'AAAA'),
+        ),
+      );
+      final result = await db.presetsDao.applyTemplateSlots(
+        templateId: templateId,
+        targetPresetId: targetId2,
+        templateSlotIndices: List<int>.generate(30, (i) => i),
+        insertionOffset: 22,
+      );
+      expect(result.skippedTemplateSlotIndices, hasLength(20));
+      expect(result.insertedSlotIndices, hasLength(10));
+    });
+  });
+
+  group('PresetsDao.applyTemplateSlots — self-application', () {
+    test('applying template onto itself doubles the slot count', () async {
+      await _seedAlgorithm(db, 'AAAA');
+      await _seedAlgorithm(db, 'BBBB');
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [
+          _slot(slotIndex: 0, guid: 'AAAA', values: {1: 10}),
+          _slot(
+            slotIndex: 1,
+            guid: 'BBBB',
+            customName: 'orig-bb',
+            values: {1: 20},
+            mappings: {3: _mapping(source: 7)},
+          ),
+        ],
+      );
+
+      final result = await db.presetsDao.applyTemplateSlots(
+        templateId: templateId,
+        targetPresetId: templateId,
+        templateSlotIndices: const [0, 1],
+        insertionOffset: 2,
+      );
+
+      expect(result.insertedSlotIndices, [2, 3]);
+      final loaded = await db.presetsDao.getFullPresetDetails(templateId);
+      expect(loaded!.slots, hasLength(4));
+      expect(loaded.slots[0].algorithm.guid, 'AAAA');
+      expect(loaded.slots[1].algorithm.guid, 'BBBB');
+      expect(loaded.slots[1].slot.customName, 'orig-bb');
+      expect(loaded.slots[2].algorithm.guid, 'AAAA');
+      expect(loaded.slots[2].parameterValues[1], 10);
+      expect(loaded.slots[3].algorithm.guid, 'BBBB');
+      expect(loaded.slots[3].slot.customName, 'orig-bb');
+      expect(loaded.slots[3].mappings[3]?.source, 7);
+    });
+  });
+
+  group('PresetsDao.applyTemplateSlots — slot fidelity', () {
+    test('copies parameter values, strings, mappings, and routing', () async {
+      await _seedAlgorithm(db, 'AAAA');
+
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [
+          _slot(
+            slotIndex: 0,
+            guid: 'AAAA',
+            customName: 'verbatim-name',
+            values: {0: 1, 1: 2, 2: 3},
+            strings: {0: 'hello', 5: 'world'},
+            mappings: {
+              0: _mapping(source: 9, perfPageIndex: 3),
+              1: _mapping(source: 12, midiCC: 7, perfPageIndex: 0),
+            },
+          ),
+        ],
+      );
+
+      // Attach a PresetRouting row to the template slot manually.
+      final tmplSlotId = (await (db.select(db.presetSlots)
+                ..where((s) => s.presetId.equals(templateId)))
+              .getSingle())
+          .id;
+      await db.into(db.presetRoutings).insert(
+            PresetRoutingsCompanion.insert(
+              presetSlotId: Value(tmplSlotId),
+              routingInfoJson: const [4, 5, 6, 7, 8, 9],
+            ),
+          );
+
+      final targetId = await _savePreset(db, 'Target');
+
+      await db.presetsDao.applyTemplateSlots(
+        templateId: templateId,
+        targetPresetId: targetId,
+        templateSlotIndices: const [0],
+        insertionOffset: 0,
+      );
+
+      final loaded = await db.presetsDao.getFullPresetDetails(targetId);
+      expect(loaded, isNotNull);
+      final slot = loaded!.slots.single;
+      expect(slot.slot.customName, 'verbatim-name');
+      expect(slot.parameterValues, {0: 1, 1: 2, 2: 3});
+      expect(slot.parameterStringValues, {0: 'hello', 5: 'world'});
+      expect(slot.mappings[0]?.source, 9);
+      expect(slot.mappings[0]?.perfPageIndex, 3);
+      expect(slot.mappings[1]?.source, 12);
+      expect(slot.mappings[1]?.midiCC, 7);
+
+      // Routing should also have been copied.
+      final newSlot = await (db.select(db.presetSlots)
+            ..where((s) => s.presetId.equals(targetId)))
+          .getSingle();
+      final routings = await (db.select(db.presetRoutings)
+            ..where((r) => r.presetSlotId.equals(newSlot.id)))
+          .get();
+      expect(routings, hasLength(1));
+      expect(routings.first.routingInfoJson, [4, 5, 6, 7, 8, 9]);
+    });
+
+    test('templateSlotIndices respects template slotIndex ordering', () async {
+      for (final g in const ['AAAA', 'BBBB', 'CCCC']) {
+        await _seedAlgorithm(db, g);
+      }
+      // Save template with slots in non-ascending insertion order; their
+      // logical slotIndex still drives the meaning of "index 0".
+      final templateId = await _savePreset(
+        db,
+        'Tmpl',
+        isTemplate: true,
+        slots: [
+          _slot(slotIndex: 2, guid: 'CCCC'),
+          _slot(slotIndex: 0, guid: 'AAAA'),
+          _slot(slotIndex: 1, guid: 'BBBB'),
+        ],
+      );
+      final targetId = await _savePreset(db, 'Target');
+
+      await db.presetsDao.applyTemplateSlots(
+        templateId: templateId,
+        targetPresetId: targetId,
+        templateSlotIndices: const [0, 2],
+        insertionOffset: 0,
+      );
+
+      final loaded = await db.presetsDao.getFullPresetDetails(targetId);
+      expect(loaded!.slots, hasLength(2));
+      expect(loaded.slots[0].algorithm.guid, 'AAAA');
+      expect(loaded.slots[1].algorithm.guid, 'CCCC');
+    });
+  });
+}

--- a/test/db/daos/presets_dao_test.dart
+++ b/test/db/daos/presets_dao_test.dart
@@ -106,6 +106,80 @@ void main() {
       );
     });
 
+    test(
+      'saves and loads preset routing rows with full preset details',
+      () async {
+        await database.metadataDao.upsertAlgorithms([
+          AlgorithmEntry(
+            guid: 'ROUT',
+            name: 'Routing Algorithm',
+            numSpecifications: 0,
+            pluginFilePath: null,
+          ),
+        ]);
+
+        final presetId = await database.presetsDao.saveFullPreset(
+          FullPresetDetails(
+            preset: PresetEntry(
+              id: -1,
+              name: 'Routing Preset',
+              lastModified: DateTime.now(),
+              isTemplate: true,
+            ),
+            slots: [
+              FullPresetSlot(
+                slot: PresetSlotEntry(
+                  id: -1,
+                  presetId: -1,
+                  slotIndex: 0,
+                  algorithmGuid: 'ROUT',
+                  customName: null,
+                ),
+                algorithm: AlgorithmEntry(
+                  guid: 'ROUT',
+                  name: 'Routing Algorithm',
+                  numSpecifications: 0,
+                  pluginFilePath: null,
+                ),
+                parameterValues: {},
+                parameterStringValues: {},
+                mappings: {},
+                routing: PresetRoutingEntry(
+                  presetSlotId: -1,
+                  routingInfoJson: const [1, 2, 3, 4, 5, 6],
+                ),
+              ),
+            ],
+          ),
+          isTemplate: true,
+        );
+
+        final loadedPreset = await database.presetsDao.getFullPresetDetails(
+          presetId,
+        );
+
+        expect(loadedPreset, isNotNull);
+        expect(loadedPreset!.slots.single.routing, isNotNull);
+        expect(loadedPreset.slots.single.routing!.routingInfoJson, [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+        ]);
+
+        final savedRoutingRows = await database
+            .select(database.presetRoutings)
+            .get();
+        expect(savedRoutingRows, hasLength(1));
+        expect(
+          savedRoutingRows.single.presetSlotId,
+          loadedPreset.slots.single.slot.id,
+        );
+      },
+    );
+
     test('saves mapping with perfPageIndex = 0 (not assigned)', () async {
       // 1. Create test algorithm
       await database.metadataDao.upsertAlgorithms([
@@ -317,8 +391,14 @@ void main() {
       );
 
       // 4. Save both
-      await database.presetsDao.saveFullPreset(templateDetails, isTemplate: true);
-      await database.presetsDao.saveFullPreset(regularDetails, isTemplate: false);
+      await database.presetsDao.saveFullPreset(
+        templateDetails,
+        isTemplate: true,
+      );
+      await database.presetsDao.saveFullPreset(
+        regularDetails,
+        isTemplate: false,
+      );
 
       // 5. Query templates
       final templates = await database.presetsDao.getTemplates();
@@ -401,8 +481,14 @@ void main() {
       );
 
       // 4. Save both
-      await database.presetsDao.saveFullPreset(templateDetails, isTemplate: true);
-      await database.presetsDao.saveFullPreset(regularDetails, isTemplate: false);
+      await database.presetsDao.saveFullPreset(
+        templateDetails,
+        isTemplate: true,
+      );
+      await database.presetsDao.saveFullPreset(
+        regularDetails,
+        isTemplate: false,
+      );
 
       // 5. Query non-templates
       final nonTemplates = await database.presetsDao.getNonTemplates();
@@ -651,7 +737,9 @@ void main() {
       expect(updatedPreset, isNotNull);
       expect(
         updatedPreset!.preset.lastModified.isAfter(initialTimestamp) ||
-        updatedPreset.preset.lastModified.isAtSameMomentAs(initialTimestamp),
+            updatedPreset.preset.lastModified.isAtSameMomentAs(
+              initialTimestamp,
+            ),
         isTrue,
         reason: 'lastModified should be updated or remain the same',
       );

--- a/test/db/io_flags_migration_test.dart
+++ b/test/db/io_flags_migration_test.dart
@@ -17,8 +17,9 @@ void main() {
     });
 
     test('Fresh v10 schema includes ioFlags column', () async {
-      // Test that schema version 11 includes ioFlags column (incremented for ParameterOutputModeUsage table)
-      expect(database.schemaVersion, 11);
+      // Schema version was 11 when ParameterOutputModeUsage was added; it was
+      // bumped to 12 for Presets.category + Presets.templateMetadata.
+      expect(database.schemaVersion, 12);
 
       // Insert a test algorithm
       await database.into(database.algorithms).insert(

--- a/test/db/migrations/v11_to_v12_template_metadata_test.dart
+++ b/test/db/migrations/v11_to_v12_template_metadata_test.dart
@@ -1,0 +1,101 @@
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/db/database.dart';
+
+void main() {
+  group('v11 to v12 template metadata migration', () {
+    late AppDatabase database;
+
+    setUp(() {
+      database = AppDatabase.forTesting(NativeDatabase.memory());
+    });
+
+    tearDown(() async {
+      await database.close();
+    });
+
+    test('schema version is 12', () {
+      expect(database.schemaVersion, 12);
+    });
+
+    test('fresh v12 schema accepts null category and templateMetadata',
+        () async {
+      final id = await database.into(database.presets).insert(
+            PresetsCompanion.insert(
+              name: 'My Template',
+              isTemplate: const Value(true),
+            ),
+          );
+
+      final preset = await (database.select(database.presets)
+            ..where((p) => p.id.equals(id)))
+          .getSingle();
+
+      expect(preset.name, 'My Template');
+      expect(preset.isTemplate, isTrue);
+      expect(preset.category, isNull);
+      expect(preset.templateMetadata, isNull);
+    });
+
+    test('fresh v12 schema persists category and templateMetadata strings',
+        () async {
+      final id = await database.into(database.presets).insert(
+            PresetsCompanion.insert(
+              name: 'Cathedral Reverb',
+              isTemplate: const Value(true),
+              category: const Value('Reverb'),
+              templateMetadata: const Value(
+                '{"description":"Long hall","tags":["space","wet"],"author":"neal","schemaVersion":1}',
+              ),
+            ),
+          );
+
+      final preset = await (database.select(database.presets)
+            ..where((p) => p.id.equals(id)))
+          .getSingle();
+
+      expect(preset.category, 'Reverb');
+      expect(
+        preset.templateMetadata,
+        contains('"description":"Long hall"'),
+      );
+    });
+
+    test('category and templateMetadata round-trip including UTF-8 codepoints',
+        () async {
+      const jsonText = '{"description":"Glöcken — 🔔","tags":["bells","✨"]}';
+      final id = await database.into(database.presets).insert(
+            PresetsCompanion.insert(
+              name: 'Bells',
+              isTemplate: const Value(true),
+              category: const Value('Перкуссия'),
+              templateMetadata: const Value(jsonText),
+            ),
+          );
+
+      final preset = await (database.select(database.presets)
+            ..where((p) => p.id.equals(id)))
+          .getSingle();
+
+      expect(preset.category, 'Перкуссия');
+      expect(preset.templateMetadata, jsonText);
+    });
+
+    test('default values for existing rows are null (migration safety)',
+        () async {
+      // Insert a row without specifying the new columns.
+      final id = await database.into(database.presets).insert(
+            PresetsCompanion.insert(name: 'Legacy preset'),
+          );
+
+      final preset = await (database.select(database.presets)
+            ..where((p) => p.id.equals(id)))
+          .getSingle();
+
+      expect(preset.category, isNull);
+      expect(preset.templateMetadata, isNull);
+      expect(preset.isTemplate, isFalse);
+    });
+  });
+}

--- a/test/mcp/tools/apply_template_tool_test.dart
+++ b/test/mcp/tools/apply_template_tool_test.dart
@@ -6,6 +6,8 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nt_helper/cubit/disting_cubit.dart';
 import 'package:nt_helper/db/daos/presets_dao.dart';
 import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/domain/disting_nt_sysex.dart';
+import 'package:nt_helper/domain/i_disting_midi_manager.dart';
 import 'package:nt_helper/mcp/tool_registry.dart';
 import 'package:nt_helper/mcp/tools/disting_tools.dart';
 import 'package:nt_helper/services/disting_controller.dart';
@@ -14,6 +16,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 class MockDistingController extends Mock implements DistingController {}
 
 class MockDistingCubit extends Mock implements DistingCubit {}
+
+class MockDistingMidiManager extends Mock implements IDistingMidiManager {}
+
+class FakeAlgorithmInfo extends Fake implements AlgorithmInfo {}
 
 FullPresetSlot _slot({required int slotIndex, required String guid}) {
   return FullPresetSlot(
@@ -65,12 +71,18 @@ void main() {
   late MockDistingCubit cubit;
   late DistingTools tools;
 
+  setUpAll(() {
+    registerFallbackValue(FakeAlgorithmInfo());
+    registerFallbackValue(<int>[]);
+  });
+
   setUp(() {
     TestWidgetsFlutterBinding.ensureInitialized();
     SharedPreferences.setMockInitialValues({});
     db = AppDatabase.forTesting(NativeDatabase.memory());
     cubit = MockDistingCubit();
     when(() => cubit.database).thenReturn(db);
+    when(() => cubit.state).thenReturn(const DistingState.initial());
     tools = DistingTools(MockDistingController(), cubit);
   });
 
@@ -162,5 +174,41 @@ void main() {
       expect(entry.inputSchema['properties'], contains('slot_indices'));
       expect(entry.timeout, const Duration(seconds: 120));
     });
+
+    test(
+      'device target returns failure when device apply emits failure',
+      () async {
+        final manager = MockDistingMidiManager();
+        when(() => cubit.requireDisting()).thenReturn(manager);
+        when(
+          () => manager.requestNumAlgorithmsInPreset(),
+        ).thenAnswer((_) async => 0);
+        when(
+          () => manager.requestAddAlgorithm(
+            any<AlgorithmInfo>(),
+            any<List<int>>(),
+          ),
+        ).thenAnswer((_) async => throw Exception('MIDI send failed'));
+
+        await _seedAlgorithm(db, 'AAAA');
+        final templateId = await _savePreset(
+          db,
+          'Starter',
+          isTemplate: true,
+          slots: [_slot(slotIndex: 0, guid: 'AAAA')],
+        );
+
+        final response = await tools.applyTemplateToPreset({
+          'template_id': templateId,
+          'target': 'device',
+        });
+        final json = jsonDecode(response) as Map<String, dynamic>;
+
+        expect(json['success'], isFalse);
+        expect(json['error'], 'partial_apply');
+        expect(json['applied_slot_count'], 0);
+        expect(json['message'], contains('Connection lost during injection'));
+      },
+    );
   });
 }

--- a/test/mcp/tools/apply_template_tool_test.dart
+++ b/test/mcp/tools/apply_template_tool_test.dart
@@ -1,0 +1,166 @@
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/cubit/disting_cubit.dart';
+import 'package:nt_helper/db/daos/presets_dao.dart';
+import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/mcp/tool_registry.dart';
+import 'package:nt_helper/mcp/tools/disting_tools.dart';
+import 'package:nt_helper/services/disting_controller.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MockDistingController extends Mock implements DistingController {}
+
+class MockDistingCubit extends Mock implements DistingCubit {}
+
+FullPresetSlot _slot({required int slotIndex, required String guid}) {
+  return FullPresetSlot(
+    slot: PresetSlotEntry(
+      id: -1,
+      presetId: -1,
+      slotIndex: slotIndex,
+      algorithmGuid: guid,
+    ),
+    algorithm: AlgorithmEntry(
+      guid: guid,
+      name: 'Alg $guid',
+      numSpecifications: 0,
+    ),
+    parameterValues: {slotIndex: slotIndex * 10},
+    parameterStringValues: {},
+    mappings: {},
+  );
+}
+
+Future<void> _seedAlgorithm(AppDatabase db, String guid) async {
+  await db.metadataDao.upsertAlgorithms([
+    AlgorithmEntry(guid: guid, name: 'Alg $guid', numSpecifications: 0),
+  ]);
+}
+
+Future<int> _savePreset(
+  AppDatabase db,
+  String name, {
+  required bool isTemplate,
+  required List<FullPresetSlot> slots,
+}) {
+  return db.presetsDao.saveFullPreset(
+    FullPresetDetails(
+      preset: PresetEntry(
+        id: -1,
+        name: name,
+        lastModified: DateTime.now(),
+        isTemplate: isTemplate,
+      ),
+      slots: slots,
+    ),
+    isTemplate: isTemplate,
+  );
+}
+
+void main() {
+  late AppDatabase db;
+  late MockDistingCubit cubit;
+  late DistingTools tools;
+
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    cubit = MockDistingCubit();
+    when(() => cubit.database).thenReturn(db);
+    tools = DistingTools(MockDistingController(), cubit);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('apply_template_to_preset tool', () {
+    test('applies selected template slots to a named target preset', () async {
+      await _seedAlgorithm(db, 'AAAA');
+      await _seedAlgorithm(db, 'BBBB');
+      await _savePreset(
+        db,
+        'Starter',
+        isTemplate: true,
+        slots: [
+          _slot(slotIndex: 0, guid: 'AAAA'),
+          _slot(slotIndex: 1, guid: 'BBBB'),
+        ],
+      );
+      final targetId = await _savePreset(
+        db,
+        'Target',
+        isTemplate: false,
+        slots: const [],
+      );
+
+      final response = await tools.applyTemplateToPreset({
+        'template_name': 'Starter',
+        'target': 'preset',
+        'target_preset_name': 'Target',
+        'slot_indices': [1, 1],
+        'insertion_offset': 0,
+      });
+      final json = jsonDecode(response) as Map<String, dynamic>;
+
+      expect(json['success'], isTrue);
+      expect(json['target'], 'preset');
+      expect(json['target_preset_id'], targetId);
+      expect(json['applied_slot_count'], 2);
+      expect(json['inserted_slot_indices'], [0, 1]);
+      expect(json['skipped_template_slot_indices'], isEmpty);
+
+      final target = await db.presetsDao.getFullPresetDetails(targetId);
+      expect(target!.slots.map((slot) => slot.slot.algorithmGuid), [
+        'BBBB',
+        'BBBB',
+      ]);
+    });
+
+    test('returns structured space errors from the DAO', () async {
+      await _seedAlgorithm(db, 'AAAA');
+      final templateId = await _savePreset(
+        db,
+        'Too Big',
+        isTemplate: true,
+        slots: [
+          _slot(slotIndex: 0, guid: 'AAAA'),
+          _slot(slotIndex: 1, guid: 'AAAA'),
+        ],
+      );
+      final targetId = await _savePreset(
+        db,
+        'Crowded',
+        isTemplate: false,
+        slots: [for (var i = 0; i < 31; i++) _slot(slotIndex: i, guid: 'AAAA')],
+      );
+
+      final response = await tools.applyTemplateToPreset({
+        'template_id': templateId,
+        'target': 'preset',
+        'target_preset_id': targetId,
+      });
+      final json = jsonDecode(response) as Map<String, dynamic>;
+
+      expect(json['success'], isFalse);
+      expect(json['error'], 'space');
+      expect(json['current'], 31);
+      expect(json['applied'], 2);
+      expect(json['limit'], 32);
+    });
+
+    test('registry exposes apply_template_to_preset', () {
+      final registry = ToolRegistry(cubit);
+      final entry = registry.findByName('apply_template_to_preset');
+
+      expect(entry, isNotNull);
+      expect(entry!.inputSchema['properties'], contains('template_name'));
+      expect(entry.inputSchema['properties'], contains('slot_indices'));
+      expect(entry.timeout, const Duration(seconds: 120));
+    });
+  });
+}

--- a/test/models/template_metadata_test.dart
+++ b/test/models/template_metadata_test.dart
@@ -1,0 +1,169 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/models/template_metadata.dart';
+
+void main() {
+  group('TemplateMetadata.fromJsonString', () {
+    test('null source returns empty metadata', () {
+      final m = TemplateMetadata.fromJsonString(null);
+
+      expect(m.description, isNull);
+      expect(m.tags, isEmpty);
+      expect(m.author, isNull);
+      expect(m.createdAt, isNull);
+      expect(m.extras, isEmpty);
+      expect(m.isEmpty, isTrue);
+    });
+
+    test('empty string returns empty metadata', () {
+      final m = TemplateMetadata.fromJsonString('');
+
+      expect(m.description, isNull);
+      expect(m.tags, isEmpty);
+      expect(m.author, isNull);
+      expect(m.createdAt, isNull);
+      expect(m.extras, isEmpty);
+    });
+
+    test('malformed JSON returns empty metadata without throwing', () {
+      final m = TemplateMetadata.fromJsonString('{not valid json');
+
+      expect(m.description, isNull);
+      expect(m.tags, isEmpty);
+    });
+
+    test('parses known fields', () {
+      const src = '{'
+          '"description":"Reverbs and delays",'
+          '"tags":["space","wet","stereo"],'
+          '"author":"neal",'
+          '"createdAt":"2026-05-22T10:00:00Z",'
+          '"schemaVersion":1'
+          '}';
+      final m = TemplateMetadata.fromJsonString(src);
+
+      expect(m.description, 'Reverbs and delays');
+      expect(m.tags, ['space', 'wet', 'stereo']);
+      expect(m.author, 'neal');
+      expect(m.createdAt, '2026-05-22T10:00:00Z');
+      expect(m.extras, isEmpty);
+    });
+
+    test('unknown top-level keys flow into extras', () {
+      const src =
+          '{"description":"x","futureFlag":true,"customNumber":42,"nested":{"a":1}}';
+      final m = TemplateMetadata.fromJsonString(src);
+
+      expect(m.description, 'x');
+      expect(m.extras['futureFlag'], isTrue);
+      expect(m.extras['customNumber'], 42);
+      expect(m.extras['nested'], {'a': 1});
+    });
+
+    test('missing known keys default to null/empty', () {
+      const src = '{"author":"neal"}';
+      final m = TemplateMetadata.fromJsonString(src);
+
+      expect(m.description, isNull);
+      expect(m.author, 'neal');
+      expect(m.tags, isEmpty);
+    });
+
+    test('tags coerce non-string entries to strings', () {
+      const src = '{"tags":["valid",42,null,true]}';
+      final m = TemplateMetadata.fromJsonString(src);
+
+      expect(m.tags, ['valid', '42', '', 'true']);
+    });
+  });
+
+  group('TemplateMetadata.toJsonString', () {
+    test('empty metadata serializes to schemaVersion-only JSON', () {
+      const m = TemplateMetadata();
+      final encoded = m.toJsonString();
+      final decoded = jsonDecode(encoded) as Map<String, dynamic>;
+
+      expect(decoded['schemaVersion'], 1);
+      expect(decoded.containsKey('description'), isFalse);
+      expect(decoded.containsKey('tags'), isFalse);
+    });
+
+    test('serializes known fields and omits nulls', () {
+      const m = TemplateMetadata(
+        description: 'hi',
+        tags: ['a', 'b'],
+        author: 'neal',
+        createdAt: '2026-05-22T00:00:00Z',
+      );
+      final encoded = m.toJsonString();
+      final decoded = jsonDecode(encoded) as Map<String, dynamic>;
+
+      expect(decoded['description'], 'hi');
+      expect(decoded['tags'], ['a', 'b']);
+      expect(decoded['author'], 'neal');
+      expect(decoded['createdAt'], '2026-05-22T00:00:00Z');
+      expect(decoded['schemaVersion'], 1);
+    });
+
+    test('extras are merged back into output JSON', () {
+      const m = TemplateMetadata(
+        description: 'desc',
+        extras: {'futureFlag': true, 'customNumber': 42},
+      );
+      final decoded =
+          jsonDecode(m.toJsonString()) as Map<String, dynamic>;
+
+      expect(decoded['description'], 'desc');
+      expect(decoded['futureFlag'], isTrue);
+      expect(decoded['customNumber'], 42);
+    });
+
+    test('known fields take precedence over extras with same key', () {
+      const m = TemplateMetadata(
+        description: 'real',
+        extras: {'description': 'shadow'},
+      );
+      final decoded =
+          jsonDecode(m.toJsonString()) as Map<String, dynamic>;
+
+      expect(decoded['description'], 'real');
+    });
+
+    test('round-trips via fromJsonString/toJsonString', () {
+      const original = TemplateMetadata(
+        description: 'rt',
+        tags: ['a', 'b'],
+        author: 'n',
+        createdAt: '2026-05-22T00:00:00Z',
+        extras: {'foo': 'bar'},
+      );
+      final roundTripped =
+          TemplateMetadata.fromJsonString(original.toJsonString());
+
+      expect(roundTripped.description, original.description);
+      expect(roundTripped.tags, original.tags);
+      expect(roundTripped.author, original.author);
+      expect(roundTripped.createdAt, original.createdAt);
+      expect(roundTripped.extras, original.extras);
+    });
+  });
+
+  group('TemplateMetadata.isEmpty', () {
+    test('returns true for the default empty value', () {
+      expect(const TemplateMetadata().isEmpty, isTrue);
+      expect(TemplateMetadata.empty().isEmpty, isTrue);
+    });
+
+    test('returns false when any field is set', () {
+      expect(const TemplateMetadata(description: 'x').isEmpty, isFalse);
+      expect(const TemplateMetadata(tags: ['a']).isEmpty, isFalse);
+      expect(const TemplateMetadata(author: 'n').isEmpty, isFalse);
+      expect(const TemplateMetadata(createdAt: '2026').isEmpty, isFalse);
+      expect(
+        const TemplateMetadata(extras: {'k': 'v'}).isEmpty,
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/ui/metadata_sync/metadata_sync_cubit_apply_template_test.dart
+++ b/test/ui/metadata_sync/metadata_sync_cubit_apply_template_test.dart
@@ -1,0 +1,413 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/db/daos/metadata_dao.dart';
+import 'package:nt_helper/db/daos/presets_dao.dart';
+import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/domain/disting_nt_sysex.dart';
+import 'package:nt_helper/domain/i_disting_midi_manager.dart';
+import 'package:nt_helper/models/packed_mapping_data.dart';
+import 'package:nt_helper/ui/metadata_sync/metadata_sync_cubit.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MockDistingMidiManager extends Mock implements IDistingMidiManager {}
+
+class MockAppDatabase extends Mock implements AppDatabase {}
+
+class MockMetadataDao extends Mock implements MetadataDao {}
+
+class MockPresetsDao extends Mock implements PresetsDao {}
+
+class FakeAlgorithmInfo extends Fake implements AlgorithmInfo {}
+
+class FakePackedMappingData extends Fake implements PackedMappingData {}
+
+FullPresetDetails _template({
+  int id = 1,
+  String name = 'Tmpl',
+  List<FullPresetSlot>? slots,
+}) =>
+    FullPresetDetails(
+      preset: PresetEntry(
+        id: id,
+        name: name,
+        lastModified: DateTime.now(),
+        isTemplate: true,
+      ),
+      slots: slots ??
+          [
+            FullPresetSlot(
+              slot: PresetSlotEntry(
+                id: 1,
+                presetId: id,
+                slotIndex: 0,
+                algorithmGuid: 'guid-1',
+              ),
+              algorithm: AlgorithmEntry(
+                guid: 'guid-1',
+                name: 'Alg 1',
+                numSpecifications: 0,
+              ),
+              parameterValues: {},
+              parameterStringValues: {},
+              mappings: {},
+            ),
+          ],
+    );
+
+void main() {
+  late MetadataSyncCubit cubit;
+  late MockDistingMidiManager mockManager;
+  late MockAppDatabase mockDatabase;
+  late MockMetadataDao mockMetadataDao;
+  late MockPresetsDao mockPresetsDao;
+
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    registerFallbackValue(FakeAlgorithmInfo());
+    registerFallbackValue(FakePackedMappingData());
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    mockManager = MockDistingMidiManager();
+    mockDatabase = MockAppDatabase();
+    mockMetadataDao = MockMetadataDao();
+    mockPresetsDao = MockPresetsDao();
+    when(() => mockDatabase.metadataDao).thenReturn(mockMetadataDao);
+    when(() => mockDatabase.presetsDao).thenReturn(mockPresetsDao);
+    cubit = MetadataSyncCubit(mockDatabase);
+  });
+
+  tearDown(() => cubit.close());
+
+  group('applyTemplateToPreset', () {
+    blocTest<MetadataSyncCubit, MetadataSyncState>(
+      'delegates to DAO with the given args and emits ViewingLocalData on success',
+      build: () {
+        when(() => mockPresetsDao.applyTemplateSlots(
+              templateId: any(named: 'templateId'),
+              targetPresetId: any(named: 'targetPresetId'),
+              templateSlotIndices: any(named: 'templateSlotIndices'),
+              insertionOffset: any(named: 'insertionOffset'),
+              overwrite: any(named: 'overwrite'),
+            )).thenAnswer(
+          (_) async => const ApplyTemplateSlotsResult(
+            targetPresetId: 42,
+            insertedSlotIndices: [0, 1, 2],
+            skippedTemplateSlotIndices: [],
+          ),
+        );
+        when(() => mockMetadataDao.getAllAlgorithms())
+            .thenAnswer((_) async => []);
+        when(() => mockMetadataDao.getAlgorithmParameterCounts())
+            .thenAnswer((_) async => <String, int>{});
+        when(() => mockPresetsDao.getAllPresets())
+            .thenAnswer((_) async => <PresetEntry>[]);
+        return cubit;
+      },
+      act: (c) async {
+        await c.applyTemplateToPreset(
+          templateId: 7,
+          targetPresetId: 42,
+          templateSlotIndices: const [0, 1, 2],
+          insertionOffset: 3,
+          overwrite: false,
+        );
+      },
+      expect: () => [isA<LoadingPreset>(), isA<ViewingLocalData>()],
+      verify: (_) {
+        verify(() => mockPresetsDao.applyTemplateSlots(
+              templateId: 7,
+              targetPresetId: 42,
+              templateSlotIndices: const [0, 1, 2],
+              insertionOffset: 3,
+              overwrite: false,
+            )).called(1);
+      },
+    );
+
+    blocTest<MetadataSyncCubit, MetadataSyncState>(
+      'translates TemplateSpaceException to metadataSyncFailure',
+      build: () {
+        when(() => mockPresetsDao.applyTemplateSlots(
+              templateId: any(named: 'templateId'),
+              targetPresetId: any(named: 'targetPresetId'),
+              templateSlotIndices: any(named: 'templateSlotIndices'),
+              insertionOffset: any(named: 'insertionOffset'),
+              overwrite: any(named: 'overwrite'),
+            )).thenThrow(TemplateSpaceException(current: 30, applied: 4));
+        return cubit;
+      },
+      act: (c) async {
+        await expectLater(
+          () => c.applyTemplateToPreset(
+            templateId: 1,
+            targetPresetId: 2,
+            templateSlotIndices: const [0, 1, 2, 3],
+            insertionOffset: 0,
+          ),
+          throwsA(isA<TemplateSpaceException>()),
+        );
+      },
+      expect: () => [
+        isA<MetadataSyncFailure>().having(
+          (s) => s.error,
+          'error message',
+          allOf(contains('30'), contains('4'), contains('32')),
+        ),
+      ],
+    );
+
+    blocTest<MetadataSyncCubit, MetadataSyncState>(
+      'returns DAO result to the caller',
+      build: () {
+        when(() => mockPresetsDao.applyTemplateSlots(
+              templateId: any(named: 'templateId'),
+              targetPresetId: any(named: 'targetPresetId'),
+              templateSlotIndices: any(named: 'templateSlotIndices'),
+              insertionOffset: any(named: 'insertionOffset'),
+              overwrite: any(named: 'overwrite'),
+            )).thenAnswer(
+          (_) async => const ApplyTemplateSlotsResult(
+            targetPresetId: 9,
+            insertedSlotIndices: [5],
+            skippedTemplateSlotIndices: [1],
+            warning: 'Skipped 1.',
+          ),
+        );
+        when(() => mockMetadataDao.getAllAlgorithms())
+            .thenAnswer((_) async => []);
+        when(() => mockMetadataDao.getAlgorithmParameterCounts())
+            .thenAnswer((_) async => <String, int>{});
+        when(() => mockPresetsDao.getAllPresets())
+            .thenAnswer((_) async => <PresetEntry>[]);
+        return cubit;
+      },
+      act: (c) async {
+        final result = await c.applyTemplateToPreset(
+          templateId: 1,
+          targetPresetId: 9,
+          templateSlotIndices: const [0, 1],
+          insertionOffset: 5,
+        );
+        expect(result.targetPresetId, 9);
+        expect(result.insertedSlotIndices, [5]);
+        expect(result.skippedTemplateSlotIndices, [1]);
+        expect(result.warning, isNotNull);
+      },
+    );
+  });
+
+  group('applyTemplateToDevice', () {
+    blocTest<MetadataSyncCubit, MetadataSyncState>(
+      'emits progress states injectingTemplate(applied, total) during apply',
+      build: () {
+        when(() => mockManager.requestNumAlgorithmsInPreset())
+            .thenAnswer((_) async => 0);
+        when(() => mockManager.requestAddAlgorithm(any(), any()))
+            .thenAnswer((_) async => {});
+        when(() => mockManager.setParameterValue(any(), any(), any()))
+            .thenAnswer((_) async => {});
+        when(() => mockManager.requestSetMapping(any(), any(), any()))
+            .thenAnswer((_) async => {});
+        when(() => mockManager.requestSendSlotName(any(), any()))
+            .thenAnswer((_) async => {});
+        when(() => mockMetadataDao.getFullAlgorithmDetails(any())).thenAnswer(
+          (_) async => FullAlgorithmDetails(
+            algorithm: AlgorithmEntry(
+              guid: 'guid-1',
+              name: 'Alg 1',
+              numSpecifications: 0,
+            ),
+            specifications: [],
+            parameters: [],
+            parameterPages: [],
+            enums: {},
+          ),
+        );
+        when(() => mockMetadataDao.getAllAlgorithms())
+            .thenAnswer((_) async => []);
+        when(() => mockMetadataDao.getAlgorithmParameterCounts())
+            .thenAnswer((_) async => <String, int>{});
+        when(() => mockPresetsDao.getAllPresets())
+            .thenAnswer((_) async => <PresetEntry>[]);
+        return cubit;
+      },
+      act: (c) async {
+        await c.applyTemplateToDevice(
+          template: _template(slots: [
+            for (var i = 0; i < 2; i++)
+              FullPresetSlot(
+                slot: PresetSlotEntry(
+                  id: i + 1,
+                  presetId: 1,
+                  slotIndex: i,
+                  algorithmGuid: 'guid-1',
+                ),
+                algorithm: AlgorithmEntry(
+                  guid: 'guid-1',
+                  name: 'Alg 1',
+                  numSpecifications: 0,
+                ),
+                parameterValues: {},
+                parameterStringValues: {},
+                mappings: {},
+              ),
+          ]),
+          templateSlotIndices: const [0, 1],
+          manager: mockManager,
+        );
+      },
+      expect: () => [
+        isA<InjectingTemplate>()
+            .having((s) => s.applied, 'applied', 0)
+            .having((s) => s.total, 'total', 2),
+        isA<InjectingTemplate>()
+            .having((s) => s.applied, 'applied', 1)
+            .having((s) => s.total, 'total', 2),
+        isA<InjectingTemplate>()
+            .having((s) => s.applied, 'applied', 2)
+            .having((s) => s.total, 'total', 2),
+        isA<PresetLoadSuccess>(),
+        isA<LoadingPreset>(),
+        isA<ViewingLocalData>(),
+      ],
+    );
+
+    blocTest<MetadataSyncCubit, MetadataSyncState>(
+      'only applies the slot indices requested (partial selection)',
+      build: () {
+        when(() => mockManager.requestNumAlgorithmsInPreset())
+            .thenAnswer((_) async => 0);
+        when(() => mockManager.requestAddAlgorithm(any(), any()))
+            .thenAnswer((_) async => {});
+        when(() => mockManager.setParameterValue(any(), any(), any()))
+            .thenAnswer((_) async => {});
+        when(() => mockManager.requestSetMapping(any(), any(), any()))
+            .thenAnswer((_) async => {});
+        when(() => mockManager.requestSendSlotName(any(), any()))
+            .thenAnswer((_) async => {});
+        when(() => mockMetadataDao.getFullAlgorithmDetails(any())).thenAnswer(
+          (_) async => FullAlgorithmDetails(
+            algorithm: AlgorithmEntry(
+              guid: 'guid-x',
+              name: 'Alg x',
+              numSpecifications: 0,
+            ),
+            specifications: [],
+            parameters: [],
+            parameterPages: [],
+            enums: {},
+          ),
+        );
+        when(() => mockMetadataDao.getAllAlgorithms())
+            .thenAnswer((_) async => []);
+        when(() => mockMetadataDao.getAlgorithmParameterCounts())
+            .thenAnswer((_) async => <String, int>{});
+        when(() => mockPresetsDao.getAllPresets())
+            .thenAnswer((_) async => <PresetEntry>[]);
+        return cubit;
+      },
+      act: (c) async {
+        final slots = [
+          for (var i = 0; i < 5; i++)
+            FullPresetSlot(
+              slot: PresetSlotEntry(
+                id: i + 1,
+                presetId: 1,
+                slotIndex: i,
+                algorithmGuid: 'guid-$i',
+              ),
+              algorithm: AlgorithmEntry(
+                guid: 'guid-$i',
+                name: 'Alg $i',
+                numSpecifications: 0,
+              ),
+              parameterValues: {0: i * 10},
+              parameterStringValues: {},
+              mappings: {},
+            ),
+        ];
+        await c.applyTemplateToDevice(
+          template: _template(slots: slots),
+          templateSlotIndices: const [1, 3],
+          manager: mockManager,
+        );
+      },
+      verify: (_) {
+        verify(() => mockManager.requestAddAlgorithm(any(), any())).called(2);
+        verify(() => mockManager.setParameterValue(0, 0, 10)).called(1);
+        verify(() => mockManager.setParameterValue(1, 0, 30)).called(1);
+        verifyNever(() => mockManager.setParameterValue(any(), 0, 0));
+        verifyNever(() => mockManager.setParameterValue(any(), 0, 20));
+        verifyNever(() => mockManager.setParameterValue(any(), 0, 40));
+      },
+    );
+  });
+
+  group('injectTemplateToDevice (delegating)', () {
+    blocTest<MetadataSyncCubit, MetadataSyncState>(
+      'injectTemplateToDevice applies all template slots',
+      build: () {
+        when(() => mockManager.requestNumAlgorithmsInPreset())
+            .thenAnswer((_) async => 0);
+        when(() => mockManager.requestAddAlgorithm(any(), any()))
+            .thenAnswer((_) async => {});
+        when(() => mockManager.setParameterValue(any(), any(), any()))
+            .thenAnswer((_) async => {});
+        when(() => mockManager.requestSetMapping(any(), any(), any()))
+            .thenAnswer((_) async => {});
+        when(() => mockManager.requestSendSlotName(any(), any()))
+            .thenAnswer((_) async => {});
+        when(() => mockMetadataDao.getFullAlgorithmDetails(any())).thenAnswer(
+          (_) async => FullAlgorithmDetails(
+            algorithm: AlgorithmEntry(
+              guid: 'guid-1',
+              name: 'Alg 1',
+              numSpecifications: 0,
+            ),
+            specifications: [],
+            parameters: [],
+            parameterPages: [],
+            enums: {},
+          ),
+        );
+        when(() => mockMetadataDao.getAllAlgorithms())
+            .thenAnswer((_) async => []);
+        when(() => mockMetadataDao.getAlgorithmParameterCounts())
+            .thenAnswer((_) async => <String, int>{});
+        when(() => mockPresetsDao.getAllPresets())
+            .thenAnswer((_) async => <PresetEntry>[]);
+        return cubit;
+      },
+      act: (c) async {
+        await c.injectTemplateToDevice(
+          _template(slots: [
+            for (var i = 0; i < 3; i++)
+              FullPresetSlot(
+                slot: PresetSlotEntry(
+                  id: i + 1,
+                  presetId: 1,
+                  slotIndex: i,
+                  algorithmGuid: 'guid-1',
+                ),
+                algorithm: AlgorithmEntry(
+                  guid: 'guid-1',
+                  name: 'Alg 1',
+                  numSpecifications: 0,
+                ),
+                parameterValues: {},
+                parameterStringValues: {},
+                mappings: {},
+              ),
+          ]),
+          mockManager,
+        );
+      },
+      verify: (_) {
+        verify(() => mockManager.requestAddAlgorithm(any(), any())).called(3);
+      },
+    );
+  });
+}

--- a/test/ui/metadata_sync/metadata_sync_cubit_inject_template_test.dart
+++ b/test/ui/metadata_sync/metadata_sync_cubit_inject_template_test.dart
@@ -122,7 +122,7 @@ void main() {
         await cubit.injectTemplateToDevice(template, mockMidiManager);
       },
       expect: () => [
-        const MetadataSyncState.loadingPreset(),
+        const MetadataSyncState.injectingTemplate(applied: 0, total: 2),
         isA<PresetLoadFailure>().having(
           (state) => state.error,
           'error message',
@@ -483,7 +483,7 @@ void main() {
         await cubit.injectTemplateToDevice(emptyTemplate, mockMidiManager);
       },
       expect: () => [
-        const MetadataSyncState.loadingPreset(),
+        const MetadataSyncState.injectingTemplate(applied: 0, total: 0),
         isA<PresetLoadFailure>().having(
           (state) => state.error,
           'error message',
@@ -533,7 +533,7 @@ void main() {
         await cubit.injectTemplateToDevice(template, mockMidiManager);
       },
       expect: () => [
-        const MetadataSyncState.loadingPreset(),
+        const MetadataSyncState.injectingTemplate(applied: 0, total: 1),
         isA<PresetLoadFailure>().having(
           (state) => state.error,
           'error message',

--- a/test/ui/template_manager/create_template_from_preset_dialog_test.dart
+++ b/test/ui/template_manager/create_template_from_preset_dialog_test.dart
@@ -16,7 +16,11 @@ FullPresetSlot _slot(int index, String guid) {
       algorithmGuid: guid,
       customName: 'Slot $index',
     ),
-    algorithm: AlgorithmEntry(guid: guid, name: 'Alg $guid', numSpecifications: 0),
+    algorithm: AlgorithmEntry(
+      guid: guid,
+      name: 'Alg $guid',
+      numSpecifications: 0,
+    ),
     parameterValues: {index: index + 100},
     parameterStringValues: {},
     mappings: {},
@@ -78,11 +82,26 @@ void main() {
     await tester.tap(find.text('Open'));
     await tester.pumpAndSettle();
 
-    await tester.enterText(find.byKey(const ValueKey('template-name')), 'FX Pair');
-    await tester.enterText(find.byKey(const ValueKey('template-category')), 'Ambience');
-    await tester.enterText(find.byKey(const ValueKey('template-description')), 'Delay and reverb');
-    await tester.enterText(find.byKey(const ValueKey('template-tags')), 'wide, live');
-    await tester.enterText(find.byKey(const ValueKey('template-author')), 'Neal');
+    await tester.enterText(
+      find.byKey(const ValueKey('template-name')),
+      'FX Pair',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('template-category')),
+      'Ambience',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('template-description')),
+      'Delay and reverb',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('template-tags')),
+      'wide, live',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('template-author')),
+      'Neal',
+    );
     await tester.tap(find.byTooltip('Select all visible slots'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Create template'));

--- a/test/ui/template_manager/create_template_from_preset_dialog_test.dart
+++ b/test/ui/template_manager/create_template_from_preset_dialog_test.dart
@@ -1,0 +1,111 @@
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/db/daos/presets_dao.dart';
+import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/ui/template_manager/create_template_from_preset_dialog.dart';
+
+FullPresetSlot _slot(int index, String guid) {
+  return FullPresetSlot(
+    slot: PresetSlotEntry(
+      id: -1,
+      presetId: -1,
+      slotIndex: index,
+      algorithmGuid: guid,
+      customName: 'Slot $index',
+    ),
+    algorithm: AlgorithmEntry(guid: guid, name: 'Alg $guid', numSpecifications: 0),
+    parameterValues: {index: index + 100},
+    parameterStringValues: {},
+    mappings: {},
+  );
+}
+
+Future<void> _seedAlgorithm(AppDatabase db, String guid) async {
+  await db.metadataDao.upsertAlgorithms([
+    AlgorithmEntry(guid: guid, name: 'Alg $guid', numSpecifications: 0),
+  ]);
+}
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    await _seedAlgorithm(db, 'AAAA');
+    await _seedAlgorithm(db, 'BBBB');
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  testWidgets('creates a template from selected preset slots with metadata', (
+    tester,
+  ) async {
+    final source = FullPresetDetails(
+      preset: PresetEntry(
+        id: 7,
+        name: 'Source',
+        lastModified: DateTime(2026),
+        isTemplate: false,
+      ),
+      slots: [_slot(0, 'AAAA'), _slot(1, 'BBBB')],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => TextButton(
+              onPressed: () {
+                showDialog<void>(
+                  context: context,
+                  builder: (_) => CreateTemplateFromPresetDialog(
+                    database: db,
+                    source: source,
+                  ),
+                );
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byKey(const ValueKey('template-name')), 'FX Pair');
+    await tester.enterText(find.byKey(const ValueKey('template-category')), 'Ambience');
+    await tester.enterText(find.byKey(const ValueKey('template-description')), 'Delay and reverb');
+    await tester.enterText(find.byKey(const ValueKey('template-tags')), 'wide, live');
+    await tester.enterText(find.byKey(const ValueKey('template-author')), 'Neal');
+    await tester.tap(find.byTooltip('Select all visible slots'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Create template'));
+    await tester.pumpAndSettle();
+
+    final templates = await db.presetsDao.getTemplates();
+    expect(templates, hasLength(1));
+    final created = templates.single;
+    expect(created.preset.name, 'FX Pair');
+    expect(created.preset.category, 'Ambience');
+    expect(created.slots, hasLength(2));
+    expect(created.slots.map((slot) => slot.slot.slotIndex), [0, 1]);
+    expect(created.slots.map((slot) => slot.slot.algorithmGuid), [
+      'AAAA',
+      'BBBB',
+    ]);
+    expect(created.slots.last.parameterValues[1], 101);
+
+    final metadata =
+        jsonDecode(created.preset.templateMetadata!) as Map<String, dynamic>;
+    expect(metadata['description'], 'Delay and reverb');
+    expect(metadata['tags'], ['wide', 'live']);
+    expect(metadata['author'], 'Neal');
+    expect(metadata['schemaVersion'], 1);
+  });
+}

--- a/test/ui/template_manager/template_apply_dialog_test.dart
+++ b/test/ui/template_manager/template_apply_dialog_test.dart
@@ -115,6 +115,39 @@ void main() {
     expect(target.slots.map((slot) => slot.slot.algorithmGuid), ['BBBB']);
   });
 
+  testWidgets('replace mode replaces from the selected start slot', (
+    tester,
+  ) async {
+    final templateId = await _savePreset(
+      db,
+      'Starter',
+      isTemplate: true,
+      slots: [_slot(0, 'BBBB')],
+    );
+    final targetId = await _savePreset(
+      db,
+      'Target',
+      isTemplate: false,
+      slots: [_slot(0, 'AAAA'), _slot(1, 'AAAA')],
+    );
+    final template = (await db.presetsDao.getFullPresetDetails(templateId))!;
+
+    await _pumpDialog(tester, db: db, template: template, selected: {0});
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Replace existing slots'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Apply selected'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Applied 1 slot'), findsOneWidget);
+    final target = (await db.presetsDao.getFullPresetDetails(targetId))!;
+    expect(target.slots.map((slot) => slot.slot.algorithmGuid), [
+      'BBBB',
+      'AAAA',
+    ]);
+  });
+
   testWidgets('renders TemplateSpaceException diagnostics', (tester) async {
     final templateId = await _savePreset(
       db,
@@ -178,5 +211,55 @@ void main() {
 
     expect(cancelled, isTrue);
     completer.complete();
+  });
+
+  testWidgets('current device target is disabled without apply callback', (
+    tester,
+  ) async {
+    final templateId = await _savePreset(
+      db,
+      'Starter',
+      isTemplate: true,
+      slots: [_slot(0, 'AAAA')],
+    );
+    await _savePreset(db, 'Target', isTemplate: false, slots: const []);
+    final template = (await db.presetsDao.getFullPresetDetails(templateId))!;
+
+    await _pumpDialog(tester, db: db, template: template, selected: {0});
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Current device'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Target preset'), findsOneWidget);
+  });
+
+  testWidgets('device apply surfaces callback failures instead of success', (
+    tester,
+  ) async {
+    final templateId = await _savePreset(
+      db,
+      'Starter',
+      isTemplate: true,
+      slots: [_slot(0, 'AAAA')],
+    );
+    final template = (await db.presetsDao.getFullPresetDetails(templateId))!;
+
+    await _pumpDialog(
+      tester,
+      db: db,
+      template: template,
+      selected: {0},
+      onApplyDevice: () async => throw StateError('device failed'),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Current device'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Apply selected'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('device failed'), findsOneWidget);
+    expect(find.textContaining('Applied 1 slot'), findsNothing);
   });
 }

--- a/test/ui/template_manager/template_apply_dialog_test.dart
+++ b/test/ui/template_manager/template_apply_dialog_test.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/db/daos/presets_dao.dart';
+import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/ui/template_manager/template_apply_dialog.dart';
+
+FullPresetSlot _slot(int index, String guid) {
+  return FullPresetSlot(
+    slot: PresetSlotEntry(
+      id: -1,
+      presetId: -1,
+      slotIndex: index,
+      algorithmGuid: guid,
+    ),
+    algorithm: AlgorithmEntry(guid: guid, name: 'Alg $guid', numSpecifications: 0),
+    parameterValues: {index: index * 10},
+    parameterStringValues: {},
+    mappings: {},
+  );
+}
+
+Future<void> _seedAlgorithm(AppDatabase db, String guid) async {
+  await db.metadataDao.upsertAlgorithms([
+    AlgorithmEntry(guid: guid, name: 'Alg $guid', numSpecifications: 0),
+  ]);
+}
+
+Future<int> _savePreset(
+  AppDatabase db,
+  String name, {
+  required bool isTemplate,
+  required List<FullPresetSlot> slots,
+}) {
+  return db.presetsDao.saveFullPreset(
+    FullPresetDetails(
+      preset: PresetEntry(
+        id: -1,
+        name: name,
+        lastModified: DateTime(2026),
+        isTemplate: isTemplate,
+      ),
+      slots: slots,
+    ),
+    isTemplate: isTemplate,
+  );
+}
+
+Future<void> _pumpDialog(
+  WidgetTester tester, {
+  required AppDatabase db,
+  required FullPresetDetails template,
+  required Set<int> selected,
+  Future<void> Function()? onApplyDevice,
+  VoidCallback? onCancelDeviceApply,
+}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: TemplateApplyDialog(
+          database: db,
+          template: template,
+          selectedIndices: selected,
+          onApplyDevice: onApplyDevice,
+          onCancelDeviceApply: onCancelDeviceApply,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    await _seedAlgorithm(db, 'AAAA');
+    await _seedAlgorithm(db, 'BBBB');
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  testWidgets('applies selected slots to an existing preset', (tester) async {
+    final templateId = await _savePreset(
+      db,
+      'Starter',
+      isTemplate: true,
+      slots: [_slot(0, 'AAAA'), _slot(1, 'BBBB')],
+    );
+    final targetId = await _savePreset(
+      db,
+      'Target',
+      isTemplate: false,
+      slots: const [],
+    );
+    final template = (await db.presetsDao.getFullPresetDetails(templateId))!;
+
+    await _pumpDialog(tester, db: db, template: template, selected: {1});
+    await tester.pumpAndSettle();
+
+    expect(find.text('Target'), findsOneWidget);
+    await tester.tap(find.text('Apply selected'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Applied 1 slot'), findsOneWidget);
+    final target = (await db.presetsDao.getFullPresetDetails(targetId))!;
+    expect(target.slots.map((slot) => slot.slot.algorithmGuid), ['BBBB']);
+  });
+
+  testWidgets('renders TemplateSpaceException diagnostics', (tester) async {
+    final templateId = await _savePreset(
+      db,
+      'Too Big',
+      isTemplate: true,
+      slots: [_slot(0, 'AAAA'), _slot(1, 'BBBB')],
+    );
+    await _savePreset(
+      db,
+      'Crowded',
+      isTemplate: false,
+      slots: [for (var i = 0; i < 31; i++) _slot(i, 'AAAA')],
+    );
+    final template = (await db.presetsDao.getFullPresetDetails(templateId))!;
+
+    await _pumpDialog(tester, db: db, template: template, selected: {0, 1});
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Apply selected'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('31 existing'), findsOneWidget);
+    expect(
+      find.text('31 existing + 2 selected exceeds the 32-slot limit.'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('32-slot limit'), findsOneWidget);
+  });
+
+  testWidgets('device apply cancel button invokes cancellation callback', (
+    tester,
+  ) async {
+    final templateId = await _savePreset(
+      db,
+      'Starter',
+      isTemplate: true,
+      slots: [_slot(0, 'AAAA')],
+    );
+    final template = (await db.presetsDao.getFullPresetDetails(templateId))!;
+    final completer = Completer<void>();
+    var cancelled = false;
+
+    await _pumpDialog(
+      tester,
+      db: db,
+      template: template,
+      selected: {0},
+      onApplyDevice: () => completer.future,
+      onCancelDeviceApply: () => cancelled = true,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Current device'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Apply selected'));
+    await tester.pump();
+
+    expect(find.text('Cancel'), findsOneWidget);
+    await tester.tap(find.text('Cancel'));
+    await tester.pump();
+
+    expect(cancelled, isTrue);
+    completer.complete();
+  });
+}

--- a/test/ui/template_manager/template_apply_dialog_test.dart
+++ b/test/ui/template_manager/template_apply_dialog_test.dart
@@ -15,7 +15,11 @@ FullPresetSlot _slot(int index, String guid) {
       slotIndex: index,
       algorithmGuid: guid,
     ),
-    algorithm: AlgorithmEntry(guid: guid, name: 'Alg $guid', numSpecifications: 0),
+    algorithm: AlgorithmEntry(
+      guid: guid,
+      name: 'Alg $guid',
+      numSpecifications: 0,
+    ),
     parameterValues: {index: index * 10},
     parameterStringValues: {},
     mappings: {},

--- a/test/ui/template_manager/template_manager_route_test.dart
+++ b/test/ui/template_manager/template_manager_route_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/disting_app.dart';
+
+void main() {
+  test('DistingApp exposes the Template Manager route', () {
+    expect(DistingApp.templateManagerRoute, '/template-manager');
+    expect(DistingApp.buildRoutes(), contains(DistingApp.templateManagerRoute));
+  });
+}

--- a/test/ui/template_manager/template_manager_screen_test.dart
+++ b/test/ui/template_manager/template_manager_screen_test.dart
@@ -100,4 +100,19 @@ void main() {
     expect(find.text('Delay'), findsNothing);
     expect(find.text('Reverb'), findsOneWidget);
   });
+
+  testWidgets('opens apply dialog for selected slots', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(home: TemplateManagerScreen(database: db)),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Delay').last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Apply selected'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Apply template slots'), findsOneWidget);
+    expect(find.textContaining('1 selected from Space Kit'), findsOneWidget);
+  });
 }

--- a/test/ui/template_manager/template_manager_screen_test.dart
+++ b/test/ui/template_manager/template_manager_screen_test.dart
@@ -1,0 +1,103 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/db/daos/presets_dao.dart';
+import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/models/template_metadata.dart';
+import 'package:nt_helper/ui/template_manager/template_manager_screen.dart';
+
+FullPresetSlot _slot(int index, String guid, String name) {
+  return FullPresetSlot(
+    slot: PresetSlotEntry(
+      id: -1,
+      presetId: -1,
+      slotIndex: index,
+      algorithmGuid: guid,
+    ),
+    algorithm: AlgorithmEntry(guid: guid, name: name, numSpecifications: 0),
+    parameterValues: {0: 10},
+    parameterStringValues: {},
+    mappings: {},
+  );
+}
+
+Future<void> _seedAlgorithm(AppDatabase db, String guid, String name) async {
+  await db.metadataDao.upsertAlgorithms([
+    AlgorithmEntry(guid: guid, name: name, numSpecifications: 0),
+  ]);
+}
+
+Future<void> _saveTemplate(
+  AppDatabase db,
+  String name, {
+  String? category,
+  required TemplateMetadata metadata,
+  required List<FullPresetSlot> slots,
+}) async {
+  await db.presetsDao.saveFullPreset(
+    FullPresetDetails(
+      preset: PresetEntry(
+        id: -1,
+        name: name,
+        lastModified: DateTime(2026),
+        isTemplate: true,
+        category: category,
+        templateMetadata: metadata.toJsonString(),
+      ),
+      slots: slots,
+    ),
+    isTemplate: true,
+  );
+}
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    await _seedAlgorithm(db, 'dely', 'Delay');
+    await _seedAlgorithm(db, 'rvb', 'Reverb');
+    await _saveTemplate(
+      db,
+      'Space Kit',
+      category: 'Ambience',
+      metadata: const TemplateMetadata(tags: ['wide'], author: 'Neal'),
+      slots: [_slot(0, 'dely', 'Delay'), _slot(1, 'rvb', 'Reverb')],
+    );
+    await _saveTemplate(
+      db,
+      'Utility Kit',
+      metadata: const TemplateMetadata(tags: ['utility']),
+      slots: [_slot(0, 'dely', 'Delay')],
+    );
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  testWidgets('renders templates grouped by category and filters slots', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(home: TemplateManagerScreen(database: db)),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Ambience'), findsOneWidget);
+    expect(find.text('Uncategorized'), findsOneWidget);
+    expect(find.text('Space Kit'), findsWidgets);
+    expect(find.text('wide'), findsWidgets);
+
+    await tester.tap(find.text('Space Kit').first);
+    await tester.pumpAndSettle();
+    expect(find.text('Neal'), findsOneWidget);
+    expect(find.text('Delay'), findsOneWidget);
+    expect(find.text('Reverb'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField).last, 'verb');
+    await tester.pumpAndSettle();
+    expect(find.text('Delay'), findsNothing);
+    expect(find.text('Reverb'), findsOneWidget);
+  });
+}

--- a/test/ui/template_manager/template_manager_screen_test.dart
+++ b/test/ui/template_manager/template_manager_screen_test.dart
@@ -115,4 +115,37 @@ void main() {
     expect(find.text('Apply template slots'), findsOneWidget);
     expect(find.textContaining('1 selected from Space Kit'), findsOneWidget);
   });
+
+  testWidgets('passes selected slots to current-device apply callback', (
+    tester,
+  ) async {
+    FullPresetDetails? appliedTemplate;
+    List<int>? appliedSlots;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: TemplateManagerScreen(
+          database: db,
+          onApplyDevice: (template, selectedIndices) async {
+            appliedTemplate = template;
+            appliedSlots = selectedIndices;
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reverb').last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Apply selected'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Current device'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Apply selected').last);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Applied 1 slot'), findsOneWidget);
+    expect(appliedTemplate?.preset.name, 'Space Kit');
+    expect(appliedSlots, [1]);
+  });
 }

--- a/test/ui/template_manager/template_slot_selection_list_test.dart
+++ b/test/ui/template_manager/template_slot_selection_list_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/db/daos/presets_dao.dart';
+import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/ui/template_manager/template_slot_selection_list.dart';
+
+FullPresetDetails _template() {
+  FullPresetSlot slot(int index, String guid, String name) {
+    return FullPresetSlot(
+      slot: PresetSlotEntry(
+        id: index + 1,
+        presetId: 1,
+        slotIndex: index,
+        algorithmGuid: guid,
+      ),
+      algorithm: AlgorithmEntry(guid: guid, name: name, numSpecifications: 0),
+      parameterValues: {0: index},
+      parameterStringValues: {},
+      mappings: {},
+    );
+  }
+
+  return FullPresetDetails(
+    preset: PresetEntry(
+      id: 1,
+      name: 'Starter',
+      lastModified: DateTime(2026),
+      isTemplate: true,
+    ),
+    slots: [
+      slot(0, 'dely', 'Delay'),
+      slot(1, 'chor', 'Chorus'),
+      slot(2, 'rvb', 'Reverb'),
+    ],
+  );
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required Set<int> selected,
+  required ValueChanged<Set<int>> onChanged,
+}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: TemplateSlotSelectionList(
+          template: _template(),
+          selectedIndices: selected,
+          onSelectionChanged: onChanged,
+          currentTargetSlotCount: 4,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('toggles rows and supports select all / none', (tester) async {
+    var selected = <int>{};
+
+    await _pump(
+      tester,
+      selected: selected,
+      onChanged: (next) => selected = next,
+    );
+
+    await tester.tap(find.text('Delay'));
+    await tester.pumpAndSettle();
+    expect(selected, {0});
+
+    await _pump(
+      tester,
+      selected: selected,
+      onChanged: (next) => selected = next,
+    );
+    await tester.tap(find.byTooltip('Select all visible slots'));
+    await tester.pumpAndSettle();
+    expect(selected, {0, 1, 2});
+
+    await _pump(
+      tester,
+      selected: selected,
+      onChanged: (next) => selected = next,
+    );
+    await tester.tap(find.byTooltip('Select none'));
+    await tester.pumpAndSettle();
+    expect(selected, isEmpty);
+  });
+
+  testWidgets('filters by algorithm name and renders space readout', (
+    tester,
+  ) async {
+    await _pump(tester, selected: {0, 2}, onChanged: (_) {});
+
+    expect(find.text('Delay'), findsOneWidget);
+    expect(find.text('Chorus'), findsOneWidget);
+    expect(
+      find.textContaining('2 selected + 4 current = 6 / 32'),
+      findsOneWidget,
+    );
+
+    await tester.enterText(find.byType(TextField), 'verb');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Delay'), findsNothing);
+    expect(find.text('Chorus'), findsNothing);
+    expect(find.text('Reverb'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Adds multi-algorithm template support across persistence, metadata sync, MCP tooling, and the Flutter UI.

- Adds schema v12 template metadata storage and resilient JSON round-trip handling.
- Adds partial template application in PresetsDao, plus cubit/device helpers for applying templates to presets and connected devices.
- Adds template creation/application dialogs, the template manager route, and associated navigation entry points.
- Adds the MCP apply-template tool and updates MCP documentation.
- Adds focused coverage for migrations, model serialization, DAO behavior, MCP tool behavior, cubit flows, and template manager UI.

## Impact

Users can create reusable templates from existing presets and apply selected template slots into other presets or a connected device without replacing unrelated slots. MCP clients can also trigger template application through the new tool surface.

## Validation

- flutter analyze
- flutter test

Both passed locally. Flutter emitted existing Swift Package Manager adoption warnings for several plugins during both commands.