### PR TITLE
fix(routing): preserve duplicate channel input ports

### DIFF
--- a/lib/core/routing/multi_channel_algorithm_routing.dart
+++ b/lib/core/routing/multi_channel_algorithm_routing.dart
@@ -581,9 +581,14 @@ class MultiChannelAlgorithmRouting extends CachedAlgorithmRouting {
       for (final p in slot.parameters) p.name: p,
     };
 
-    // Build a map of parameter numbers to their send page (if any)
+    // Build maps of parameter numbers to their page and send page (if any).
+    final parameterToPageName = <int, String>{};
     final parameterToSendPage = <int, String>{};
     for (final page in slot.pages.pages) {
+      for (final paramNum in page.parameters) {
+        parameterToPageName[paramNum] = page.name;
+      }
+
       // Check if this is a send page (e.g., "Send 1", "Send 2")
       if (page.name.startsWith('Send ') &&
           RegExp(r'Send \d+').hasMatch(page.name)) {
@@ -592,6 +597,54 @@ class MultiChannelAlgorithmRouting extends CachedAlgorithmRouting {
           parameterToSendPage[paramNum] = page.name;
         }
       }
+    }
+
+    final valueByParam = <int, int>{
+      for (final v in slot.values) v.parameterNumber: v.value,
+    };
+
+    final ioParameterEntries =
+        <({String name, int busValue, ParameterInfo? paramInfo})>[];
+    final consumedIoParameterNumbers = <int>{};
+
+    // Prefer the slot parameter list so duplicate parameter names on different
+    // pages (for example mixer channel inputs) do not collapse into one map key.
+    for (final param in slot.parameters) {
+      final isIoParameter =
+          param.isInput ||
+          param.isOutput ||
+          AlgorithmRouting.isHardcodedInput(slot.algorithm.guid, param.name);
+      if (!isIoParameter) continue;
+
+      ioParameterEntries.add((
+        name: param.name,
+        busValue: valueByParam[param.parameterNumber] ?? param.defaultValue,
+        paramInfo: param,
+      ));
+      consumedIoParameterNumbers.add(param.parameterNumber);
+    }
+
+    // Preserve compatibility with callers/tests that provide synthetic
+    // ioParameters not present in the slot metadata.
+    for (final entry in ioParameters.entries) {
+      final fallbackParamInfo = paramsByName[entry.key];
+      if (fallbackParamInfo != null &&
+          consumedIoParameterNumbers.contains(
+            fallbackParamInfo.parameterNumber,
+          )) {
+        continue;
+      }
+
+      ioParameterEntries.add((
+        name: entry.key,
+        busValue: entry.value,
+        paramInfo: fallbackParamInfo,
+      ));
+    }
+
+    final ioNameCounts = <String, int>{};
+    for (final entry in ioParameterEntries) {
+      ioNameCounts[entry.name] = (ioNameCounts[entry.name] ?? 0) + 1;
     }
 
     // Group send parameters by send number
@@ -627,12 +680,12 @@ class MultiChannelAlgorithmRouting extends CachedAlgorithmRouting {
     }
 
     // Process routing parameters as regular ports
-    for (final entry in ioParameters.entries) {
-      final paramName = entry.key;
-      final busValue = entry.value;
+    for (final entry in ioParameterEntries) {
+      final paramName = entry.name;
+      final busValue = entry.busValue;
 
       // Get parameter number for unique ID generation
-      final paramInfo = paramsByName[paramName];
+      final paramInfo = entry.paramInfo;
       final paramNumber = paramInfo?.parameterNumber ?? 0;
 
       // Check if this parameter belongs to a send page
@@ -682,10 +735,20 @@ class MultiChannelAlgorithmRouting extends CachedAlgorithmRouting {
           .replaceAll('(', '')
           .replaceAll(')', '');
 
+      final pageName = paramInfo == null
+          ? null
+          : parameterToPageName[paramInfo.parameterNumber];
+      final displayName =
+          (ioNameCounts[paramName] ?? 0) > 1 &&
+              pageName != null &&
+              pageName.isNotEmpty
+          ? '$pageName: $paramName'
+          : paramName;
+
       final port = {
         'id': '${algorithmUuid ?? 'algo'}_${sanitizedName}_$paramNumber',
         // Use algorithm UUID, sanitized name, and parameter number for uniqueness
-        'name': paramName, // Keep original name for display
+        'name': displayName,
         'type': portType == PortType.audio
             ? 'audio'
             : 'cv', // Store as string for parsing

--- a/test/core/routing/duplicate_parameter_name_routing_test.dart
+++ b/test/core/routing/duplicate_parameter_name_routing_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/core/routing/algorithm_routing.dart';
+import 'package:nt_helper/core/routing/connection_discovery_service.dart';
+import 'package:nt_helper/core/routing/models/connection.dart';
+import 'package:nt_helper/cubit/disting_cubit.dart';
+import 'package:nt_helper/domain/disting_nt_sysex.dart';
+
+void main() {
+  group('duplicate parameter name routing', () {
+    test(
+      'preserves mixer channel inputs that share the same parameter names',
+      () {
+        final routing = AlgorithmRouting.fromSlot(
+          _createMixerSlotWithChannels(),
+        );
+
+        expect(
+          routing.inputPorts.map((p) => p.busValue),
+          containsAll(<int>[11, 12, 10, 9]),
+        );
+        expect(
+          routing.inputPorts.map((p) => p.parameterNumber),
+          containsAll(<int>[10, 11, 20, 21, 30, 31]),
+        );
+        expect(
+          routing.inputPorts.map((p) => p.name),
+          containsAll(<String>[
+            'Channel 1: From:Input left/mono',
+            'Channel 1: From:Input right',
+            'Channel 2: From:Input left/mono',
+            'Channel 3: From:Input left/mono',
+          ]),
+        );
+      },
+    );
+
+    test(
+      'discovers hardware input connections for duplicated mixer inputs',
+      () {
+        final routing = AlgorithmRouting.fromSlot(
+          _createMixerSlotWithChannels(),
+          algorithmUuid: 'mixer_1',
+        );
+
+        final connections = ConnectionDiscoveryService.discoverConnections([
+          routing,
+        ]);
+        final hardwareInputs = connections
+            .where((c) => c.connectionType == ConnectionType.hardwareInput)
+            .toList();
+
+        expect(
+          hardwareInputs.map((c) => c.busNumber),
+          containsAll(<int>[11, 12, 10, 9]),
+        );
+        expect(
+          hardwareInputs
+              .where((c) => c.busNumber == 11 || c.busNumber == 12)
+              .map((c) => c.algorithmId)
+              .toSet(),
+          equals({'mixer_1'}),
+        );
+      },
+    );
+  });
+}
+
+Slot _createMixerSlotWithChannels() {
+  const algorithmIndex = 0;
+  return Slot(
+    algorithm: Algorithm(
+      algorithmIndex: algorithmIndex,
+      guid: 'mixs',
+      name: 'Mixer Stereo',
+    ),
+    routing: RoutingInfo(
+      algorithmIndex: algorithmIndex,
+      routingInfo: List.filled(6, 0),
+    ),
+    pages: ParameterPages(
+      algorithmIndex: algorithmIndex,
+      pages: [
+        ParameterPage(name: 'Channel 1', parameters: [10, 11]),
+        ParameterPage(name: 'Channel 2', parameters: [20, 21]),
+        ParameterPage(name: 'Channel 3', parameters: [30, 31]),
+      ],
+    ),
+    parameters: [
+      _inputParameter(10, 'From:Input left/mono'),
+      _inputParameter(11, 'From:Input right'),
+      _inputParameter(20, 'From:Input left/mono'),
+      _inputParameter(21, 'From:Input right'),
+      _inputParameter(30, 'From:Input left/mono'),
+      _inputParameter(31, 'From:Input right'),
+    ],
+    values: [
+      ParameterValue(
+        algorithmIndex: algorithmIndex,
+        parameterNumber: 10,
+        value: 11,
+      ),
+      ParameterValue(
+        algorithmIndex: algorithmIndex,
+        parameterNumber: 11,
+        value: 12,
+      ),
+      ParameterValue(
+        algorithmIndex: algorithmIndex,
+        parameterNumber: 20,
+        value: 10,
+      ),
+      ParameterValue(
+        algorithmIndex: algorithmIndex,
+        parameterNumber: 21,
+        value: 0,
+      ),
+      ParameterValue(
+        algorithmIndex: algorithmIndex,
+        parameterNumber: 30,
+        value: 9,
+      ),
+      ParameterValue(
+        algorithmIndex: algorithmIndex,
+        parameterNumber: 31,
+        value: 0,
+      ),
+    ],
+    enums: const [],
+    mappings: const [],
+    valueStrings: const [],
+  );
+}
+
+ParameterInfo _inputParameter(int parameterNumber, String name) {
+  const algorithmIndex = 0;
+  return ParameterInfo(
+    algorithmIndex: algorithmIndex,
+    parameterNumber: parameterNumber,
+    name: name,
+    min: 0,
+    max: 64,
+    defaultValue: 0,
+    unit: 1,
+    powerOfTen: 0,
+    ioFlags: 5, // isInput | isAudio
+  );
+}


### PR DESCRIPTION
## Summary
- Preserve duplicated routing input ports for multi-channel algorithms that reuse parameter names across channels.
- Add regression tests for duplicate parameter names and hardware input connection discovery.

## Verification
- `flutter test test/core/routing/duplicate_parameter_name_routing_test.dart`
