### PR TITLE
Add chat attachments and scoped local workspace tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # nt_helper
 
+## Fork Note: Chat Attachments + Local Workspace Access
+
+This fork is experimenting with two chat-focused additions:
+
+- Paste or attach images directly into the in-app chat so the assistant can inspect screenshots, patch diagrams, reference images, and other visual context.
+- Attach files the chat/Codex path can understand, including PDFs, TXT/Markdown/JSON/code files, Disting NT preset files, and algorithm/plugin-related files.
+- Save selected attachments into an `uploads/` folder under a user-selected chat workspace.
+- Grant the in-app chat scoped workspace tools for listing, reading, writing, and searching files without exposing arbitrary filesystem paths.
+
+The goal is to test these features in the fork first, then discuss merging them upstream if they work well.
+
 A cross-platform Flutter application designed for editing presets on the Expert Sleepers Disting NT module. It provides an intuitive interface for managing algorithms, parameters, and mappings on your Disting NT device.
 
 ## Core Features

--- a/docs/AUTHOR_HANDOFF.md
+++ b/docs/AUTHOR_HANDOFF.md
@@ -1,0 +1,47 @@
+# Handoff for Thorinside
+
+Hi Thorinside,
+
+I have opened this as a draft because it is an experimental fork change and still needs broader testing before it should be considered merge-ready.
+
+The goal is to improve the chat/Codex workflow by letting users give the assistant richer local context.
+
+## What This Adds
+
+- Image attachments in chat
+- Pasted image support
+- General file attachments for model-supported inputs such as text, JSON, PDFs, and preset/algo-style files
+- A local chat workspace directory setting
+- Scoped local workspace/upload tools for chat use only
+
+The file access is intentionally scoped. It does not expose arbitrary filesystem paths; it is limited to the selected workspace/uploads area.
+
+## Test Builds
+
+Desktop test builds from this fork are published here:
+
+https://github.com/nymphnerds/nt_helper/releases/tag/chat-attachments-test-build-v1
+
+Assets included:
+
+- Windows x64
+- Linux x64
+
+No macOS build is included yet because that requires macOS and Xcode.
+
+## Tested So Far
+
+- Windows app builds and launches
+- Image upload works in chat
+- Uploaded image displays correctly
+- The model receives and reasons about the image
+
+## Still Needs Testing
+
+- PDF attachments
+- Text/JSON attachment handling
+- Disting NT preset/algo file workflows
+- Local workspace list/read/write tools
+- Regression testing existing Disting tools
+
+I am very happy for this to be reviewed as a possible direction rather than a finished merge request.

--- a/lib/chat/cubit/chat_cubit.dart
+++ b/lib/chat/cubit/chat_cubit.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -17,6 +18,8 @@ import 'package:nt_helper/chat/services/memory_service.dart';
 import 'package:nt_helper/chat/services/system_prompt.dart';
 import 'package:nt_helper/chat/services/tool_bridge_service.dart';
 import 'package:nt_helper/mcp/tool_registry.dart';
+import 'package:nt_helper/services/settings_service.dart';
+import 'package:path/path.dart' as path;
 
 typedef LlmProviderFactory = LlmProvider Function(ChatSettings settings);
 
@@ -60,14 +63,25 @@ class ChatCubit extends Cubit<ChatState> {
        _providerFactory = providerFactory,
        super(const ChatReady());
 
-  Future<void> sendMessage(String text, ChatSettings settings) async {
-    if (text.trim().isEmpty) return;
+  Future<void> sendMessage(
+    String text,
+    ChatSettings settings, {
+    List<ChatImageAttachment> imageAttachments = const [],
+    List<ChatFileAttachment> fileAttachments = const [],
+  }) async {
+    if (text.trim().isEmpty &&
+        imageAttachments.isEmpty &&
+        fileAttachments.isEmpty) {
+      return;
+    }
 
     final currentState = state;
     if (currentState is! ChatReady || currentState.isProcessing) return;
 
     // Handle /context command locally — no API call needed
-    if (text.trim().toLowerCase() == '/context') {
+    if (text.trim().toLowerCase() == '/context' &&
+        imageAttachments.isEmpty &&
+        fileAttachments.isEmpty) {
       _handleContextCommand(currentState);
       return;
     }
@@ -82,7 +96,14 @@ class ChatCubit extends Cubit<ChatState> {
     }
 
     // Show processing state immediately
-    final userMessage = ChatMessage.user(text.trim());
+    final messageText = text.trim().isEmpty
+        ? _defaultAttachmentMessage(imageAttachments, fileAttachments)
+        : text.trim();
+    final userMessage = ChatMessage.user(
+      messageText,
+      imageAttachments: imageAttachments,
+      fileAttachments: fileAttachments,
+    );
     final messages = [...currentState.messages, userMessage];
     emit(currentState.copyWith(messages: messages, isProcessing: true));
 
@@ -108,9 +129,43 @@ class ChatCubit extends Cubit<ChatState> {
         await _performCompaction(settings);
       }
 
+      final uploadedPaths = await _saveAttachmentsToUploads(
+        imageAttachments,
+        fileAttachments,
+      );
+      final llmMessageText = uploadedPaths.isEmpty
+          ? messageText
+          : _messageWithUploadedPaths(messageText, uploadedPaths);
+
       // Add to LLM history
       _historyLengthBeforeLoop = _llmHistory.length;
-      _llmHistory.add(LlmMessage.user(text.trim()));
+      final llmImageAttachments = imageAttachments
+          .map(
+            (image) => LlmImageAttachment(
+              data: image.data,
+              mimeType: image.mimeType,
+              name: image.name,
+            ),
+          )
+          .toList();
+      final llmFileAttachments = fileAttachments
+          .map(
+            (file) => LlmFileAttachment(
+              name: file.name,
+              data: file.data,
+              mimeType: file.mimeType,
+              sizeBytes: file.sizeBytes,
+              textContent: file.textContent,
+            ),
+          )
+          .toList();
+      _llmHistory.add(
+        LlmMessage.user(
+          _messageWithFileAttachments(llmMessageText, fileAttachments),
+          imageAttachments: llmImageAttachments,
+          fileAttachments: llmFileAttachments,
+        ),
+      );
 
       // Create provider (disposing the previous one first)
       _activeProvider?.dispose();
@@ -167,6 +222,109 @@ class ChatCubit extends Cubit<ChatState> {
           ),
         );
       }
+    }
+  }
+
+  String _defaultAttachmentMessage(
+    List<ChatImageAttachment> imageAttachments,
+    List<ChatFileAttachment> fileAttachments,
+  ) {
+    if (imageAttachments.isNotEmpty && fileAttachments.isNotEmpty) {
+      return 'Attached images and files.';
+    }
+    if (imageAttachments.isNotEmpty) return 'Attached image.';
+    return 'Attached file.';
+  }
+
+  String _messageWithFileAttachments(
+    String messageText,
+    List<ChatFileAttachment> fileAttachments,
+  ) {
+    final buffer = StringBuffer(messageText);
+    for (final file in fileAttachments) {
+      if (file.textContent == null) continue;
+      buffer
+        ..writeln()
+        ..writeln()
+        ..writeln(
+          '--- Attached file: ${file.name} (${file.sizeBytes} bytes) ---',
+        )
+        ..writeln(file.textContent)
+        ..writeln('--- End attached file: ${file.name} ---');
+    }
+    return buffer.toString();
+  }
+
+  String _messageWithUploadedPaths(String messageText, List<String> paths) {
+    final buffer = StringBuffer(messageText)
+      ..writeln()
+      ..writeln()
+      ..writeln('Uploaded files saved in the chat workspace:');
+    for (final uploadedPath in paths) {
+      buffer.writeln('- $uploadedPath');
+    }
+    return buffer.toString();
+  }
+
+  Future<List<String>> _saveAttachmentsToUploads(
+    List<ChatImageAttachment> imageAttachments,
+    List<ChatFileAttachment> fileAttachments,
+  ) async {
+    final root = SettingsService().chatLocalDirectory?.trim();
+    if (root == null || root.isEmpty) return const [];
+
+    try {
+      final uploadsDir = Directory(path.join(root, 'uploads'));
+      await uploadsDir.create(recursive: true);
+      final saved = <String>[];
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+
+      for (var i = 0; i < imageAttachments.length; i++) {
+        final image = imageAttachments[i];
+        final name = _safeUploadName(
+          image.name ?? 'image_$i${_extensionForMime(image.mimeType)}',
+        );
+        final relativePath = path.join('uploads', '${timestamp}_$name');
+        await File(path.join(root, relativePath)).writeAsBytes(
+          base64Decode(image.data),
+        );
+        saved.add(relativePath);
+      }
+
+      for (var i = 0; i < fileAttachments.length; i++) {
+        final file = fileAttachments[i];
+        final name = _safeUploadName(file.name);
+        final relativePath = path.join('uploads', '${timestamp}_$name');
+        await File(path.join(root, relativePath)).writeAsBytes(
+          base64Decode(file.data),
+        );
+        saved.add(relativePath);
+      }
+
+      return saved;
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  String _safeUploadName(String name) {
+    final baseName = path.basename(name).replaceAll(
+      RegExp(r'[^A-Za-z0-9._-]+'),
+      '_',
+    );
+    return baseName.isEmpty ? 'attachment' : baseName;
+  }
+
+  String _extensionForMime(String mimeType) {
+    switch (mimeType) {
+      case 'image/jpeg':
+        return '.jpg';
+      case 'image/webp':
+        return '.webp';
+      case 'image/gif':
+        return '.gif';
+      default:
+        return '.png';
     }
   }
 

--- a/lib/chat/models/chat_message.dart
+++ b/lib/chat/models/chat_message.dart
@@ -13,6 +13,34 @@ enum ChatMessageRole {
   compaction,
 }
 
+class ChatImageAttachment {
+  final String data;
+  final String mimeType;
+  final String? name;
+
+  const ChatImageAttachment({
+    required this.data,
+    required this.mimeType,
+    this.name,
+  });
+}
+
+class ChatFileAttachment {
+  final String name;
+  final String data;
+  final String mimeType;
+  final int sizeBytes;
+  final String? textContent;
+
+  const ChatFileAttachment({
+    required this.name,
+    required this.data,
+    required this.mimeType,
+    required this.sizeBytes,
+    this.textContent,
+  });
+}
+
 class ChatMessage {
   final String id;
   final ChatMessageRole role;
@@ -22,6 +50,8 @@ class ChatMessage {
   final Map<String, dynamic>? toolArguments;
   final String? imageBase64;
   final String? imageMimeType;
+  final List<ChatImageAttachment> imageAttachments;
+  final List<ChatFileAttachment> fileAttachments;
   final DateTime timestamp;
 
   const ChatMessage({
@@ -33,15 +63,25 @@ class ChatMessage {
     this.toolArguments,
     this.imageBase64,
     this.imageMimeType,
+    this.imageAttachments = const [],
+    this.fileAttachments = const [],
     required this.timestamp,
   });
 
   bool get hasImage => imageBase64 != null && imageMimeType != null;
+  bool get hasImageAttachments => imageAttachments.isNotEmpty;
+  bool get hasFileAttachments => fileAttachments.isNotEmpty;
 
-  factory ChatMessage.user(String content) => ChatMessage(
+  factory ChatMessage.user(
+    String content, {
+    List<ChatImageAttachment> imageAttachments = const [],
+    List<ChatFileAttachment> fileAttachments = const [],
+  }) => ChatMessage(
     id: _generateId(),
     role: ChatMessageRole.user,
     content: content,
+    imageAttachments: imageAttachments,
+    fileAttachments: fileAttachments,
     timestamp: DateTime.now(),
   );
 

--- a/lib/chat/models/llm_types.dart
+++ b/lib/chat/models/llm_types.dart
@@ -5,6 +5,34 @@
 
 enum LlmRole { user, assistant, tool }
 
+class LlmImageAttachment {
+  final String data;
+  final String mimeType;
+  final String? name;
+
+  const LlmImageAttachment({
+    required this.data,
+    required this.mimeType,
+    this.name,
+  });
+}
+
+class LlmFileAttachment {
+  final String name;
+  final String data;
+  final String mimeType;
+  final int sizeBytes;
+  final String? textContent;
+
+  const LlmFileAttachment({
+    required this.name,
+    required this.data,
+    required this.mimeType,
+    required this.sizeBytes,
+    this.textContent,
+  });
+}
+
 /// A message in the LLM conversation.
 class LlmMessage {
   final LlmRole role;
@@ -14,6 +42,8 @@ class LlmMessage {
   final String? toolName;
   final String? imageBase64;
   final String? imageMimeType;
+  final List<LlmImageAttachment> imageAttachments;
+  final List<LlmFileAttachment> fileAttachments;
 
   const LlmMessage({
     required this.role,
@@ -23,12 +53,24 @@ class LlmMessage {
     this.toolName,
     this.imageBase64,
     this.imageMimeType,
+    this.imageAttachments = const [],
+    this.fileAttachments = const [],
   });
 
   bool get hasImage => imageBase64 != null && imageMimeType != null;
+  bool get hasImageAttachments => imageAttachments.isNotEmpty;
+  bool get hasFileAttachments => fileAttachments.isNotEmpty;
 
-  factory LlmMessage.user(String content) =>
-      LlmMessage(role: LlmRole.user, content: content);
+  factory LlmMessage.user(
+    String content, {
+    List<LlmImageAttachment> imageAttachments = const [],
+    List<LlmFileAttachment> fileAttachments = const [],
+  }) => LlmMessage(
+    role: LlmRole.user,
+    content: content,
+    imageAttachments: imageAttachments,
+    fileAttachments: fileAttachments,
+  );
 
   factory LlmMessage.assistant(String content) =>
       LlmMessage(role: LlmRole.assistant, content: content);

--- a/lib/chat/providers/anthropic_provider.dart
+++ b/lib/chat/providers/anthropic_provider.dart
@@ -98,7 +98,36 @@ class AnthropicProvider with LlmErrorHandling implements LlmProvider {
     for (final msg in messages) {
       switch (msg.role) {
         case LlmRole.user:
-          result.add({'role': 'user', 'content': msg.content!});
+          if (msg.hasImageAttachments || msg.hasFileAttachments) {
+            result.add({
+              'role': 'user',
+              'content': <dynamic>[
+                {'type': 'text', 'text': msg.content ?? ''},
+                for (final image in msg.imageAttachments)
+                  {
+                    'type': 'image',
+                    'source': {
+                      'type': 'base64',
+                      'media_type': image.mimeType,
+                      'data': image.data,
+                    },
+                  },
+                for (final file in msg.fileAttachments)
+                  if (file.mimeType == 'application/pdf')
+                    {
+                      'type': 'document',
+                      'source': {
+                        'type': 'base64',
+                        'media_type': file.mimeType,
+                        'data': file.data,
+                      },
+                      'title': file.name,
+                    },
+              ],
+            });
+          } else {
+            result.add({'role': 'user', 'content': msg.content!});
+          }
         case LlmRole.assistant:
           if (msg.toolCalls != null && msg.toolCalls!.isNotEmpty) {
             final content = <Map<String, dynamic>>[];

--- a/lib/chat/providers/openai_provider.dart
+++ b/lib/chat/providers/openai_provider.dart
@@ -110,7 +110,23 @@ class OpenAIProvider with LlmErrorHandling implements LlmProvider {
     for (final msg in messages) {
       switch (msg.role) {
         case LlmRole.user:
-          result.add({'role': 'user', 'content': msg.content!});
+          if (msg.hasImageAttachments) {
+            result.add({
+              'role': 'user',
+              'content': <dynamic>[
+                {'type': 'text', 'text': msg.content ?? ''},
+                for (final image in msg.imageAttachments)
+                  {
+                    'type': 'image_url',
+                    'image_url': {
+                      'url': 'data:${image.mimeType};base64,${image.data}',
+                    },
+                  },
+              ],
+            });
+          } else {
+            result.add({'role': 'user', 'content': msg.content!});
+          }
         case LlmRole.assistant:
           if (msg.toolCalls != null && msg.toolCalls!.isNotEmpty) {
             final apiMsg = <String, dynamic>{'role': 'assistant'};

--- a/lib/chat/providers/openai_subscription_provider.dart
+++ b/lib/chat/providers/openai_subscription_provider.dart
@@ -96,6 +96,18 @@ class OpenAISubscriptionProvider implements LlmProvider {
             'role': 'user',
             'content': [
               {'type': 'input_text', 'text': msg.content ?? ''},
+              for (final image in msg.imageAttachments)
+                {
+                  'type': 'input_image',
+                  'image_url': 'data:${image.mimeType};base64,${image.data}',
+                },
+              for (final file in msg.fileAttachments)
+                if (_isCodexFileInput(file.mimeType))
+                  {
+                    'type': 'input_file',
+                    'filename': file.name,
+                    'file_data': 'data:${file.mimeType};base64,${file.data}',
+                  },
             ],
           });
           break;
@@ -161,6 +173,12 @@ class OpenAISubscriptionProvider implements LlmProvider {
           },
         )
         .toList();
+  }
+
+  bool _isCodexFileInput(String mimeType) {
+    return mimeType == 'application/pdf' ||
+        mimeType == 'application/json' ||
+        mimeType.startsWith('text/');
   }
 
   Future<LlmResponse> _parseEventStream(Stream<List<int>> stream) async {

--- a/lib/chat/services/local_file_tools.dart
+++ b/lib/chat/services/local_file_tools.dart
@@ -1,0 +1,508 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:nt_helper/mcp/tool_registry.dart';
+import 'package:nt_helper/services/settings_service.dart';
+import 'package:path/path.dart' as path;
+
+const localFileToolNames = {
+  'local_list_files',
+  'local_read_file',
+  'local_search_files',
+  'list_workspace_files',
+  'read_workspace_file',
+  'write_workspace_file',
+  'list_uploaded_files',
+  'read_uploaded_file',
+};
+
+void registerLocalFileTools(List<ToolRegistryEntry> entries) {
+  final tools = _LocalFileTools(SettingsService());
+
+  entries.addAll([
+    ToolRegistryEntry(
+      name: 'list_workspace_files',
+      description:
+          'List files under the user-selected chat workspace directory. Paths are relative to that workspace.',
+      inputSchema: {
+        'properties': {
+          'path': {
+            'type': 'string',
+            'description': 'Optional relative subdirectory to list.',
+          },
+          'recursive': {
+            'type': 'boolean',
+            'description': 'Whether to include nested files. Default: false.',
+          },
+          'limit': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 200,
+            'description': 'Maximum number of entries to return. Default: 50.',
+          },
+        },
+      },
+      handler: tools.listFiles,
+      timeout: const Duration(seconds: 5),
+    ),
+    ToolRegistryEntry(
+      name: 'read_workspace_file',
+      description:
+          'Read a file from the user-selected chat workspace. Text is returned as UTF-8; binary files are returned as base64. Paths are relative to that workspace.',
+      inputSchema: {
+        'properties': {
+          'path': {
+            'type': 'string',
+            'description': 'Relative path of the text file to read.',
+          },
+          'max_bytes': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 200000,
+            'description':
+                'Maximum bytes to read. Default: 100000. Larger files return an error.',
+          },
+        },
+        'required': ['path'],
+      },
+      handler: tools.readFile,
+      timeout: const Duration(seconds: 5),
+    ),
+    ToolRegistryEntry(
+      name: 'write_workspace_file',
+      description:
+          'Write a UTF-8 text file under the user-selected chat workspace. Paths are relative to that workspace.',
+      inputSchema: {
+        'properties': {
+          'path': {
+            'type': 'string',
+            'description': 'Relative path of the file to write.',
+          },
+          'content': {
+            'type': 'string',
+            'description': 'UTF-8 text content to write.',
+          },
+          'create_parents': {
+            'type': 'boolean',
+            'description': 'Create missing parent directories. Default: true.',
+          },
+        },
+        'required': ['path', 'content'],
+      },
+      handler: tools.writeFile,
+      timeout: const Duration(seconds: 5),
+    ),
+    ToolRegistryEntry(
+      name: 'list_uploaded_files',
+      description:
+          'List files under the uploads/ folder inside the selected chat workspace.',
+      inputSchema: {
+        'properties': {
+          'recursive': {
+            'type': 'boolean',
+            'description': 'Whether to include nested files. Default: false.',
+          },
+          'limit': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 200,
+            'description': 'Maximum number of entries to return. Default: 50.',
+          },
+        },
+      },
+      handler: tools.listUploadedFiles,
+      timeout: const Duration(seconds: 5),
+    ),
+    ToolRegistryEntry(
+      name: 'read_uploaded_file',
+      description:
+          'Read a file from uploads/ inside the selected chat workspace. Text is returned as UTF-8; binary files are returned as base64.',
+      inputSchema: {
+        'properties': {
+          'filename': {
+            'type': 'string',
+            'description': 'Filename or relative path under uploads/.',
+          },
+          'max_bytes': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 200000,
+            'description':
+                'Maximum bytes to read. Default: 100000. Larger files return an error.',
+          },
+        },
+        'required': ['filename'],
+      },
+      handler: tools.readUploadedFile,
+      timeout: const Duration(seconds: 5),
+    ),
+    ToolRegistryEntry(
+      name: 'local_list_files',
+      description:
+          'List files under the user-selected local chat directory. Paths are relative to that directory.',
+      inputSchema: {
+        'properties': {
+          'path': {
+            'type': 'string',
+            'description': 'Optional relative subdirectory to list.',
+          },
+          'recursive': {
+            'type': 'boolean',
+            'description': 'Whether to include nested files. Default: false.',
+          },
+          'limit': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 200,
+            'description': 'Maximum number of entries to return. Default: 50.',
+          },
+        },
+      },
+      handler: tools.listFiles,
+      timeout: const Duration(seconds: 5),
+    ),
+    ToolRegistryEntry(
+      name: 'local_read_file',
+      description:
+          'Read a file from the user-selected local chat directory. Text is returned as UTF-8; binary files are returned as base64. Paths are relative to that directory.',
+      inputSchema: {
+        'properties': {
+          'path': {
+            'type': 'string',
+            'description': 'Relative path of the text file to read.',
+          },
+          'max_bytes': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 200000,
+            'description':
+                'Maximum bytes to read. Default: 100000. Larger files return an error.',
+          },
+        },
+        'required': ['path'],
+      },
+      handler: tools.readFile,
+      timeout: const Duration(seconds: 5),
+    ),
+    ToolRegistryEntry(
+      name: 'local_search_files',
+      description:
+          'Search UTF-8 text files under the user-selected local chat directory. Paths are relative to that directory.',
+      inputSchema: {
+        'properties': {
+          'query': {
+            'type': 'string',
+            'description': 'Case-insensitive text to search for.',
+          },
+          'path': {
+            'type': 'string',
+            'description': 'Optional relative subdirectory to search.',
+          },
+          'limit': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 100,
+            'description': 'Maximum number of matches to return. Default: 25.',
+          },
+          'max_file_bytes': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 500000,
+            'description':
+                'Skip files larger than this many bytes. Default: 200000.',
+          },
+        },
+        'required': ['query'],
+      },
+      handler: tools.searchFiles,
+      timeout: const Duration(seconds: 10),
+    ),
+  ]);
+}
+
+class _LocalFileTools {
+  final SettingsService _settings;
+
+  _LocalFileTools(this._settings);
+
+  Future<String> listFiles(Map<String, dynamic> args) async {
+    final root = await _rootDirectory();
+    if (root == null) return _notConfigured();
+
+    final target = await _resolveUnderRoot(root, args['path'] as String?);
+    if (target == null) return _outsideRoot();
+    if (!await target.exists()) {
+      return _json({'success': false, 'error': 'path_not_found'});
+    }
+    if (target is! Directory) {
+      return _json({'success': false, 'error': 'not_a_directory'});
+    }
+
+    final recursive = args['recursive'] == true;
+    final limit = _intArg(args['limit'], fallback: 50, min: 1, max: 200);
+    final entries = <Map<String, dynamic>>[];
+
+    await for (final entity in target.list(recursive: recursive)) {
+      final stat = await entity.stat();
+      entries.add({
+        'path': _relative(root, entity.path),
+        'type': entity is Directory ? 'directory' : 'file',
+        'size': stat.type == FileSystemEntityType.file ? stat.size : null,
+        'modified': stat.modified.toIso8601String(),
+      });
+      if (entries.length >= limit) break;
+    }
+
+    return _json({
+      'success': true,
+      'root': root.path,
+      'path': _relative(root, target.path),
+      'entries': entries,
+      'truncated': entries.length >= limit,
+    });
+  }
+
+  Future<String> readFile(Map<String, dynamic> args) async {
+    final root = await _rootDirectory();
+    if (root == null) return _notConfigured();
+
+    final requestedPath = args['path'];
+    if (requestedPath is! String || requestedPath.trim().isEmpty) {
+      return _json({'success': false, 'error': 'missing_path'});
+    }
+
+    final target = await _resolveUnderRoot(root, requestedPath);
+    if (target == null) return _outsideRoot();
+    if (target is! File || !await target.exists()) {
+      return _json({'success': false, 'error': 'file_not_found'});
+    }
+
+    final maxBytes = _intArg(
+      args['max_bytes'],
+      fallback: 100000,
+      min: 1,
+      max: 200000,
+    );
+    final stat = await target.stat();
+    if (stat.size > maxBytes) {
+      return _json({
+        'success': false,
+        'error': 'file_too_large',
+        'size': stat.size,
+        'max_bytes': maxBytes,
+      });
+    }
+
+    try {
+      final content = await target.readAsString();
+      return _json({
+        'success': true,
+        'path': _relative(root, target.path),
+        'size': stat.size,
+        'encoding': 'utf8',
+        'content': content,
+      });
+    } on FormatException {
+      final bytes = await target.readAsBytes();
+      return _json({
+        'success': true,
+        'path': _relative(root, target.path),
+        'size': stat.size,
+        'encoding': 'base64',
+        'content_base64': base64Encode(bytes),
+      });
+    }
+  }
+
+  Future<String> writeFile(Map<String, dynamic> args) async {
+    final root = await _rootDirectory();
+    if (root == null) return _notConfigured();
+
+    final requestedPath = args['path'];
+    final content = args['content'];
+    if (requestedPath is! String || requestedPath.trim().isEmpty) {
+      return _json({'success': false, 'error': 'missing_path'});
+    }
+    if (content is! String) {
+      return _json({'success': false, 'error': 'missing_content'});
+    }
+    if (content.length > 500000) {
+      return _json({
+        'success': false,
+        'error': 'content_too_large',
+        'max_chars': 500000,
+      });
+    }
+
+    final target = await _resolveUnderRoot(root, requestedPath);
+    if (target == null) return _outsideRoot();
+    if (target is Directory) {
+      return _json({'success': false, 'error': 'path_is_directory'});
+    }
+
+    final createParents = args['create_parents'] != false;
+    final parent = Directory(path.dirname(target.path));
+    if (!await parent.exists()) {
+      if (!createParents) {
+        return _json({'success': false, 'error': 'parent_not_found'});
+      }
+      await parent.create(recursive: true);
+    }
+
+    await File(target.path).writeAsString(content);
+    final stat = await File(target.path).stat();
+    return _json({
+      'success': true,
+      'path': _relative(root, target.path),
+      'size': stat.size,
+    });
+  }
+
+  Future<String> listUploadedFiles(Map<String, dynamic> args) {
+    return listFiles({...args, 'path': 'uploads'});
+  }
+
+  Future<String> readUploadedFile(Map<String, dynamic> args) {
+    final filename = args['filename'];
+    if (filename is! String || filename.trim().isEmpty) {
+      return Future.value(_json({'success': false, 'error': 'missing_filename'}));
+    }
+    return readFile({
+      ...args,
+      'path': path.join('uploads', filename),
+    });
+  }
+
+  Future<String> searchFiles(Map<String, dynamic> args) async {
+    final root = await _rootDirectory();
+    if (root == null) return _notConfigured();
+
+    final query = args['query'];
+    if (query is! String || query.trim().isEmpty) {
+      return _json({'success': false, 'error': 'missing_query'});
+    }
+
+    final target = await _resolveUnderRoot(root, args['path'] as String?);
+    if (target == null) return _outsideRoot();
+    if (target is! Directory || !await target.exists()) {
+      return _json({'success': false, 'error': 'directory_not_found'});
+    }
+
+    final limit = _intArg(args['limit'], fallback: 25, min: 1, max: 100);
+    final maxFileBytes = _intArg(
+      args['max_file_bytes'],
+      fallback: 200000,
+      min: 1,
+      max: 500000,
+    );
+    final needle = query.toLowerCase();
+    final matches = <Map<String, dynamic>>[];
+
+    await for (final entity in target.list(recursive: true)) {
+      if (entity is! File) continue;
+      final stat = await entity.stat();
+      if (stat.size > maxFileBytes) continue;
+
+      String content;
+      try {
+        content = await entity.readAsString();
+      } on FormatException {
+        continue;
+      }
+
+      final lines = const LineSplitter().convert(content);
+      for (var i = 0; i < lines.length; i++) {
+        final line = lines[i];
+        final matchIndex = line.toLowerCase().indexOf(needle);
+        if (matchIndex == -1) continue;
+        matches.add({
+          'path': _relative(root, entity.path),
+          'line': i + 1,
+          'preview': line.trim(),
+        });
+        if (matches.length >= limit) {
+          return _json({
+            'success': true,
+            'root': root.path,
+            'query': query,
+            'matches': matches,
+            'truncated': true,
+          });
+        }
+      }
+    }
+
+    return _json({
+      'success': true,
+      'root': root.path,
+      'query': query,
+      'matches': matches,
+      'truncated': false,
+    });
+  }
+
+  Future<Directory?> _rootDirectory() async {
+    final configured = _settings.chatLocalDirectory?.trim();
+    if (configured == null || configured.isEmpty) return null;
+    final root = Directory(configured);
+    if (!await root.exists()) return null;
+    return Directory(await root.resolveSymbolicLinks());
+  }
+
+  Future<FileSystemEntity?> _resolveUnderRoot(
+    Directory root,
+    String? relativePath,
+  ) async {
+    final rawPath = relativePath?.trim();
+    final combined = rawPath == null || rawPath.isEmpty
+        ? root.path
+        : path.join(root.path, rawPath);
+    final normalized = path.normalize(combined);
+    final parent = Directory(path.dirname(normalized));
+    final resolvedParent = await parent.exists()
+        ? await parent.resolveSymbolicLinks()
+        : path.normalize(parent.path);
+    final resolvedPath = path.normalize(path.join(resolvedParent, path.basename(normalized)));
+    if (!path.isWithin(root.path, resolvedPath) && resolvedPath != root.path) {
+      return null;
+    }
+
+    final type = await FileSystemEntity.type(resolvedPath);
+    return type == FileSystemEntityType.directory
+        ? Directory(resolvedPath)
+        : File(resolvedPath);
+  }
+
+  String _relative(Directory root, String entityPath) {
+    final rel = path.relative(entityPath, from: root.path);
+    return rel == '.' ? '' : rel;
+  }
+
+  int _intArg(
+    dynamic value, {
+    required int fallback,
+    required int min,
+    required int max,
+  }) {
+    final parsed = value is int
+        ? value
+        : value is num
+        ? value.toInt()
+        : value is String
+        ? int.tryParse(value) ?? fallback
+        : fallback;
+    return parsed.clamp(min, max).toInt();
+  }
+
+  String _notConfigured() => _json({
+    'success': false,
+    'error': 'local_directory_not_configured',
+  });
+
+  String _outsideRoot() => _json({
+    'success': false,
+    'error': 'path_outside_local_directory',
+  });
+
+  String _json(Map<String, dynamic> value) => jsonEncode(value);
+}

--- a/lib/chat/ui/chat_input_bar.dart
+++ b/lib/chat/ui/chat_input_bar.dart
@@ -117,7 +117,7 @@ class _ChatInputBarState extends State<ChatInputBar> {
   }
 
   Future<void> _attachImages() async {
-    final result = await FilePicker.platform.pickFiles(
+    final result = await FilePicker.pickFiles(
       type: FileType.image,
       allowMultiple: true,
       withData: true,
@@ -131,7 +131,7 @@ class _ChatInputBarState extends State<ChatInputBar> {
   }
 
   Future<void> _attachFiles() async {
-    final result = await FilePicker.platform.pickFiles(
+    final result = await FilePicker.pickFiles(
       allowMultiple: true,
       withData: true,
     );

--- a/lib/chat/ui/chat_input_bar.dart
+++ b/lib/chat/ui/chat_input_bar.dart
@@ -1,10 +1,22 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:nt_helper/chat/models/chat_message.dart';
 import 'package:nt_helper/services/key_binding_service.dart';
+import 'package:pasteboard/pasteboard.dart';
+import 'package:path/path.dart' as path;
 
 class ChatInputBar extends StatefulWidget {
   final bool isProcessing;
-  final ValueChanged<String> onSend;
+  final void Function(
+    String text,
+    List<ChatImageAttachment> imageAttachments,
+    List<ChatFileAttachment> fileAttachments,
+  )
+  onSend;
   final VoidCallback onCancel;
   final VoidCallback onSettings;
   final FocusNode? focusNode;
@@ -28,6 +40,8 @@ class _ChatInputBarState extends State<ChatInputBar> {
   bool _isExpanded = false;
   bool _hasTyped = false;
   double _availableWidth = 0;
+  final List<ChatImageAttachment> _imageAttachments = [];
+  final List<ChatFileAttachment> _fileAttachments = [];
 
   FocusNode get _focusNode =>
       widget.focusNode ?? (_ownedFocusNode ??= FocusNode());
@@ -86,10 +100,152 @@ class _ChatInputBarState extends State<ChatInputBar> {
 
   void _handleSend() {
     final text = _controller.text.trim();
-    if (text.isEmpty) return;
-    widget.onSend(text);
+    if (text.isEmpty && _imageAttachments.isEmpty && _fileAttachments.isEmpty) {
+      return;
+    }
+    widget.onSend(
+      text,
+      List.unmodifiable(_imageAttachments),
+      List.unmodifiable(_fileAttachments),
+    );
     _controller.clear();
+    setState(() {
+      _imageAttachments.clear();
+      _fileAttachments.clear();
+    });
     _focusNode.requestFocus();
+  }
+
+  Future<void> _attachImages() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.image,
+      allowMultiple: true,
+      withData: true,
+    );
+    if (result == null) return;
+    for (final file in result.files) {
+      final bytes = file.bytes ?? await _readFileBytes(file.path);
+      if (bytes == null) continue;
+      _addImage(bytes, name: file.name);
+    }
+  }
+
+  Future<void> _attachFiles() async {
+    final result = await FilePicker.platform.pickFiles(
+      allowMultiple: true,
+      withData: true,
+    );
+    if (result == null) return;
+    for (final file in result.files) {
+      final bytes = file.bytes ?? await _readFileBytes(file.path);
+      if (bytes == null) continue;
+      final mimeType = _mimeTypeForName(file.name);
+      if (mimeType.startsWith('image/')) {
+        _addImage(bytes, name: file.name);
+        continue;
+      }
+      _addFile(bytes, name: file.name, mimeType: mimeType);
+    }
+  }
+
+  Future<void> _pasteImage() async {
+    final bytes = await Pasteboard.image;
+    if (bytes == null || bytes.isEmpty) return;
+    _addImage(bytes, name: 'clipboard.png');
+  }
+
+  Future<List<int>?> _readFileBytes(String? filePath) async {
+    if (filePath == null) return null;
+    return File(filePath).readAsBytes();
+  }
+
+  void _addImage(List<int> bytes, {String? name}) {
+    final fileName = name ?? 'image.png';
+    final mimeType = _mimeTypeForName(fileName);
+    setState(() {
+      _imageAttachments.add(
+        ChatImageAttachment(
+          data: base64Encode(bytes),
+          mimeType: mimeType,
+          name: fileName,
+        ),
+      );
+    });
+  }
+
+  void _addFile(
+    List<int> bytes, {
+    required String name,
+    required String mimeType,
+  }) {
+    String? textContent;
+    try {
+      textContent = utf8.decode(bytes);
+    } on FormatException {
+      textContent = null;
+    }
+    setState(() {
+      _fileAttachments.add(
+        ChatFileAttachment(
+          name: name,
+          data: base64Encode(bytes),
+          mimeType: mimeType,
+          sizeBytes: bytes.length,
+          textContent: textContent,
+        ),
+      );
+    });
+  }
+
+  void _removeImage(int index) {
+    setState(() => _imageAttachments.removeAt(index));
+  }
+
+  void _removeFile(int index) {
+    setState(() => _fileAttachments.removeAt(index));
+  }
+
+  String _mimeTypeForName(String fileName) {
+    switch (path.extension(fileName).toLowerCase()) {
+      case '.png':
+        return 'image/png';
+      case '.jpg':
+      case '.jpeg':
+        return 'image/jpeg';
+      case '.webp':
+        return 'image/webp';
+      case '.gif':
+        return 'image/gif';
+      case '.pdf':
+        return 'application/pdf';
+      case '.json':
+      case '.ntpreset':
+      case '.preset':
+        return 'application/json';
+      case '.txt':
+      case '.md':
+      case '.markdown':
+      case '.csv':
+      case '.yaml':
+      case '.yml':
+      case '.toml':
+      case '.xml':
+      case '.lua':
+      case '.dart':
+      case '.js':
+      case '.ts':
+      case '.py':
+      case '.sh':
+        return 'text/plain';
+      case '.syx':
+      case '.o':
+      case '.wasm':
+      case '.bin':
+      case '.dat':
+        return 'application/octet-stream';
+      default:
+        return 'application/octet-stream';
+    }
   }
 
   @override
@@ -120,6 +276,7 @@ class _ChatInputBarState extends State<ChatInputBar> {
                 4 // SizedBox before send button
                 -
                 48; // send/cancel IconButton width
+            _availableWidth -= 120; // attach file/image and paste IconButtons
             if (!_isExpanded) {
               _availableWidth -= 40; // settings IconButton width
             }
@@ -141,60 +298,106 @@ class _ChatInputBarState extends State<ChatInputBar> {
                           ),
                         ),
                 ),
+                Semantics(
+                  label: 'Attach file',
+                  button: true,
+                  child: IconButton(
+                    icon: const Icon(Icons.attach_file, size: 20),
+                    tooltip: 'Attach file',
+                    onPressed: widget.isProcessing ? null : _attachFiles,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ),
+                Semantics(
+                  label: 'Attach image',
+                  button: true,
+                  child: IconButton(
+                    icon: const Icon(Icons.image_outlined, size: 20),
+                    tooltip: 'Attach image',
+                    onPressed: widget.isProcessing ? null : _attachImages,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ),
+                Semantics(
+                  label: 'Paste image',
+                  button: true,
+                  child: IconButton(
+                    icon: const Icon(Icons.content_paste, size: 20),
+                    tooltip: 'Paste image',
+                    onPressed: widget.isProcessing ? null : _pasteImage,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ),
                 Expanded(
-                  child: Shortcuts(
-                    shortcuts: {
-                      LogicalKeySet(LogicalKeyboardKey.enter):
-                          const _SendIntent(),
-                      for (final key
-                          in _digitKeys) ...<SingleActivator, Intent>{
-                        SingleActivator(key):
-                            const DoNothingAndStopPropagationTextIntent(),
-                        SingleActivator(key, shift: true):
-                            const DoNothingAndStopPropagationTextIntent(),
-                      },
-                      for (final activator
-                          in KeyBindingService().globalShortcuts.keys)
-                        activator:
-                            const DoNothingAndStopPropagationTextIntent(),
-                    },
-                    child: Actions(
-                      actions: {
-                        _SendIntent: CallbackAction<_SendIntent>(
-                          onInvoke: (_) {
-                            if (!widget.isProcessing) _handleSend();
-                            return null;
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (_imageAttachments.isNotEmpty)
+                        _ImageAttachmentStrip(
+                          attachments: _imageAttachments,
+                          onRemove: _removeImage,
+                        ),
+                      if (_fileAttachments.isNotEmpty)
+                        _FileAttachmentStrip(
+                          attachments: _fileAttachments,
+                          onRemove: _removeFile,
+                        ),
+                      Shortcuts(
+                        shortcuts: {
+                          LogicalKeySet(LogicalKeyboardKey.enter):
+                              const _SendIntent(),
+                          for (final key
+                              in _digitKeys) ...<SingleActivator, Intent>{
+                            SingleActivator(key):
+                                const DoNothingAndStopPropagationTextIntent(),
+                            SingleActivator(key, shift: true):
+                                const DoNothingAndStopPropagationTextIntent(),
                           },
-                        ),
-                      },
-                      child: TextField(
-                        controller: _controller,
-                        focusNode: _focusNode,
-                        decoration: InputDecoration(
-                          hintText: _hasTyped
-                              ? null
-                              : 'Ask about your preset...',
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(24),
-                            borderSide: BorderSide.none,
+                          for (final activator
+                              in KeyBindingService().globalShortcuts.keys)
+                            activator:
+                                const DoNothingAndStopPropagationTextIntent(),
+                        },
+                        child: Actions(
+                          actions: {
+                            _SendIntent: CallbackAction<_SendIntent>(
+                              onInvoke: (_) {
+                                if (!widget.isProcessing) _handleSend();
+                                return null;
+                              },
+                            ),
+                          },
+                          child: TextField(
+                            controller: _controller,
+                            focusNode: _focusNode,
+                            decoration: InputDecoration(
+                              hintText: _hasTyped
+                                  ? null
+                                  : 'Ask about your preset...',
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(24),
+                                borderSide: BorderSide.none,
+                              ),
+                              filled: true,
+                              fillColor:
+                                  theme.colorScheme.surfaceContainerHighest,
+                              contentPadding: const EdgeInsets.symmetric(
+                                horizontal: 16,
+                                vertical: 10,
+                              ),
+                              isDense: true,
+                            ),
+                            enabled: !widget.isProcessing,
+                            textInputAction: TextInputAction.send,
+                            onSubmitted: widget.isProcessing
+                                ? null
+                                : (_) => _handleSend(),
+                            maxLines: 3,
+                            minLines: 1,
                           ),
-                          filled: true,
-                          fillColor: theme.colorScheme.surfaceContainerHighest,
-                          contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 16,
-                            vertical: 10,
-                          ),
-                          isDense: true,
                         ),
-                        enabled: !widget.isProcessing,
-                        textInputAction: TextInputAction.send,
-                        onSubmitted: widget.isProcessing
-                            ? null
-                            : (_) => _handleSend(),
-                        maxLines: 3,
-                        minLines: 1,
                       ),
-                    ),
+                    ],
                   ),
                 ),
                 const SizedBox(width: 4),
@@ -235,6 +438,111 @@ class _ChatInputBarState extends State<ChatInputBar> {
 
 class _SendIntent extends Intent {
   const _SendIntent();
+}
+
+class _ImageAttachmentStrip extends StatelessWidget {
+  final List<ChatImageAttachment> attachments;
+  final ValueChanged<int> onRemove;
+
+  const _ImageAttachmentStrip({
+    required this.attachments,
+    required this.onRemove,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      height: 58,
+      alignment: Alignment.centerLeft,
+      margin: const EdgeInsets.only(bottom: 6),
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: attachments.length,
+        separatorBuilder: (_, _) => const SizedBox(width: 6),
+        itemBuilder: (context, index) {
+          final attachment = attachments[index];
+          return Stack(
+            clipBehavior: Clip.none,
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(6),
+                child: Image.memory(
+                  base64Decode(attachment.data),
+                  width: 52,
+                  height: 52,
+                  fit: BoxFit.cover,
+                ),
+              ),
+              Positioned(
+                top: -6,
+                right: -6,
+                child: Material(
+                  color: theme.colorScheme.surface,
+                  shape: const CircleBorder(),
+                  child: InkWell(
+                    customBorder: const CircleBorder(),
+                    onTap: () => onRemove(index),
+                    child: Icon(
+                      Icons.cancel,
+                      size: 18,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _FileAttachmentStrip extends StatelessWidget {
+  final List<ChatFileAttachment> attachments;
+  final ValueChanged<int> onRemove;
+
+  const _FileAttachmentStrip({
+    required this.attachments,
+    required this.onRemove,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      height: 36,
+      alignment: Alignment.centerLeft,
+      margin: const EdgeInsets.only(bottom: 6),
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: attachments.length,
+        separatorBuilder: (_, _) => const SizedBox(width: 6),
+        itemBuilder: (context, index) {
+          final attachment = attachments[index];
+          return InputChip(
+            avatar: Icon(
+              attachment.mimeType == 'application/pdf'
+                  ? Icons.picture_as_pdf
+                  : Icons.description_outlined,
+              size: 16,
+            ),
+            label: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 160),
+              child: Text(
+                attachment.name,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.labelSmall,
+              ),
+            ),
+            onDeleted: () => onRemove(index),
+            visualDensity: VisualDensity.compact,
+          );
+        },
+      ),
+    );
+  }
 }
 
 const _digitKeys = [

--- a/lib/chat/ui/chat_message_bubble.dart
+++ b/lib/chat/ui/chat_message_bubble.dart
@@ -66,11 +66,33 @@ class _UserBubbleState extends State<_UserBubble> {
               ),
               child: Semantics(
                 label: 'You said: ${widget.message.content}',
-                child: Text(
-                  widget.message.content,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: theme.colorScheme.onPrimaryContainer,
-                  ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (widget.message.hasImageAttachments) ...[
+                      _MessageImageGrid(
+                        attachments: widget.message.imageAttachments,
+                      ),
+                      if (widget.message.content.isNotEmpty ||
+                          widget.message.hasFileAttachments)
+                        const SizedBox(height: 8),
+                    ],
+                    if (widget.message.hasFileAttachments) ...[
+                      _MessageFileChips(
+                        attachments: widget.message.fileAttachments,
+                      ),
+                      if (widget.message.content.isNotEmpty)
+                        const SizedBox(height: 8),
+                    ],
+                    if (widget.message.content.isNotEmpty)
+                      Text(
+                        widget.message.content,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onPrimaryContainer,
+                        ),
+                      ),
+                  ],
                 ),
               ),
             ),
@@ -83,6 +105,71 @@ class _UserBubbleState extends State<_UserBubble> {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _MessageFileChips extends StatelessWidget {
+  final List<ChatFileAttachment> attachments;
+
+  const _MessageFileChips({required this.attachments});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Wrap(
+      spacing: 6,
+      runSpacing: 6,
+      alignment: WrapAlignment.end,
+      children: [
+        for (final attachment in attachments)
+          Chip(
+            avatar: Icon(
+              attachment.mimeType == 'application/pdf'
+                  ? Icons.picture_as_pdf
+                  : Icons.description_outlined,
+              size: 16,
+              color: theme.colorScheme.onPrimaryContainer,
+            ),
+            label: Text(
+              attachment.name,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onPrimaryContainer,
+              ),
+            ),
+            backgroundColor: theme.colorScheme.primaryContainer,
+            side: BorderSide(color: theme.colorScheme.outlineVariant),
+            visualDensity: VisualDensity.compact,
+          ),
+      ],
+    );
+  }
+}
+
+class _MessageImageGrid extends StatelessWidget {
+  final List<ChatImageAttachment> attachments;
+
+  const _MessageImageGrid({required this.attachments});
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 6,
+      runSpacing: 6,
+      alignment: WrapAlignment.end,
+      children: [
+        for (final attachment in attachments)
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: Image.memory(
+              base64Decode(attachment.data),
+              width: 140,
+              height: 100,
+              fit: BoxFit.cover,
+            ),
+          ),
+      ],
     );
   }
 }

--- a/lib/chat/ui/chat_panel.dart
+++ b/lib/chat/ui/chat_panel.dart
@@ -110,7 +110,7 @@ class _ChatPanelState extends State<ChatPanel> {
         const Expanded(child: _EmptyState()),
         ChatInputBar(
           isProcessing: false,
-          onSend: (text) => _send(context, text),
+          onSend: (text, images, files) => _send(context, text, images, files),
           onCancel: () {},
           onSettings: () => _openSettings(context),
           focusNode: _inputFocusNode,
@@ -214,7 +214,7 @@ class _ChatPanelState extends State<ChatPanel> {
           ),
         ChatInputBar(
           isProcessing: state.isProcessing,
-          onSend: (text) => _send(context, text),
+          onSend: (text, images, files) => _send(context, text, images, files),
           onCancel: () => context.read<ChatCubit>().cancelProcessing(),
           onSettings: () => _openSettings(context),
           focusNode: _inputFocusNode,
@@ -253,9 +253,19 @@ class _ChatPanelState extends State<ChatPanel> {
     );
   }
 
-  void _send(BuildContext context, String text) {
+  void _send(
+    BuildContext context,
+    String text,
+    List<ChatImageAttachment> imageAttachments,
+    List<ChatFileAttachment> fileAttachments,
+  ) {
     final settings = _loadSettings();
-    context.read<ChatCubit>().sendMessage(text, settings);
+    context.read<ChatCubit>().sendMessage(
+      text,
+      settings,
+      imageAttachments: imageAttachments,
+      fileAttachments: fileAttachments,
+    );
   }
 
   void _openSettings(BuildContext context) {

--- a/lib/chat/ui/chat_settings_dialog.dart
+++ b/lib/chat/ui/chat_settings_dialog.dart
@@ -138,7 +138,7 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
   }
 
   Future<void> _chooseLocalDirectory() async {
-    final selected = await FilePicker.platform.getDirectoryPath(
+    final selected = await FilePicker.getDirectoryPath(
       dialogTitle: 'Choose Chat Local Directory',
       initialDirectory: _localDirectoryController.text.trim().isEmpty
           ? null

--- a/lib/chat/ui/chat_settings_dialog.dart
+++ b/lib/chat/ui/chat_settings_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:nt_helper/chat/models/chat_settings.dart';
 import 'package:nt_helper/chat/services/codex_auth_service.dart';
 import 'package:nt_helper/services/settings_service.dart';
@@ -33,6 +34,7 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
   late final TextEditingController _openaiModelController;
   late final TextEditingController _openaiSubscriptionModelController;
   late final TextEditingController _openaiBaseUrlController;
+  late final TextEditingController _localDirectoryController;
   bool _showAdvanced = false;
   bool? _codexAuthFound;
   String? _codexAuthError;
@@ -78,6 +80,9 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
     _openaiBaseUrlController = TextEditingController(
       text: _settings.openaiBaseUrl,
     );
+    _localDirectoryController = TextEditingController(
+      text: _settings.chatLocalDirectory,
+    );
     _showAdvanced =
         _settings.openaiBaseUrl != null && _settings.openaiBaseUrl!.isNotEmpty;
     if (_isOpenaiSubscription) {
@@ -93,6 +98,7 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
     _openaiModelController.dispose();
     _openaiSubscriptionModelController.dispose();
     _openaiBaseUrlController.dispose();
+    _localDirectoryController.dispose();
     _codexAuthService.dispose();
     super.dispose();
   }
@@ -125,7 +131,21 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
           ? _openaiBaseUrlController.text.trim()
           : '',
     );
+    await _settings.setChatLocalDirectory(
+      _localDirectoryController.text.trim(),
+    );
     if (mounted) Navigator.of(context).pop(true);
+  }
+
+  Future<void> _chooseLocalDirectory() async {
+    final selected = await FilePicker.platform.getDirectoryPath(
+      dialogTitle: 'Choose Chat Local Directory',
+      initialDirectory: _localDirectoryController.text.trim().isEmpty
+          ? null
+          : _localDirectoryController.text.trim(),
+    );
+    if (selected == null || !mounted) return;
+    setState(() => _localDirectoryController.text = selected);
   }
 
   Future<void> _validateCodexAuth() async {
@@ -190,7 +210,7 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
       title: Semantics(header: true, child: const Text('Chat Settings')),
       content: SizedBox(
         width: 400,
-        height: 460,
+        height: 520,
         child: SingleChildScrollView(
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -214,6 +234,7 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
               ),
               if (_isOpenAI) ..._buildOpenAISettings(theme),
               if (!_isOpenAI) ..._buildAnthropicSettings(theme),
+              ..._buildLocalContextSettings(theme),
               const SizedBox(height: 16),
               Text(
                 _isOpenaiSubscription
@@ -460,5 +481,45 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
         ),
       ),
     ],
+  ];
+
+  List<Widget> _buildLocalContextSettings(ThemeData theme) => [
+    const SizedBox(height: 20),
+    Text('Local Context', style: theme.textTheme.titleSmall),
+    const SizedBox(height: 8),
+    Row(
+      children: [
+        Expanded(
+          child: DigitShortcutBlocker(
+            child: TextField(
+              controller: _localDirectoryController,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                hintText: 'Local directory for chat tools',
+                isDense: true,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        IconButton(
+          tooltip: 'Choose directory',
+          icon: const Icon(Icons.folder_open),
+          onPressed: _chooseLocalDirectory,
+        ),
+        IconButton(
+          tooltip: 'Clear directory',
+          icon: const Icon(Icons.clear),
+          onPressed: () => setState(_localDirectoryController.clear),
+        ),
+      ],
+    ),
+    const SizedBox(height: 4),
+    Text(
+      'The chat assistant can list, read, and search files under this folder.',
+      style: theme.textTheme.bodySmall?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
+    ),
   ];
 }

--- a/lib/mcp/tool_registry.dart
+++ b/lib/mcp/tool_registry.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:mcp_dart/mcp_dart.dart';
+import 'package:nt_helper/chat/services/local_file_tools.dart';
 import 'package:nt_helper/chat/services/memory_service.dart';
 import 'package:nt_helper/chat/services/memory_tools.dart';
 import 'package:nt_helper/chat/utils/image_result_detector.dart';
@@ -36,6 +37,7 @@ class ToolRegistry {
     'memory_append_daily',
     'memory_read_daily',
   };
+  static const _chatOnlyToolNames = {..._memoryToolNames, ...localFileToolNames};
 
   final List<ToolRegistryEntry> _entries = [];
   late final DistingController _controller;
@@ -49,6 +51,7 @@ class ToolRegistry {
     _registerAll();
     if (memoryService != null) {
       registerMemoryTools(_entries, memoryService);
+      registerLocalFileTools(_entries);
     }
   }
 
@@ -65,7 +68,7 @@ class ToolRegistry {
   /// Memory tools are excluded — they are for the in-app chat only.
   void applyToMcpServer(McpServer server) {
     for (final entry in _entries) {
-      if (_memoryToolNames.contains(entry.name)) continue;
+      if (_chatOnlyToolNames.contains(entry.name)) continue;
       server.registerTool(
         entry.name,
         description: entry.description,

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -67,6 +67,7 @@ class SettingsService {
   static const String _openaiSubscriptionModelKey = 'openai_subscription_model';
   static const String _openaiBaseUrlKey = 'openai_base_url';
   static const String _allowCodexAuthRefreshKey = 'allow_codex_auth_refresh';
+  static const String _chatLocalDirectoryKey = 'chat_local_directory';
   static const String _uiScaleKey = 'ui_scale';
   static const String _autoCenterOnSelectionKey = 'auto_center_on_selection';
   static const String _showBackwardConnectionsKey = 'show_backward_connections';
@@ -107,6 +108,7 @@ class SettingsService {
     _openaiSubscriptionModelKey,
     _openaiBaseUrlKey,
     _allowCodexAuthRefreshKey,
+    _chatLocalDirectoryKey,
     _uiScaleKey,
     _autoCenterOnSelectionKey,
     _showBackwardConnectionsKey,
@@ -506,6 +508,18 @@ class SettingsService {
   /// Set whether nt_helper may refresh Codex ChatGPT auth.
   Future<bool> setAllowCodexAuthRefresh(bool value) async {
     return await _prefs?.setBool(_allowCodexAuthRefreshKey, value) ?? false;
+  }
+
+  /// Local directory the chat assistant may access through chat-only tools.
+  String? get chatLocalDirectory => _prefs?.getString(_chatLocalDirectoryKey);
+
+  /// Set the local directory the chat assistant may access.
+  Future<bool> setChatLocalDirectory(String value) async {
+    if (value.trim().isEmpty) {
+      return await _prefs?.remove(_chatLocalDirectoryKey) ?? false;
+    }
+    return await _prefs?.setString(_chatLocalDirectoryKey, value.trim()) ??
+        false;
   }
 
   /// Get the OpenAI base URL (for LM Studio, OpenRouter, etc.)


### PR DESCRIPTION
## Summary

This draft PR adds experimental richer context support to the chat/Codex workflow:

- image attachments and pasted images in chat
- general file attachments for model-supported files such as text, JSON, PDFs, and preset-style files
- a local chat workspace directory setting
- scoped local workspace/upload tools for chat use only
- a README note documenting the fork experiment

## Why

I wanted the chat assistant to work with local context directly, especially screenshots, Disting NT preset/algo files, PDFs, notes, and other files Codex-style models can understand.

The local file access is intentionally scoped to the selected workspace/uploads area rather than arbitrary filesystem paths.

## Tested so far

- Built the Windows app locally with Flutter
- Launched the generated Windows executable
- Uploaded an image in chat
- Confirmed the image displayed correctly
- Confirmed the model received and reasoned about the image

## Still needs testing

- PDF attachments
- text/JSON attachment handling
- Disting NT preset/algo file workflows
- local workspace list/read/write tools
- regression testing existing Disting tools

Opening this as a draft because it works in initial testing, but it is not ready to merge until the broader file/local workspace flows are checked.