### PR TITLE
[codex] Add chat ACL attachments and generic tool references

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -889,8 +889,8 @@ await McpServerService.instance.stop();
 ### MCP Tools
 
 **Algorithm Tools** (`lib/mcp/tools/algorithm_tools.dart`):
-- `list_algorithms` - Search/filter algorithms
-- `get_algorithm_details` - Full metadata with fuzzy name matching
+- `search_algorithms` - Search/filter algorithms
+- `algorithm_info` - Full documentation metadata with fuzzy name matching
 - `find_algorithm_in_preset` - Locate algorithm instances
 
 **Disting Tools** (`lib/mcp/tools/disting_tools.dart`):

--- a/docs/mcp-api-guide.md
+++ b/docs/mcp-api-guide.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-The Disting NT MCP (Model Context Protocol) API provides 16 individual, well-named tools for interacting with your hardware. Each tool does one thing with a flat parameter structure, making it easy for any LLM to use correctly.
+The Disting NT MCP (Model Context Protocol) API provides 18 individual, well-named tools for interacting with your hardware. Each tool does one thing with a flat parameter structure, making it easy for any LLM to use correctly.
 
 ### Design Philosophy
 
-- **16 individual tools**: Each tool has a single purpose with simple parameters
+- **18 individual tools**: Each tool has a single purpose with simple parameters
 - **No multiplexing**: No `target` parameters to route behavior — tool name says what it does
 - **Flat schemas**: Parameters are top-level, not nested inside `data` objects
 - **Mapping support**: Full CV/MIDI/i2c/performance page mapping for parameter control
@@ -20,6 +20,40 @@ The Disting NT MCP (Model Context Protocol) API provides 16 individual, well-nam
 - Incorrect: `midiChannel`, `isMidiEnabled`, `cvInput`
 
 ## Tool Reference
+
+### Reference Tools
+
+Any tool can return a `tool_reference` instead of a large payload. Use these tools to read or search the referenced result.
+
+#### read_reference
+
+Read a page from a large tool result reference.
+
+**Parameters**:
+- `reference_id` (required, string): Reference ID returned by a previous tool result.
+- `offset` (optional, integer): Character offset to start reading from. Default: 0.
+- `limit` (optional, integer): Maximum characters to return. Default: 8000, max: 16000.
+
+```json
+{"tool": "read_reference", "arguments": {"reference_id": "ref_123", "offset": 0, "limit": 8000}}
+```
+
+#### search_reference
+
+Search inside a large tool result reference and return matching snippets with offsets.
+
+**Parameters**:
+- `reference_id` (required, string): Reference ID returned by a previous tool result.
+- `query` (required, string): Case-insensitive text to search for.
+- `start_offset` (optional, integer): Character offset to begin searching from. Default: 0.
+- `limit` (optional, integer): Maximum matches to return. Default: 20, max: 50.
+- `context_chars` (optional, integer): Context characters around each match. Default: 120, max: 500.
+
+```json
+{"tool": "search_reference", "arguments": {"reference_id": "ref_123", "query": "cutoff"}}
+```
+
+---
 
 ### Template Tools
 
@@ -177,19 +211,13 @@ Show a compact preset overview: preset name and slot list with algorithm names a
 
 #### show_slot
 
-Show a slot with paginated parameter summaries. Each parameter shows its name, current value, and range (for numerics). Does NOT include enum value lists or full mapping detail — use `show_parameter` for those.
+Show a slot with parameter summaries. Each parameter shows its name, current value, and range (for numerics). Does NOT include enum value lists or full mapping detail — use `show_parameter` for those. Large results may be returned as a `tool_reference`.
 
 **Parameters**:
 - `slot_index` (required, integer): Slot index (0-31)
-- `offset` (optional, integer): Start at this parameter index (default: 0)
-- `limit` (optional, integer): Max parameters to return (default: 10, max: 100)
 
 ```json
 {"tool": "show_slot", "arguments": {"slot_index": 0}}
-```
-
-```json
-{"tool": "show_slot", "arguments": {"slot_index": 0, "offset": 10, "limit": 10}}
 ```
 
 **Example response**:
@@ -198,9 +226,6 @@ Show a slot with paginated parameter summaries. Each parameter shows its name, c
   "slot_index": 0,
   "algorithm": {"guid": "vcod", "name": "Dual VCO"},
   "parameter_count": 18,
-  "offset": 0,
-  "limit": 10,
-  "has_more": true,
   "parameters": [
     {"parameter_number": 0, "parameter_name": "Pitch", "is_disabled": false, "value": 60, "min": 0, "max": 127},
     {"parameter_number": 1, "parameter_name": "Waveform", "is_disabled": false, "is_enum": true, "value": "Sawtooth", "has_mapping": true, "performance_page": 1}
@@ -655,10 +680,7 @@ Returns algorithm names and parameter counts per slot. No parameters fetched.
 ```json
 {"tool": "show_slot", "arguments": {"slot_index": 0}}
 ```
-Returns first 10 parameter summaries (name, current value, range). If `has_more` is true, page through:
-```json
-{"tool": "show_slot", "arguments": {"slot_index": 0, "offset": 10}}
-```
+Returns parameter summaries (name, current value, range). If the result is large, it returns a `tool_reference`; use `read_reference` or `search_reference` to inspect it.
 
 ### Step 3: Inspect a specific parameter before editing
 ```json

--- a/docs/mcp-api-guide.md
+++ b/docs/mcp-api-guide.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-The Disting NT MCP (Model Context Protocol) API provides 15 individual, well-named tools for interacting with your hardware. Each tool does one thing with a flat parameter structure, making it easy for any LLM to use correctly.
+The Disting NT MCP (Model Context Protocol) API provides 16 individual, well-named tools for interacting with your hardware. Each tool does one thing with a flat parameter structure, making it easy for any LLM to use correctly.
 
 ### Design Philosophy
 
-- **15 individual tools**: Each tool has a single purpose with simple parameters
+- **16 individual tools**: Each tool has a single purpose with simple parameters
 - **No multiplexing**: No `target` parameters to route behavior — tool name says what it does
 - **Flat schemas**: Parameters are top-level, not nested inside `data` objects
 - **Mapping support**: Full CV/MIDI/i2c/performance page mapping for parameter control
@@ -101,6 +101,29 @@ Search for algorithms by name, category, description, use cases, parameter names
 
 ```json
 {"tool": "search_algorithms", "arguments": {"query": "pitch shifting"}}
+```
+
+---
+
+#### algorithm_info
+
+Show documentation-style metadata for a specific algorithm. This uses the same metadata source as the app's algorithm Help screen.
+
+**Parameters**:
+- `guid` (optional, string): Algorithm GUID, for example `"clck"`.
+- `name` (optional, string): Algorithm name. Used if `guid` is omitted.
+- `expand_features` (optional, boolean): If true, expands feature-provided parameters into the parameter list. Default: false.
+
+Provide either `guid` or `name`.
+
+**Returns**: Description, categories, ports, specifications, parameters, and features.
+
+```json
+{"tool": "algorithm_info", "arguments": {"guid": "clck"}}
+```
+
+```json
+{"tool": "algorithm_info", "arguments": {"name": "Clock", "expand_features": true}}
 ```
 
 ---

--- a/lib/chat/cubit/chat_cubit.dart
+++ b/lib/chat/cubit/chat_cubit.dart
@@ -60,14 +60,25 @@ class ChatCubit extends Cubit<ChatState> {
        _providerFactory = providerFactory,
        super(const ChatReady());
 
-  Future<void> sendMessage(String text, ChatSettings settings) async {
-    if (text.trim().isEmpty) return;
+  Future<void> sendMessage(
+    String text,
+    ChatSettings settings, {
+    List<ChatImageAttachment> imageAttachments = const [],
+    List<ChatFileAttachment> fileAttachments = const [],
+  }) async {
+    if (text.trim().isEmpty &&
+        imageAttachments.isEmpty &&
+        fileAttachments.isEmpty) {
+      return;
+    }
 
     final currentState = state;
     if (currentState is! ChatReady || currentState.isProcessing) return;
 
     // Handle /context command locally — no API call needed
-    if (text.trim().toLowerCase() == '/context') {
+    if (text.trim().toLowerCase() == '/context' &&
+        imageAttachments.isEmpty &&
+        fileAttachments.isEmpty) {
       _handleContextCommand(currentState);
       return;
     }
@@ -82,11 +93,40 @@ class ChatCubit extends Cubit<ChatState> {
     }
 
     // Show processing state immediately
-    final userMessage = ChatMessage.user(text.trim());
+    final messageText = text.trim().isEmpty
+        ? _defaultAttachmentMessage(imageAttachments, fileAttachments)
+        : text.trim();
+    final userMessage = ChatMessage.user(
+      messageText,
+      imageAttachments: imageAttachments,
+      fileAttachments: fileAttachments,
+    );
     final messages = [...currentState.messages, userMessage];
     emit(currentState.copyWith(messages: messages, isProcessing: true));
 
     try {
+      final unsupportedFiles = _unsupportedFilesForProvider(
+        settings.provider,
+        fileAttachments,
+      );
+      if (unsupportedFiles.isNotEmpty) {
+        emit(
+          currentState.copyWith(
+            messages: [
+              ...messages,
+              ChatMessage.assistant(
+                _unsupportedAttachmentMessage(
+                  settings.provider,
+                  unsupportedFiles,
+                ),
+              ),
+            ],
+            isProcessing: false,
+          ),
+        );
+        return;
+      }
+
       // Bootstrap memory on first send
       if (!_bootstrapped) {
         _memoryContent = await _memoryService.readMemory();
@@ -110,7 +150,33 @@ class ChatCubit extends Cubit<ChatState> {
 
       // Add to LLM history
       _historyLengthBeforeLoop = _llmHistory.length;
-      _llmHistory.add(LlmMessage.user(text.trim()));
+      final llmImageAttachments = imageAttachments
+          .map(
+            (image) => LlmImageAttachment(
+              data: image.data,
+              mimeType: image.mimeType,
+              name: image.name,
+            ),
+          )
+          .toList();
+      final llmFileAttachments = fileAttachments
+          .map(
+            (file) => LlmFileAttachment(
+              name: file.name,
+              data: file.data,
+              mimeType: file.mimeType,
+              sizeBytes: file.sizeBytes,
+              textContent: file.textContent,
+            ),
+          )
+          .toList();
+      _llmHistory.add(
+        LlmMessage.user(
+          _messageWithFileAttachments(messageText, fileAttachments),
+          imageAttachments: llmImageAttachments,
+          fileAttachments: llmFileAttachments,
+        ),
+      );
 
       // Create provider (disposing the previous one first)
       _activeProvider?.dispose();
@@ -168,6 +234,78 @@ class ChatCubit extends Cubit<ChatState> {
         );
       }
     }
+  }
+
+  String _defaultAttachmentMessage(
+    List<ChatImageAttachment> imageAttachments,
+    List<ChatFileAttachment> fileAttachments,
+  ) {
+    if (imageAttachments.isNotEmpty && fileAttachments.isNotEmpty) {
+      return 'Attached images and files.';
+    }
+    if (imageAttachments.isNotEmpty) {
+      return imageAttachments.length == 1
+          ? 'Attached image.'
+          : 'Attached images.';
+    }
+    return fileAttachments.length == 1 ? 'Attached file.' : 'Attached files.';
+  }
+
+  String _messageWithFileAttachments(
+    String messageText,
+    List<ChatFileAttachment> fileAttachments,
+  ) {
+    final buffer = StringBuffer(messageText);
+    for (final file in fileAttachments) {
+      if (file.textContent == null) continue;
+      buffer
+        ..writeln()
+        ..writeln()
+        ..writeln(
+          '--- Attached file: ${file.name} (${file.sizeBytes} bytes) ---',
+        )
+        ..writeln(file.textContent)
+        ..writeln('--- End attached file: ${file.name} ---');
+    }
+    return buffer.toString();
+  }
+
+  List<ChatFileAttachment> _unsupportedFilesForProvider(
+    LlmProviderType provider,
+    List<ChatFileAttachment> fileAttachments,
+  ) {
+    return fileAttachments
+        .where((file) => !_providerSupportsFileAttachment(provider, file))
+        .toList();
+  }
+
+  bool _providerSupportsFileAttachment(
+    LlmProviderType provider,
+    ChatFileAttachment file,
+  ) {
+    if (file.textContent != null) return true;
+    return switch (provider) {
+      LlmProviderType.anthropic || LlmProviderType.anthropicSubscription =>
+        file.mimeType == 'application/pdf',
+      LlmProviderType.openaiSubscription => file.mimeType == 'application/pdf',
+      LlmProviderType.openai => false,
+    };
+  }
+
+  String _unsupportedAttachmentMessage(
+    LlmProviderType provider,
+    List<ChatFileAttachment> unsupportedFiles,
+  ) {
+    final names = unsupportedFiles.map((file) => file.name).join(', ');
+    final providerName = switch (provider) {
+      LlmProviderType.anthropic => 'Anthropic API',
+      LlmProviderType.anthropicSubscription => 'Anthropic subscription',
+      LlmProviderType.openai => 'OpenAI API',
+      LlmProviderType.openaiSubscription => 'OpenAI subscription',
+    };
+    return 'Unsupported attachment for $providerName: $names. '
+        'Use images, UTF-8 text/JSON files, or switch to a provider that '
+        'supports this file type.';
   }
 
   void _handleLoopEvent(ChatLoopEvent event) {

--- a/lib/chat/cubit/chat_cubit.dart
+++ b/lib/chat/cubit/chat_cubit.dart
@@ -40,16 +40,10 @@ class ChatCubit extends Cubit<ChatState> {
   bool _bootstrapped = false;
   String? _memoryContent;
   String? _dailyLogs;
-  String? _currentModel;
+  int _currentContextWindowTokens = LlmProvider.defaultContextWindowTokens;
   bool _needsCompaction = false;
 
-  static const _contextLimits = <String, int>{
-    'claude-haiku-4-5-20251001': 200000,
-    'claude-sonnet-4-5-20250514': 200000,
-    'gpt-5-nano': 128000,
-    'gpt-5.4-mini': 128000,
-  };
-  static const _defaultContextLimit = 100000;
+  static const _compactionThresholdPercent = 85;
 
   ChatCubit({
     required ToolRegistry toolRegistry,
@@ -134,9 +128,6 @@ class ChatCubit extends Cubit<ChatState> {
         _bootstrapped = true;
       }
 
-      // Track current model for context limits
-      _currentModel = _resolveModel(settings);
-
       // Wait for any in-flight summarization before compaction/provider reset.
       if (_summarizationFuture != null) {
         await _summarizationFuture;
@@ -181,6 +172,9 @@ class ChatCubit extends Cubit<ChatState> {
       // Create provider (disposing the previous one first)
       _activeProvider?.dispose();
       _activeProvider = _createProvider(settings);
+      _currentContextWindowTokens = await _resolveContextWindow(
+        _activeProvider!,
+      );
       final toolBridge = ToolBridgeService(_toolRegistry);
       final chatService = ChatService(
         provider: _activeProvider!,
@@ -375,8 +369,10 @@ class ChatCubit extends Cubit<ChatState> {
           // Check if compaction is needed
           final totalInput =
               currentState.totalInputTokens + (usage?.inputTokens ?? 0);
-          final limit = _contextLimits[_currentModel] ?? _defaultContextLimit;
-          if (totalInput > limit ~/ 2) {
+          final contextInput = usage?.contextInputTokens ?? totalInput;
+          final compactAt =
+              _currentContextWindowTokens * _compactionThresholdPercent ~/ 100;
+          if (contextInput > compactAt) {
             _needsCompaction = true;
           }
         }
@@ -487,6 +483,7 @@ class ChatCubit extends Cubit<ChatState> {
     // Run one agentic loop turn for the LLM to save context
     _activeProvider?.dispose();
     _activeProvider = _createProvider(settings);
+    _currentContextWindowTokens = await _resolveContextWindow(_activeProvider!);
     final toolBridge = ToolBridgeService(_toolRegistry);
     final chatService = ChatService(
       provider: _activeProvider!,
@@ -639,18 +636,6 @@ class ChatCubit extends Cubit<ChatState> {
     emit(const ChatReady());
   }
 
-  String _resolveModel(ChatSettings settings) {
-    switch (settings.provider) {
-      case LlmProviderType.anthropic:
-      case LlmProviderType.anthropicSubscription:
-        return settings.anthropicModel;
-      case LlmProviderType.openai:
-        return settings.openaiModel;
-      case LlmProviderType.openaiSubscription:
-        return settings.openaiSubscriptionModel;
-    }
-  }
-
   LlmProvider _createProvider(ChatSettings settings) {
     if (_providerFactory != null) return _providerFactory(settings);
     switch (settings.provider) {
@@ -676,6 +661,17 @@ class ChatCubit extends Cubit<ChatState> {
           allowAuthRefresh: settings.allowCodexAuthRefresh,
         );
     }
+  }
+
+  Future<int> _resolveContextWindow(LlmProvider provider) async {
+    try {
+      final resolved = await provider.resolveContextWindowTokens();
+      if (resolved != null && resolved > 0) return resolved;
+    } on Object {
+      // Context-window metadata is advisory. Keep chat usable if metadata
+      // lookup fails or a test double does not implement it.
+    }
+    return LlmProvider.defaultContextWindowTokens;
   }
 
   @override

--- a/lib/chat/cubit/chat_cubit.dart
+++ b/lib/chat/cubit/chat_cubit.dart
@@ -27,6 +27,7 @@ class ChatCubit extends Cubit<ChatState> {
   StreamSubscription<dynamic>? _loopSubscription;
   LlmProvider? _activeProvider;
   Future<void>? _summarizationFuture;
+  Future<void>? _memoryRefreshFuture;
   bool _compacting = false;
 
   // Accumulated LLM message history for the agentic loop
@@ -41,7 +42,9 @@ class ChatCubit extends Cubit<ChatState> {
   String? _memoryContent;
   String? _dailyLogs;
   int _currentContextWindowTokens = LlmProvider.defaultContextWindowTokens;
+  int _lastContextInputTokens = 0;
   bool _needsCompaction = false;
+  Object? _memoryRefreshError;
 
   static const _compactionThresholdPercent = 85;
 
@@ -128,11 +131,16 @@ class ChatCubit extends Cubit<ChatState> {
         _bootstrapped = true;
       }
 
+      await _waitForMemoryRefresh();
+
       // Wait for any in-flight summarization before compaction/provider reset.
       if (_summarizationFuture != null) {
         await _summarizationFuture;
         _summarizationFuture = null;
       }
+
+      await _resetActiveProvider(settings);
+      _recomputeCompactionNeedForCurrentWindow();
 
       // Handle compaction if needed
       if (_needsCompaction) {
@@ -169,20 +177,7 @@ class ChatCubit extends Cubit<ChatState> {
         ),
       );
 
-      // Create provider (disposing the previous one first)
-      _activeProvider?.dispose();
-      _activeProvider = _createProvider(settings);
-      _currentContextWindowTokens = await _resolveContextWindow(
-        _activeProvider!,
-      );
-      final resolvedContextState = state;
-      if (resolvedContextState is ChatReady) {
-        emit(
-          resolvedContextState.copyWith(
-            contextWindowTokens: _currentContextWindowTokens,
-          ),
-        );
-      }
+      _activeProvider ??= _createProvider(settings);
       final toolBridge = ToolBridgeService(_toolRegistry);
       final chatService = ChatService(
         provider: _activeProvider!,
@@ -351,9 +346,9 @@ class ChatCubit extends Cubit<ChatState> {
         );
         // Keep cached memory context in sync for subsequent turns.
         if (name == 'memory_write') {
-          _refreshMemory();
+          _queueMemoryRefresh(_refreshMemory);
         } else if (name == 'memory_append_daily') {
-          _refreshDailyLogs();
+          _queueMemoryRefresh(_refreshDailyLogs);
         }
       case ChatLoopAssistantMessage(
         content: final content,
@@ -375,6 +370,7 @@ class ChatCubit extends Cubit<ChatState> {
           _llmHistory.clear();
           _llmHistory.addAll(newHistory);
           _historyLengthBeforeLoop = _llmHistory.length;
+          _lastContextInputTokens = contextInput;
 
           // Summarize large tool results in background
           _summarizationFuture = _summarizeLargeToolResults();
@@ -382,9 +378,7 @@ class ChatCubit extends Cubit<ChatState> {
           // Check if compaction is needed
           final compactAt =
               _currentContextWindowTokens * _compactionThresholdPercent ~/ 100;
-          if (contextInput > compactAt) {
-            _needsCompaction = true;
-          }
+          _needsCompaction = contextInput > compactAt;
         }
 
         emit(
@@ -428,6 +422,48 @@ class ChatCubit extends Cubit<ChatState> {
 
   Future<void> _refreshDailyLogs() async {
     _dailyLogs = await _memoryService.readDailyLogs();
+  }
+
+  void _queueMemoryRefresh(Future<void> Function() refresh) {
+    _memoryRefreshFuture = (_memoryRefreshFuture ?? Future<void>.value())
+        .then((_) => refresh())
+        .catchError((Object error) {
+          _memoryRefreshError ??= error;
+        });
+  }
+
+  Future<void> _waitForMemoryRefresh({bool reportErrors = true}) async {
+    final future = _memoryRefreshFuture;
+    if (future == null) return;
+    await future;
+    _memoryRefreshFuture = null;
+    final error = _memoryRefreshError;
+    _memoryRefreshError = null;
+    if (reportErrors && error != null) {
+      throw StateError('Failed to refresh chat memory context: $error');
+    }
+  }
+
+  Future<void> _resetActiveProvider(ChatSettings settings) async {
+    _activeProvider?.dispose();
+    _activeProvider = _createProvider(settings);
+    _currentContextWindowTokens = await _resolveContextWindow(_activeProvider!);
+    final currentState = state;
+    if (currentState is ChatReady) {
+      emit(
+        currentState.copyWith(contextWindowTokens: _currentContextWindowTokens),
+      );
+    }
+  }
+
+  void _recomputeCompactionNeedForCurrentWindow() {
+    if (_llmHistory.isEmpty || _lastContextInputTokens <= 0) {
+      _needsCompaction = false;
+      return;
+    }
+    final compactAt =
+        _currentContextWindowTokens * _compactionThresholdPercent ~/ 100;
+    _needsCompaction = _lastContextInputTokens > compactAt;
   }
 
   Future<void> _summarizeLargeToolResults() async {
@@ -482,6 +518,12 @@ class ChatCubit extends Cubit<ChatState> {
     await _memoryService.saveSessionSnapshot(_llmHistory);
     if (!_compacting) return;
 
+    if (_activeProvider == null) {
+      await _resetActiveProvider(settings);
+    }
+
+    final historyLengthBeforeCompaction = _llmHistory.length;
+
     // Inject compaction request
     _llmHistory.add(
       LlmMessage.user(
@@ -491,9 +533,6 @@ class ChatCubit extends Cubit<ChatState> {
     );
 
     // Run one agentic loop turn for the LLM to save context
-    _activeProvider?.dispose();
-    _activeProvider = _createProvider(settings);
-    _currentContextWindowTokens = await _resolveContextWindow(_activeProvider!);
     final toolBridge = ToolBridgeService(_toolRegistry);
     final chatService = ChatService(
       provider: _activeProvider!,
@@ -505,24 +544,46 @@ class ChatCubit extends Cubit<ChatState> {
     );
 
     final completer = Completer<void>();
+    var completed = false;
+    String? failure;
     final sub = chatService
         .runAgenticLoop(_llmHistory)
         .listen(
           (event) {
             if (event is ChatLoopAssistantMessage && event.isFinal) {
+              completed = true;
               if (event.finalHistory != null) {
                 _llmHistory.clear();
                 _llmHistory.addAll(event.finalHistory!);
               }
+            } else if (event is ChatLoopError) {
+              failure = event.message;
             }
           },
-          onDone: () => completer.complete(),
-          onError: (e) => completer.complete(),
+          onDone: () {
+            if (!completer.isCompleted) completer.complete();
+          },
+          onError: (Object error) {
+            failure = error.toString();
+            if (!completer.isCompleted) completer.complete();
+          },
         );
 
     await completer.future;
     await sub.cancel();
     if (!_compacting) return;
+
+    if (!completed) {
+      if (historyLengthBeforeCompaction <= _llmHistory.length) {
+        _llmHistory.removeRange(
+          historyLengthBeforeCompaction,
+          _llmHistory.length,
+        );
+      }
+      _needsCompaction = true;
+      _compacting = false;
+      throw StateError('Compaction failed: ${failure ?? 'no final response'}');
+    }
 
     // Trim to ~last 10 messages, ensuring we start on a user message so that
     // tool/assistant ordering is valid for all providers.
@@ -543,6 +604,7 @@ class ChatCubit extends Cubit<ChatState> {
     // Reset compaction state and token counters
     _needsCompaction = false;
     _compacting = false;
+    _lastContextInputTokens = 0;
 
     // Add compaction notice to UI
     final currentState = state;
@@ -624,12 +686,14 @@ class ChatCubit extends Cubit<ChatState> {
       await _summarizationFuture;
       _summarizationFuture = null;
     }
+    await _waitForMemoryRefresh(reportErrors: false);
     if (_llmHistory.isNotEmpty) {
       await _memoryService.saveSessionSnapshot(_llmHistory.toList());
     }
     _llmHistory.clear();
     _bootstrapped = false;
     _needsCompaction = false;
+    _lastContextInputTokens = 0;
     emit(const ChatReady());
   }
 
@@ -662,10 +726,12 @@ class ChatCubit extends Cubit<ChatState> {
         _dailyLogs = await _memoryService.readDailyLogs();
         _bootstrapped = true;
       }
+      await _waitForMemoryRefresh();
       if (_summarizationFuture != null) {
         await _summarizationFuture;
         _summarizationFuture = null;
       }
+      await _resetActiveProvider(settings);
       await _performCompaction(settings);
       final doneState = state;
       if (doneState is ChatReady) {
@@ -701,6 +767,8 @@ class ChatCubit extends Cubit<ChatState> {
 
   void dismissError() {
     _llmHistory.clear();
+    _needsCompaction = false;
+    _lastContextInputTokens = 0;
     emit(const ChatReady());
   }
 
@@ -787,6 +855,7 @@ class ChatCubit extends Cubit<ChatState> {
       await _summarizationFuture;
       _summarizationFuture = null;
     }
+    await _waitForMemoryRefresh(reportErrors: false);
     if (_llmHistory.isNotEmpty) {
       await _memoryService.saveSessionSnapshot(_llmHistory.toList());
     }

--- a/lib/chat/cubit/chat_cubit.dart
+++ b/lib/chat/cubit/chat_cubit.dart
@@ -175,6 +175,14 @@ class ChatCubit extends Cubit<ChatState> {
       _currentContextWindowTokens = await _resolveContextWindow(
         _activeProvider!,
       );
+      final resolvedContextState = state;
+      if (resolvedContextState is ChatReady) {
+        emit(
+          resolvedContextState.copyWith(
+            contextWindowTokens: _currentContextWindowTokens,
+          ),
+        );
+      }
       final toolBridge = ToolBridgeService(_toolRegistry);
       final chatService = ChatService(
         provider: _activeProvider!,
@@ -356,6 +364,11 @@ class ChatCubit extends Cubit<ChatState> {
         final uiMessages = content.isNotEmpty
             ? [...currentState.messages, ChatMessage.assistant(content)]
             : currentState.messages;
+        final totalInput =
+            currentState.totalInputTokens + (usage?.inputTokens ?? 0);
+        final totalOutput =
+            currentState.totalOutputTokens + (usage?.outputTokens ?? 0);
+        final contextInput = usage?.contextInputTokens ?? totalInput;
 
         if (isFinal) {
           final newHistory = finalHistory ?? [LlmMessage.assistant(content)];
@@ -367,9 +380,6 @@ class ChatCubit extends Cubit<ChatState> {
           _summarizationFuture = _summarizeLargeToolResults();
 
           // Check if compaction is needed
-          final totalInput =
-              currentState.totalInputTokens + (usage?.inputTokens ?? 0);
-          final contextInput = usage?.contextInputTokens ?? totalInput;
           final compactAt =
               _currentContextWindowTokens * _compactionThresholdPercent ~/ 100;
           if (contextInput > compactAt) {
@@ -382,10 +392,10 @@ class ChatCubit extends Cubit<ChatState> {
             messages: uiMessages,
             isProcessing: isFinal ? false : null,
             clearToolName: isFinal,
-            totalInputTokens:
-                currentState.totalInputTokens + (usage?.inputTokens ?? 0),
-            totalOutputTokens:
-                currentState.totalOutputTokens + (usage?.outputTokens ?? 0),
+            totalInputTokens: totalInput,
+            totalOutputTokens: totalOutput,
+            contextInputTokens: isFinal ? contextInput : null,
+            contextWindowTokens: _currentContextWindowTokens,
           ),
         );
       case ChatLoopRateLimited(
@@ -542,6 +552,8 @@ class ChatCubit extends Cubit<ChatState> {
           messages: [...currentState.messages, ChatMessage.compaction()],
           totalInputTokens: 0,
           totalOutputTokens: 0,
+          contextInputTokens: 0,
+          contextWindowTokens: _currentContextWindowTokens,
         ),
       );
     }
@@ -621,6 +633,62 @@ class ChatCubit extends Cubit<ChatState> {
     emit(const ChatReady());
   }
 
+  Future<void> compactContext(ChatSettings settings) async {
+    final currentState = state;
+    if (currentState is! ChatReady ||
+        currentState.isProcessing ||
+        _llmHistory.isEmpty) {
+      return;
+    }
+
+    if (!settings.hasApiKey) {
+      emit(
+        currentState.copyWith(
+          messages: [
+            ...currentState.messages,
+            ChatMessage.system(
+              'Configure a chat provider before compacting context.',
+            ),
+          ],
+        ),
+      );
+      return;
+    }
+
+    emit(currentState.copyWith(isProcessing: true, clearToolName: true));
+    try {
+      if (!_bootstrapped) {
+        _memoryContent = await _memoryService.readMemory();
+        _dailyLogs = await _memoryService.readDailyLogs();
+        _bootstrapped = true;
+      }
+      if (_summarizationFuture != null) {
+        await _summarizationFuture;
+        _summarizationFuture = null;
+      }
+      await _performCompaction(settings);
+      final doneState = state;
+      if (doneState is ChatReady) {
+        emit(doneState.copyWith(isProcessing: false, clearToolName: true));
+      }
+    } catch (e) {
+      _compacting = false;
+      final errorState = state;
+      if (errorState is ChatReady) {
+        emit(
+          errorState.copyWith(
+            messages: [
+              ...errorState.messages,
+              ChatMessage.assistant('Error compacting context: $e'),
+            ],
+            isProcessing: false,
+            clearToolName: true,
+          ),
+        );
+      }
+    }
+  }
+
   void cancelProcessing() {
     _compacting = false;
     _loopSubscription?.cancel();
@@ -634,6 +702,43 @@ class ChatCubit extends Cubit<ChatState> {
   void dismissError() {
     _llmHistory.clear();
     emit(const ChatReady());
+  }
+
+  ChatContextSummary get contextSummary {
+    var userMessages = 0;
+    var assistantMessages = 0;
+    var toolCalls = 0;
+    var toolResults = 0;
+    var imageAttachments = 0;
+    var fileAttachments = 0;
+    var approxCharacters = 0;
+
+    for (final message in _llmHistory) {
+      approxCharacters += message.content?.length ?? 0;
+      imageAttachments += message.imageAttachments.length;
+      fileAttachments += message.fileAttachments.length;
+      if (message.hasImage) imageAttachments++;
+      switch (message.role) {
+        case LlmRole.user:
+          userMessages++;
+        case LlmRole.assistant:
+          assistantMessages++;
+          toolCalls += message.toolCalls?.length ?? 0;
+        case LlmRole.tool:
+          toolResults++;
+      }
+    }
+
+    return ChatContextSummary(
+      messageCount: _llmHistory.length,
+      userMessages: userMessages,
+      assistantMessages: assistantMessages,
+      toolCalls: toolCalls,
+      toolResults: toolResults,
+      imageAttachments: imageAttachments,
+      fileAttachments: fileAttachments,
+      approxCharacters: approxCharacters,
+    );
   }
 
   LlmProvider _createProvider(ChatSettings settings) {

--- a/lib/chat/cubit/chat_state.dart
+++ b/lib/chat/cubit/chat_state.dart
@@ -1,6 +1,42 @@
 import 'package:equatable/equatable.dart';
 import 'package:nt_helper/chat/models/chat_message.dart';
 
+class ChatContextSummary extends Equatable {
+  final int messageCount;
+  final int userMessages;
+  final int assistantMessages;
+  final int toolCalls;
+  final int toolResults;
+  final int imageAttachments;
+  final int fileAttachments;
+  final int approxCharacters;
+
+  const ChatContextSummary({
+    this.messageCount = 0,
+    this.userMessages = 0,
+    this.assistantMessages = 0,
+    this.toolCalls = 0,
+    this.toolResults = 0,
+    this.imageAttachments = 0,
+    this.fileAttachments = 0,
+    this.approxCharacters = 0,
+  });
+
+  bool get isEmpty => messageCount == 0;
+
+  @override
+  List<Object?> get props => [
+    messageCount,
+    userMessages,
+    assistantMessages,
+    toolCalls,
+    toolResults,
+    imageAttachments,
+    fileAttachments,
+    approxCharacters,
+  ];
+}
+
 sealed class ChatState extends Equatable {
   const ChatState();
 
@@ -18,6 +54,8 @@ class ChatReady extends ChatState {
   final String? currentToolName;
   final int totalInputTokens;
   final int totalOutputTokens;
+  final int contextInputTokens;
+  final int contextWindowTokens;
 
   const ChatReady({
     this.messages = const [],
@@ -25,6 +63,8 @@ class ChatReady extends ChatState {
     this.currentToolName,
     this.totalInputTokens = 0,
     this.totalOutputTokens = 0,
+    this.contextInputTokens = 0,
+    this.contextWindowTokens = 100000,
   });
 
   ChatReady copyWith({
@@ -34,6 +74,8 @@ class ChatReady extends ChatState {
     bool clearToolName = false,
     int? totalInputTokens,
     int? totalOutputTokens,
+    int? contextInputTokens,
+    int? contextWindowTokens,
   }) {
     return ChatReady(
       messages: messages ?? this.messages,
@@ -43,6 +85,8 @@ class ChatReady extends ChatState {
           : (currentToolName ?? this.currentToolName),
       totalInputTokens: totalInputTokens ?? this.totalInputTokens,
       totalOutputTokens: totalOutputTokens ?? this.totalOutputTokens,
+      contextInputTokens: contextInputTokens ?? this.contextInputTokens,
+      contextWindowTokens: contextWindowTokens ?? this.contextWindowTokens,
     );
   }
 
@@ -53,6 +97,8 @@ class ChatReady extends ChatState {
     currentToolName,
     totalInputTokens,
     totalOutputTokens,
+    contextInputTokens,
+    contextWindowTokens,
   ];
 }
 

--- a/lib/chat/models/allowed_file_root.dart
+++ b/lib/chat/models/allowed_file_root.dart
@@ -1,0 +1,134 @@
+enum FileRootActor {
+  chat('chat'),
+  mcp('mcp');
+
+  const FileRootActor(this.storageKey);
+
+  final String storageKey;
+
+  static FileRootActor? fromStorageKey(String value) {
+    for (final actor in values) {
+      if (actor.storageKey == value) return actor;
+    }
+    return null;
+  }
+}
+
+enum FileRootPermission {
+  read('read'),
+  write('write'),
+  search('search');
+
+  const FileRootPermission(this.storageKey);
+
+  final String storageKey;
+
+  static FileRootPermission? fromStorageKey(String value) {
+    for (final permission in values) {
+      if (permission.storageKey == value) return permission;
+    }
+    return null;
+  }
+}
+
+class AllowedFileRoot {
+  const AllowedFileRoot({
+    required this.id,
+    required this.label,
+    required this.path,
+    required this.acl,
+  });
+
+  factory AllowedFileRoot.chatReadSearch({
+    required String id,
+    required String label,
+    required String path,
+  }) {
+    return AllowedFileRoot(
+      id: id,
+      label: label,
+      path: path,
+      acl: const {
+        FileRootActor.chat: {
+          FileRootPermission.read,
+          FileRootPermission.search,
+        },
+      },
+    );
+  }
+
+  factory AllowedFileRoot.fromJson(Map<String, dynamic> json) {
+    final rawAcl = json['acl'];
+    final acl = <FileRootActor, Set<FileRootPermission>>{};
+    if (rawAcl is Map) {
+      for (final entry in rawAcl.entries) {
+        final actor = FileRootActor.fromStorageKey(entry.key.toString());
+        if (actor == null) continue;
+        final rawPermissions = entry.value;
+        if (rawPermissions is! List) continue;
+        acl[actor] = rawPermissions
+            .whereType<String>()
+            .map(FileRootPermission.fromStorageKey)
+            .whereType<FileRootPermission>()
+            .toSet();
+      }
+    }
+
+    return AllowedFileRoot(
+      id: _stringField(json, 'id'),
+      label: _stringField(json, 'label'),
+      path: _stringField(json, 'path'),
+      acl: acl,
+    );
+  }
+
+  final String id;
+  final String label;
+  final String path;
+  final Map<FileRootActor, Set<FileRootPermission>> acl;
+
+  Set<FileRootPermission> permissionsFor(FileRootActor actor) {
+    return Set.unmodifiable(acl[actor] ?? const <FileRootPermission>{});
+  }
+
+  bool allows(FileRootActor actor, FileRootPermission permission) {
+    return permissionsFor(actor).contains(permission);
+  }
+
+  AllowedFileRoot copyWith({
+    String? id,
+    String? label,
+    String? path,
+    Map<FileRootActor, Set<FileRootPermission>>? acl,
+  }) {
+    return AllowedFileRoot(
+      id: id ?? this.id,
+      label: label ?? this.label,
+      path: path ?? this.path,
+      acl: acl ?? this.acl,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'label': label,
+      'path': path,
+      'acl': {
+        for (final actor in FileRootActor.values)
+          actor.storageKey:
+              (acl[actor] ?? const <FileRootPermission>{})
+                  .map((permission) => permission.storageKey)
+                  .toList()
+                ..sort(),
+      },
+    };
+  }
+
+  bool get isValid => id.trim().isNotEmpty && path.trim().isNotEmpty;
+
+  static String _stringField(Map<String, dynamic> json, String key) {
+    final value = json[key];
+    return value is String ? value.trim() : '';
+  }
+}

--- a/lib/chat/models/chat_message.dart
+++ b/lib/chat/models/chat_message.dart
@@ -13,6 +13,34 @@ enum ChatMessageRole {
   compaction,
 }
 
+class ChatImageAttachment {
+  final String data;
+  final String mimeType;
+  final String? name;
+
+  const ChatImageAttachment({
+    required this.data,
+    required this.mimeType,
+    this.name,
+  });
+}
+
+class ChatFileAttachment {
+  final String name;
+  final String data;
+  final String mimeType;
+  final int sizeBytes;
+  final String? textContent;
+
+  const ChatFileAttachment({
+    required this.name,
+    required this.data,
+    required this.mimeType,
+    required this.sizeBytes,
+    this.textContent,
+  });
+}
+
 class ChatMessage {
   final String id;
   final ChatMessageRole role;
@@ -22,6 +50,8 @@ class ChatMessage {
   final Map<String, dynamic>? toolArguments;
   final String? imageBase64;
   final String? imageMimeType;
+  final List<ChatImageAttachment> imageAttachments;
+  final List<ChatFileAttachment> fileAttachments;
   final DateTime timestamp;
 
   const ChatMessage({
@@ -33,15 +63,25 @@ class ChatMessage {
     this.toolArguments,
     this.imageBase64,
     this.imageMimeType,
+    this.imageAttachments = const [],
+    this.fileAttachments = const [],
     required this.timestamp,
   });
 
   bool get hasImage => imageBase64 != null && imageMimeType != null;
+  bool get hasImageAttachments => imageAttachments.isNotEmpty;
+  bool get hasFileAttachments => fileAttachments.isNotEmpty;
 
-  factory ChatMessage.user(String content) => ChatMessage(
+  factory ChatMessage.user(
+    String content, {
+    List<ChatImageAttachment> imageAttachments = const [],
+    List<ChatFileAttachment> fileAttachments = const [],
+  }) => ChatMessage(
     id: _generateId(),
     role: ChatMessageRole.user,
     content: content,
+    imageAttachments: imageAttachments,
+    fileAttachments: fileAttachments,
     timestamp: DateTime.now(),
   );
 

--- a/lib/chat/models/llm_types.dart
+++ b/lib/chat/models/llm_types.dart
@@ -160,5 +160,7 @@ class LlmUsage {
   });
 
   int get totalTokens => inputTokens + outputTokens;
-  int get contextInputTokens => peakInputTokens ?? inputTokens;
+  int get contextInputTokens =>
+      peakInputTokens ??
+      inputTokens + cacheCreationInputTokens + cacheReadInputTokens;
 }

--- a/lib/chat/models/llm_types.dart
+++ b/lib/chat/models/llm_types.dart
@@ -5,6 +5,34 @@
 
 enum LlmRole { user, assistant, tool }
 
+class LlmImageAttachment {
+  final String data;
+  final String mimeType;
+  final String? name;
+
+  const LlmImageAttachment({
+    required this.data,
+    required this.mimeType,
+    this.name,
+  });
+}
+
+class LlmFileAttachment {
+  final String name;
+  final String data;
+  final String mimeType;
+  final int sizeBytes;
+  final String? textContent;
+
+  const LlmFileAttachment({
+    required this.name,
+    required this.data,
+    required this.mimeType,
+    required this.sizeBytes,
+    this.textContent,
+  });
+}
+
 /// A message in the LLM conversation.
 class LlmMessage {
   final LlmRole role;
@@ -14,6 +42,8 @@ class LlmMessage {
   final String? toolName;
   final String? imageBase64;
   final String? imageMimeType;
+  final List<LlmImageAttachment> imageAttachments;
+  final List<LlmFileAttachment> fileAttachments;
 
   const LlmMessage({
     required this.role,
@@ -23,12 +53,24 @@ class LlmMessage {
     this.toolName,
     this.imageBase64,
     this.imageMimeType,
+    this.imageAttachments = const [],
+    this.fileAttachments = const [],
   });
 
   bool get hasImage => imageBase64 != null && imageMimeType != null;
+  bool get hasImageAttachments => imageAttachments.isNotEmpty;
+  bool get hasFileAttachments => fileAttachments.isNotEmpty;
 
-  factory LlmMessage.user(String content) =>
-      LlmMessage(role: LlmRole.user, content: content);
+  factory LlmMessage.user(
+    String content, {
+    List<LlmImageAttachment> imageAttachments = const [],
+    List<LlmFileAttachment> fileAttachments = const [],
+  }) => LlmMessage(
+    role: LlmRole.user,
+    content: content,
+    imageAttachments: imageAttachments,
+    fileAttachments: fileAttachments,
+  );
 
   factory LlmMessage.assistant(String content) =>
       LlmMessage(role: LlmRole.assistant, content: content);

--- a/lib/chat/models/llm_types.dart
+++ b/lib/chat/models/llm_types.dart
@@ -149,13 +149,16 @@ class LlmUsage {
   final int outputTokens;
   final int cacheCreationInputTokens;
   final int cacheReadInputTokens;
+  final int? peakInputTokens;
 
   const LlmUsage({
     required this.inputTokens,
     required this.outputTokens,
     this.cacheCreationInputTokens = 0,
     this.cacheReadInputTokens = 0,
+    this.peakInputTokens,
   });
 
   int get totalTokens => inputTokens + outputTokens;
+  int get contextInputTokens => peakInputTokens ?? inputTokens;
 }

--- a/lib/chat/providers/anthropic_provider.dart
+++ b/lib/chat/providers/anthropic_provider.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart' as http;
 import 'package:nt_helper/chat/models/llm_types.dart';
 import 'package:nt_helper/chat/providers/llm_error_handling.dart';
 import 'package:nt_helper/chat/providers/llm_provider.dart';
+import 'package:nt_helper/chat/providers/model_context_window.dart';
 import 'package:nt_helper/services/debug_service.dart';
 
 /// Anthropic Claude Messages API provider.
@@ -23,6 +24,16 @@ class AnthropicProvider with LlmErrorHandling implements LlmProvider {
 
   @override
   String get displayName => 'Claude ($model)';
+
+  @override
+  Future<int?> resolveContextWindowTokens() {
+    return AnthropicContextWindowResolver.resolveWithApiKey(
+      model: model,
+      apiKey: apiKey,
+      apiVersion: _apiVersion,
+      client: _client,
+    );
+  }
 
   @override
   Future<LlmResponse> sendMessages({

--- a/lib/chat/providers/anthropic_provider.dart
+++ b/lib/chat/providers/anthropic_provider.dart
@@ -98,7 +98,36 @@ class AnthropicProvider with LlmErrorHandling implements LlmProvider {
     for (final msg in messages) {
       switch (msg.role) {
         case LlmRole.user:
-          result.add({'role': 'user', 'content': msg.content!});
+          if (msg.hasImageAttachments || msg.hasFileAttachments) {
+            result.add({
+              'role': 'user',
+              'content': <dynamic>[
+                {'type': 'text', 'text': msg.content ?? ''},
+                for (final image in msg.imageAttachments)
+                  {
+                    'type': 'image',
+                    'source': {
+                      'type': 'base64',
+                      'media_type': image.mimeType,
+                      'data': image.data,
+                    },
+                  },
+                for (final file in msg.fileAttachments)
+                  if (file.mimeType == 'application/pdf')
+                    {
+                      'type': 'document',
+                      'source': {
+                        'type': 'base64',
+                        'media_type': file.mimeType,
+                        'data': file.data,
+                      },
+                      'title': file.name,
+                    },
+              ],
+            });
+          } else {
+            result.add({'role': 'user', 'content': msg.content!});
+          }
         case LlmRole.assistant:
           if (msg.toolCalls != null && msg.toolCalls!.isNotEmpty) {
             final content = <Map<String, dynamic>>[];

--- a/lib/chat/providers/anthropic_subscription_provider.dart
+++ b/lib/chat/providers/anthropic_subscription_provider.dart
@@ -5,6 +5,7 @@ import 'package:nt_helper/chat/models/llm_types.dart';
 import 'package:nt_helper/chat/providers/anthropic_provider.dart';
 import 'package:nt_helper/chat/providers/llm_error_handling.dart';
 import 'package:nt_helper/chat/providers/llm_provider.dart';
+import 'package:nt_helper/chat/providers/model_context_window.dart';
 import 'package:nt_helper/services/debug_service.dart';
 
 /// Anthropic subscription auth provider using Claude Code OAuth tokens.
@@ -35,6 +36,17 @@ class AnthropicSubscriptionProvider
 
   @override
   String get displayName => 'Claude Subscription ($model)';
+
+  @override
+  Future<int?> resolveContextWindowTokens() {
+    return AnthropicContextWindowResolver.resolveWithBearerToken(
+      model: model,
+      token: token,
+      apiVersion: _apiVersion,
+      betaHeader: _betaHeader,
+      client: _client,
+    );
+  }
 
   // Reuse the same message conversion and response parsing from AnthropicProvider
   // by delegating to a temporary instance.

--- a/lib/chat/providers/anthropic_subscription_provider.dart
+++ b/lib/chat/providers/anthropic_subscription_provider.dart
@@ -129,6 +129,7 @@ class AnthropicSubscriptionProvider
 
   @override
   void dispose() {
+    _delegate.dispose();
     _client.close();
   }
 }

--- a/lib/chat/providers/llm_provider.dart
+++ b/lib/chat/providers/llm_provider.dart
@@ -5,6 +5,8 @@ import 'package:nt_helper/chat/models/llm_types.dart';
 /// Implementations handle the specifics of each API (Anthropic, OpenAI)
 /// while exposing a uniform interface for the chat service.
 abstract class LlmProvider {
+  static const defaultContextWindowTokens = 100000;
+
   /// Send messages to the LLM and get a response.
   ///
   /// [messages] is the full conversation history.
@@ -18,6 +20,13 @@ abstract class LlmProvider {
 
   /// The provider name for display purposes.
   String get displayName;
+
+  /// Resolve the model context window in tokens when the provider can.
+  ///
+  /// Implementations may query provider metadata APIs or fall back to
+  /// provider-specific model-family knowledge. Returning null tells callers to
+  /// use [defaultContextWindowTokens].
+  Future<int?> resolveContextWindowTokens();
 
   /// Release HTTP client resources.
   void dispose();

--- a/lib/chat/providers/model_context_window.dart
+++ b/lib/chat/providers/model_context_window.dart
@@ -6,12 +6,27 @@ import 'package:http/http.dart' as http;
 class ModelContextWindow {
   static const defaultTokens = 100000;
 
+  static int? parseMetadataResponse(Object? decoded, {String? model}) {
+    if (decoded is Map<String, dynamic>) {
+      final direct = parseMetadata(decoded);
+      if (direct != null) return direct;
+
+      for (final key in const ['data', 'models']) {
+        final parsed = _parseModelList(decoded[key], model: model);
+        if (parsed != null) return parsed;
+      }
+    }
+
+    return _parseModelList(decoded, model: model);
+  }
+
   static int? parseMetadata(Map<String, dynamic> json) {
     for (final key in const [
       'max_input_tokens',
       'context_window',
       'context_window_tokens',
       'context_length',
+      'max_context_window',
       'max_context_tokens',
       'input_token_limit',
     ]) {
@@ -26,12 +41,29 @@ class ModelContextWindow {
         'context_window',
         'context_window_tokens',
         'context_length',
+        'max_context_window',
       ]) {
         final value = _positiveInt(capabilities[key]);
         if (value != null) return value;
       }
     }
 
+    return null;
+  }
+
+  static int? _parseModelList(Object? value, {String? model}) {
+    if (value is! List) return null;
+
+    final normalizedModel = model?.toLowerCase();
+    for (final item in value) {
+      if (item is! Map<String, dynamic>) continue;
+      if (normalizedModel != null) {
+        final id = item['id'] ?? item['model'] ?? item['slug'];
+        if (id is String && id.toLowerCase() != normalizedModel) continue;
+      }
+      final parsed = parseMetadata(item);
+      if (parsed != null) return parsed;
+    }
     return null;
   }
 
@@ -99,6 +131,60 @@ class OpenAIContextWindowResolver {
     return null;
   }
 
+  static Future<int?> resolveSubscription({
+    required String model,
+    required Map<String, String> headers,
+    required http.Client client,
+    required String clientVersion,
+    String baseUrl = 'https://chatgpt.com/backend-api/codex/responses',
+  }) async {
+    final cacheKey = 'openai-subscription:$baseUrl:$clientVersion:$model';
+    final cached = _metadataCache[cacheKey];
+    if (cached != null) return cached;
+
+    final queried = await _querySubscriptionModelMetadata(
+      model: model,
+      baseUrl: baseUrl,
+      headers: headers,
+      client: client,
+      clientVersion: clientVersion,
+    );
+    if (queried != null) {
+      _metadataCache[cacheKey] = queried;
+      return queried;
+    }
+
+    final inferred = inferSubscription(model);
+    if (inferred != null) {
+      _metadataCache[cacheKey] = inferred;
+    }
+    return inferred;
+  }
+
+  static int? inferSubscription(String model) {
+    final normalized = model.toLowerCase();
+    if (normalized.startsWith('gpt-5.5')) {
+      return 272000;
+    }
+    if (normalized == 'gpt-5.4' ||
+        normalized.startsWith('gpt-5.4-20') ||
+        normalized.startsWith('gpt-4.1')) {
+      return 1000000;
+    }
+    if (normalized.startsWith('gpt-5.4-mini') ||
+        normalized.startsWith('gpt-5.4-nano')) {
+      return 400000;
+    }
+    if (normalized.startsWith('gpt-5') ||
+        normalized.startsWith('gpt-4o') ||
+        normalized.startsWith('o1') ||
+        normalized.startsWith('o3') ||
+        normalized.startsWith('o4')) {
+      return 128000;
+    }
+    return null;
+  }
+
   static Future<int?> _queryModelMetadata({
     required String model,
     required String baseUrl,
@@ -122,11 +208,42 @@ class OpenAIContextWindowResolver {
         return null;
       }
       final parsed = jsonDecode(response.body);
-      if (parsed is! Map<String, dynamic>) return null;
-      return ModelContextWindow.parseMetadata(parsed);
+      return ModelContextWindow.parseMetadataResponse(parsed, model: model);
     } on Object {
       return null;
     }
+  }
+
+  static Future<int?> _querySubscriptionModelMetadata({
+    required String model,
+    required String baseUrl,
+    required Map<String, String> headers,
+    required http.Client client,
+    required String clientVersion,
+  }) async {
+    for (final uri in _subscriptionModelMetadataUris(
+      baseUrl,
+      model,
+      clientVersion,
+    )) {
+      try {
+        final response = await client
+            .get(uri, headers: {'Content-Type': 'application/json', ...headers})
+            .timeout(const Duration(seconds: 2));
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          continue;
+        }
+        final parsed = jsonDecode(response.body);
+        final contextWindow = ModelContextWindow.parseMetadataResponse(
+          parsed,
+          model: model,
+        );
+        if (contextWindow != null) return contextWindow;
+      } on Object {
+        continue;
+      }
+    }
+    return null;
   }
 
   static Uri? _modelMetadataUri(String baseUrl, String model) {
@@ -146,6 +263,31 @@ class OpenAIContextWindowResolver {
     return uri
         .replace(path: path, query: null, fragment: null)
         .resolve('models/${Uri.encodeComponent(model)}');
+  }
+
+  static List<Uri> _subscriptionModelMetadataUris(
+    String baseUrl,
+    String model,
+    String clientVersion,
+  ) {
+    final uri = Uri.tryParse(baseUrl);
+    if (uri == null || !uri.hasScheme || uri.host.isEmpty) return const [];
+
+    var path = uri.path;
+    if (path.endsWith('/responses')) {
+      path = path.substring(0, path.length - '/responses'.length);
+    }
+    if (path.isEmpty) path = '/';
+    if (!path.endsWith('/')) path = '$path/';
+
+    final base = uri.replace(path: path, query: null, fragment: null);
+    return [
+      base
+          .resolve('models')
+          .replace(
+            queryParameters: {'model': model, 'client_version': clientVersion},
+          ),
+    ];
   }
 }
 
@@ -242,8 +384,7 @@ class AnthropicContextWindowResolver {
         return null;
       }
       final parsed = jsonDecode(response.body);
-      if (parsed is! Map<String, dynamic>) return null;
-      return ModelContextWindow.parseMetadata(parsed);
+      return ModelContextWindow.parseMetadataResponse(parsed, model: model);
     } on Object {
       return null;
     }

--- a/lib/chat/providers/model_context_window.dart
+++ b/lib/chat/providers/model_context_window.dart
@@ -1,0 +1,251 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+class ModelContextWindow {
+  static const defaultTokens = 100000;
+
+  static int? parseMetadata(Map<String, dynamic> json) {
+    for (final key in const [
+      'max_input_tokens',
+      'context_window',
+      'context_window_tokens',
+      'context_length',
+      'max_context_tokens',
+      'input_token_limit',
+    ]) {
+      final value = _positiveInt(json[key]);
+      if (value != null) return value;
+    }
+
+    final capabilities = json['capabilities'];
+    if (capabilities is Map<String, dynamic>) {
+      for (final key in const [
+        'max_input_tokens',
+        'context_window',
+        'context_window_tokens',
+        'context_length',
+      ]) {
+        final value = _positiveInt(capabilities[key]);
+        if (value != null) return value;
+      }
+    }
+
+    return null;
+  }
+
+  static int? _positiveInt(Object? value) {
+    final parsed = switch (value) {
+      int v => v,
+      num v => v.toInt(),
+      String v => int.tryParse(v),
+      _ => null,
+    };
+    return parsed != null && parsed > 0 ? parsed : null;
+  }
+}
+
+class OpenAIContextWindowResolver {
+  static final Map<String, int> _metadataCache = {};
+
+  static Future<int?> resolve({
+    required String model,
+    required String baseUrl,
+    required String apiKey,
+    required http.Client client,
+  }) async {
+    final cacheKey = 'openai:$baseUrl:$model';
+    final cached = _metadataCache[cacheKey];
+    if (cached != null) return cached;
+
+    final queried = await _queryModelMetadata(
+      model: model,
+      baseUrl: baseUrl,
+      apiKey: apiKey,
+      client: client,
+    );
+    if (queried != null) {
+      _metadataCache[cacheKey] = queried;
+      return queried;
+    }
+
+    final inferred = infer(model);
+    if (inferred != null) {
+      _metadataCache[cacheKey] = inferred;
+    }
+    return inferred;
+  }
+
+  static int? infer(String model) {
+    final normalized = model.toLowerCase();
+    if (normalized.startsWith('gpt-5.5') ||
+        normalized == 'gpt-5.4' ||
+        normalized.startsWith('gpt-5.4-20') ||
+        normalized.startsWith('gpt-4.1')) {
+      return 1000000;
+    }
+    if (normalized.startsWith('gpt-5.4-mini') ||
+        normalized.startsWith('gpt-5.4-nano')) {
+      return 400000;
+    }
+    if (normalized.startsWith('gpt-5') ||
+        normalized.startsWith('gpt-4o') ||
+        normalized.startsWith('o1') ||
+        normalized.startsWith('o3') ||
+        normalized.startsWith('o4')) {
+      return 128000;
+    }
+    return null;
+  }
+
+  static Future<int?> _queryModelMetadata({
+    required String model,
+    required String baseUrl,
+    required String apiKey,
+    required http.Client client,
+  }) async {
+    final uri = _modelMetadataUri(baseUrl, model);
+    if (uri == null) return null;
+
+    try {
+      final response = await client
+          .get(
+            uri,
+            headers: {
+              'Authorization': 'Bearer $apiKey',
+              'Content-Type': 'application/json',
+            },
+          )
+          .timeout(const Duration(seconds: 2));
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        return null;
+      }
+      final parsed = jsonDecode(response.body);
+      if (parsed is! Map<String, dynamic>) return null;
+      return ModelContextWindow.parseMetadata(parsed);
+    } on Object {
+      return null;
+    }
+  }
+
+  static Uri? _modelMetadataUri(String baseUrl, String model) {
+    final uri = Uri.tryParse(baseUrl);
+    if (uri == null || !uri.hasScheme || uri.host.isEmpty) return null;
+
+    var path = uri.path;
+    for (final suffix in const ['/chat/completions', '/responses']) {
+      if (path.endsWith(suffix)) {
+        path = path.substring(0, path.length - suffix.length);
+        break;
+      }
+    }
+    if (path.isEmpty) path = '/';
+    if (!path.endsWith('/')) path = '$path/';
+
+    return uri
+        .replace(path: path, query: null, fragment: null)
+        .resolve('models/${Uri.encodeComponent(model)}');
+  }
+}
+
+class AnthropicContextWindowResolver {
+  static final Map<String, int> _metadataCache = {};
+  static const _modelsBaseUrl = 'https://api.anthropic.com/v1/models';
+
+  static Future<int?> resolveWithApiKey({
+    required String model,
+    required String apiKey,
+    required String apiVersion,
+    required http.Client client,
+  }) {
+    return _resolve(
+      cacheKey: 'anthropic-api-key:$model',
+      model: model,
+      headers: {'x-api-key': apiKey, 'anthropic-version': apiVersion},
+      client: client,
+    );
+  }
+
+  static Future<int?> resolveWithBearerToken({
+    required String model,
+    required String token,
+    required String apiVersion,
+    required String betaHeader,
+    required http.Client client,
+  }) {
+    return _resolve(
+      cacheKey: 'anthropic-bearer:$model',
+      model: model,
+      headers: {
+        'Authorization': 'Bearer $token',
+        'anthropic-version': apiVersion,
+        'anthropic-beta': betaHeader,
+      },
+      client: client,
+    );
+  }
+
+  static Future<int?> _resolve({
+    required String cacheKey,
+    required String model,
+    required Map<String, String> headers,
+    required http.Client client,
+  }) async {
+    final cached = _metadataCache[cacheKey];
+    if (cached != null) return cached;
+
+    final queried = await _queryModelMetadata(
+      model: model,
+      headers: headers,
+      client: client,
+    );
+    if (queried != null) {
+      _metadataCache[cacheKey] = queried;
+      return queried;
+    }
+
+    final inferred = infer(model);
+    if (inferred != null) {
+      _metadataCache[cacheKey] = inferred;
+    }
+    return inferred;
+  }
+
+  static int? infer(String model) {
+    final normalized = model.toLowerCase();
+    if (normalized.startsWith('claude-fable-5') ||
+        normalized.startsWith('claude-mythos-5') ||
+        normalized.startsWith('claude-opus-4-8') ||
+        normalized.startsWith('claude-sonnet-4-6')) {
+      return 1000000;
+    }
+    if (normalized.startsWith('claude-') ||
+        normalized.startsWith('anthropic.claude-')) {
+      return 200000;
+    }
+    return null;
+  }
+
+  static Future<int?> _queryModelMetadata({
+    required String model,
+    required Map<String, String> headers,
+    required http.Client client,
+  }) async {
+    final uri = Uri.parse('$_modelsBaseUrl/${Uri.encodeComponent(model)}');
+
+    try {
+      final response = await client
+          .get(uri, headers: headers)
+          .timeout(const Duration(seconds: 2));
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        return null;
+      }
+      final parsed = jsonDecode(response.body);
+      if (parsed is! Map<String, dynamic>) return null;
+      return ModelContextWindow.parseMetadata(parsed);
+    } on Object {
+      return null;
+    }
+  }
+}

--- a/lib/chat/providers/openai_provider.dart
+++ b/lib/chat/providers/openai_provider.dart
@@ -6,6 +6,7 @@ import 'package:nt_helper/chat/providers/llm_provider.dart';
 import 'package:nt_helper/chat/providers/anthropic_provider.dart'
     show LlmApiException;
 import 'package:nt_helper/chat/providers/llm_error_handling.dart';
+import 'package:nt_helper/chat/providers/model_context_window.dart';
 import 'package:nt_helper/services/debug_service.dart';
 
 /// OpenAI Chat Completions API provider.
@@ -27,6 +28,16 @@ class OpenAIProvider with LlmErrorHandling implements LlmProvider {
 
   @override
   String get displayName => 'OpenAI ($model)';
+
+  @override
+  Future<int?> resolveContextWindowTokens() {
+    return OpenAIContextWindowResolver.resolve(
+      model: model,
+      baseUrl: baseUrl,
+      apiKey: apiKey,
+      client: _client,
+    );
+  }
 
   @override
   Future<LlmResponse> sendMessages({

--- a/lib/chat/providers/openai_provider.dart
+++ b/lib/chat/providers/openai_provider.dart
@@ -110,7 +110,23 @@ class OpenAIProvider with LlmErrorHandling implements LlmProvider {
     for (final msg in messages) {
       switch (msg.role) {
         case LlmRole.user:
-          result.add({'role': 'user', 'content': msg.content!});
+          if (msg.hasImageAttachments) {
+            result.add({
+              'role': 'user',
+              'content': <dynamic>[
+                {'type': 'text', 'text': msg.content ?? ''},
+                for (final image in msg.imageAttachments)
+                  {
+                    'type': 'image_url',
+                    'image_url': {
+                      'url': 'data:${image.mimeType};base64,${image.data}',
+                    },
+                  },
+              ],
+            });
+          } else {
+            result.add({'role': 'user', 'content': msg.content!});
+          }
         case LlmRole.assistant:
           if (msg.toolCalls != null && msg.toolCalls!.isNotEmpty) {
             final apiMsg = <String, dynamic>{'role': 'assistant'};

--- a/lib/chat/providers/openai_subscription_provider.dart
+++ b/lib/chat/providers/openai_subscription_provider.dart
@@ -6,6 +6,7 @@ import 'package:nt_helper/chat/models/llm_types.dart';
 import 'package:nt_helper/chat/providers/anthropic_provider.dart'
     show LlmApiException;
 import 'package:nt_helper/chat/providers/llm_provider.dart';
+import 'package:nt_helper/chat/providers/model_context_window.dart';
 import 'package:nt_helper/chat/services/codex_auth_service.dart';
 import 'package:nt_helper/services/debug_service.dart';
 
@@ -28,6 +29,11 @@ class OpenAISubscriptionProvider implements LlmProvider {
 
   @override
   String get displayName => 'OpenAI Subscription ($model)';
+
+  @override
+  Future<int?> resolveContextWindowTokens() async {
+    return OpenAIContextWindowResolver.infer(model);
+  }
 
   @override
   Future<LlmResponse> sendMessages({

--- a/lib/chat/providers/openai_subscription_provider.dart
+++ b/lib/chat/providers/openai_subscription_provider.dart
@@ -32,7 +32,18 @@ class OpenAISubscriptionProvider implements LlmProvider {
 
   @override
   Future<int?> resolveContextWindowTokens() async {
-    return OpenAIContextWindowResolver.infer(model);
+    try {
+      final auth = await authService.loadAuth();
+      return OpenAIContextWindowResolver.resolveSubscription(
+        model: model,
+        headers: {'version': _clientVersion, ...auth.authHeaders},
+        client: _client,
+        clientVersion: _clientVersion,
+        baseUrl: _baseUrl,
+      );
+    } on Object {
+      return OpenAIContextWindowResolver.inferSubscription(model);
+    }
   }
 
   @override

--- a/lib/chat/providers/openai_subscription_provider.dart
+++ b/lib/chat/providers/openai_subscription_provider.dart
@@ -96,6 +96,18 @@ class OpenAISubscriptionProvider implements LlmProvider {
             'role': 'user',
             'content': [
               {'type': 'input_text', 'text': msg.content ?? ''},
+              for (final image in msg.imageAttachments)
+                {
+                  'type': 'input_image',
+                  'image_url': 'data:${image.mimeType};base64,${image.data}',
+                },
+              for (final file in msg.fileAttachments)
+                if (_isCodexFileInput(file.mimeType))
+                  {
+                    'type': 'input_file',
+                    'filename': file.name,
+                    'file_data': 'data:${file.mimeType};base64,${file.data}',
+                  },
             ],
           });
           break;
@@ -161,6 +173,10 @@ class OpenAISubscriptionProvider implements LlmProvider {
           },
         )
         .toList();
+  }
+
+  bool _isCodexFileInput(String mimeType) {
+    return mimeType == 'application/pdf';
   }
 
   Future<LlmResponse> _parseEventStream(Stream<List<int>> stream) async {

--- a/lib/chat/services/chat_service.dart
+++ b/lib/chat/services/chat_service.dart
@@ -103,6 +103,8 @@ class ChatService {
     // final one.
     int totalInputTokens = 0;
     int totalOutputTokens = 0;
+    int totalCacheCreationInputTokens = 0;
+    int totalCacheReadInputTokens = 0;
     int peakInputTokens = 0;
 
     for (int i = 0; i < _maxIterations; i++) {
@@ -148,9 +150,12 @@ class ChatService {
 
       // Accumulate usage from every API call
       if (response.usage != null) {
-        totalInputTokens += response.usage!.inputTokens;
-        totalOutputTokens += response.usage!.outputTokens;
-        peakInputTokens = max(peakInputTokens, response.usage!.inputTokens);
+        final usage = response.usage!;
+        totalInputTokens += usage.inputTokens;
+        totalOutputTokens += usage.outputTokens;
+        totalCacheCreationInputTokens += usage.cacheCreationInputTokens;
+        totalCacheReadInputTokens += usage.cacheReadInputTokens;
+        peakInputTokens = max(peakInputTokens, usage.contextInputTokens);
       }
 
       if (response.hasToolCalls) {
@@ -219,6 +224,8 @@ class ChatService {
         usage: LlmUsage(
           inputTokens: totalInputTokens,
           outputTokens: totalOutputTokens,
+          cacheCreationInputTokens: totalCacheCreationInputTokens,
+          cacheReadInputTokens: totalCacheReadInputTokens,
           peakInputTokens: peakInputTokens,
         ),
         isFinal: true,

--- a/lib/chat/services/chat_service.dart
+++ b/lib/chat/services/chat_service.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:math' show min;
+import 'dart:math' show max, min;
 
 import 'package:nt_helper/chat/models/llm_types.dart';
 import 'package:nt_helper/chat/providers/anthropic_provider.dart'
@@ -103,6 +103,7 @@ class ChatService {
     // final one.
     int totalInputTokens = 0;
     int totalOutputTokens = 0;
+    int peakInputTokens = 0;
 
     for (int i = 0; i < _maxIterations; i++) {
       yield ChatLoopThinking();
@@ -149,6 +150,7 @@ class ChatService {
       if (response.usage != null) {
         totalInputTokens += response.usage!.inputTokens;
         totalOutputTokens += response.usage!.outputTokens;
+        peakInputTokens = max(peakInputTokens, response.usage!.inputTokens);
       }
 
       if (response.hasToolCalls) {
@@ -217,6 +219,7 @@ class ChatService {
         usage: LlmUsage(
           inputTokens: totalInputTokens,
           outputTokens: totalOutputTokens,
+          peakInputTokens: peakInputTokens,
         ),
         isFinal: true,
         finalHistory: List.unmodifiable(currentMessages),

--- a/lib/chat/services/local_file_tools.dart
+++ b/lib/chat/services/local_file_tools.dart
@@ -1,0 +1,570 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:nt_helper/chat/models/allowed_file_root.dart';
+import 'package:nt_helper/mcp/tool_registry.dart';
+import 'package:nt_helper/services/settings_service.dart';
+import 'package:path/path.dart' as path;
+
+const localFileToolNames = {
+  'list_allowed_roots',
+  'list_files',
+  'read_file',
+  'write_file',
+  'search_files',
+};
+
+void registerLocalFileTools(
+  List<ToolRegistryEntry> entries, {
+  required FileRootActor actor,
+}) {
+  final tools = _LocalFileTools(SettingsService(), actor);
+
+  entries.addAll([
+    ToolRegistryEntry(
+      name: 'list_allowed_roots',
+      description:
+          'List named filesystem roots available to this caller and their permissions.',
+      inputSchema: {'properties': {}},
+      handler: tools.listAllowedRoots,
+      timeout: const Duration(seconds: 5),
+    ),
+    ToolRegistryEntry(
+      name: 'list_files',
+      description:
+          'List files under an allowed root. Paths are relative to the selected root.',
+      inputSchema: {
+        'properties': {
+          'root_id': {
+            'type': 'string',
+            'description': 'ID from list_allowed_roots.',
+          },
+          'path': {
+            'type': 'string',
+            'description': 'Optional relative subdirectory to list.',
+          },
+          'recursive': {
+            'type': 'boolean',
+            'description': 'Whether to include nested files. Default: false.',
+          },
+          'limit': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 200,
+            'description': 'Maximum number of entries to return. Default: 50.',
+          },
+        },
+        'required': ['root_id'],
+      },
+      handler: tools.listFiles,
+      timeout: const Duration(seconds: 5),
+    ),
+    ToolRegistryEntry(
+      name: 'read_file',
+      description:
+          'Read a UTF-8 text or binary file under an allowed root. Binary files are returned as base64.',
+      inputSchema: {
+        'properties': {
+          'root_id': {
+            'type': 'string',
+            'description': 'ID from list_allowed_roots.',
+          },
+          'path': {
+            'type': 'string',
+            'description': 'Relative path of the file to read.',
+          },
+          'max_bytes': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 200000,
+            'description':
+                'Maximum bytes to read. Default: 100000. Larger files return an error.',
+          },
+        },
+        'required': ['root_id', 'path'],
+      },
+      handler: tools.readFile,
+      timeout: const Duration(seconds: 5),
+    ),
+    ToolRegistryEntry(
+      name: 'write_file',
+      description:
+          'Write UTF-8 text to a file under an allowed root. No delete or rename support.',
+      inputSchema: {
+        'properties': {
+          'root_id': {
+            'type': 'string',
+            'description': 'ID from list_allowed_roots.',
+          },
+          'path': {
+            'type': 'string',
+            'description': 'Relative path of the file to write.',
+          },
+          'content': {
+            'type': 'string',
+            'description': 'UTF-8 text content to write.',
+          },
+          'create_parents': {
+            'type': 'boolean',
+            'description':
+                'Create missing parent directories under the root. Default: false.',
+          },
+          'overwrite': {
+            'type': 'boolean',
+            'description': 'Allow replacing an existing file. Default: false.',
+          },
+        },
+        'required': ['root_id', 'path', 'content'],
+      },
+      handler: tools.writeFile,
+      timeout: const Duration(seconds: 5),
+    ),
+    ToolRegistryEntry(
+      name: 'search_files',
+      description:
+          'Search UTF-8 text files under an allowed root. Paths are relative to that root.',
+      inputSchema: {
+        'properties': {
+          'root_id': {
+            'type': 'string',
+            'description': 'ID from list_allowed_roots.',
+          },
+          'query': {
+            'type': 'string',
+            'description': 'Case-insensitive text to search for.',
+          },
+          'path': {
+            'type': 'string',
+            'description': 'Optional relative subdirectory to search.',
+          },
+          'limit': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 100,
+            'description': 'Maximum number of matches to return. Default: 25.',
+          },
+          'max_file_bytes': {
+            'type': 'integer',
+            'minimum': 1,
+            'maximum': 500000,
+            'description':
+                'Skip files larger than this many bytes. Default: 200000.',
+          },
+        },
+        'required': ['root_id', 'query'],
+      },
+      handler: tools.searchFiles,
+      timeout: const Duration(seconds: 10),
+    ),
+  ]);
+}
+
+class _ResolvedRoot {
+  const _ResolvedRoot(this.config, this.directory);
+
+  final AllowedFileRoot config;
+  final Directory directory;
+}
+
+class _LocalFileTools {
+  _LocalFileTools(this._settings, this._actor);
+
+  final SettingsService _settings;
+  final FileRootActor _actor;
+
+  Future<String> listAllowedRoots(Map<String, dynamic> args) async {
+    final roots = <Map<String, dynamic>>[];
+    for (final root in _settings.allowedFileRoots) {
+      final permissions = root.permissionsFor(_actor);
+      if (permissions.isEmpty) continue;
+      roots.add({
+        'id': root.id,
+        'label': root.label,
+        'path': root.path,
+        'permissions':
+            permissions.map((permission) => permission.storageKey).toList()
+              ..sort(),
+      });
+    }
+
+    return _json({'success': true, 'roots': roots});
+  }
+
+  Future<String> listFiles(Map<String, dynamic> args) async {
+    final rootResult = await _resolveRoot(args, FileRootPermission.read);
+    if (rootResult.error != null) return rootResult.error!;
+    final root = rootResult.root!;
+
+    final target = await _resolveUnderRoot(root.directory, args['path']);
+    if (target.error != null) return target.error!;
+    final entity = target.entity!;
+    if (!await entity.exists()) {
+      return _json({'success': false, 'error': 'path_not_found'});
+    }
+    if (entity is! Directory) {
+      return _json({'success': false, 'error': 'not_a_directory'});
+    }
+
+    final recursive = args['recursive'] == true;
+    final limit = _intArg(args['limit'], fallback: 50, min: 1, max: 200);
+    final entries = <Map<String, dynamic>>[];
+
+    await for (final child in entity.list(
+      recursive: recursive,
+      followLinks: false,
+    )) {
+      if (child is Link) continue;
+      if (!await _pathResolvesInsideRoot(root.directory, child.path)) continue;
+      final stat = await child.stat();
+      entries.add({
+        'path': _relative(root.directory, child.path),
+        'type': child is Directory ? 'directory' : 'file',
+        'size': stat.type == FileSystemEntityType.file ? stat.size : null,
+        'modified': stat.modified.toIso8601String(),
+      });
+      if (entries.length >= limit) break;
+    }
+
+    return _json({
+      'success': true,
+      'root_id': root.config.id,
+      'root_label': root.config.label,
+      'path': _relative(root.directory, entity.path),
+      'entries': entries,
+      'truncated': entries.length >= limit,
+    });
+  }
+
+  Future<String> readFile(Map<String, dynamic> args) async {
+    final rootResult = await _resolveRoot(args, FileRootPermission.read);
+    if (rootResult.error != null) return rootResult.error!;
+    final root = rootResult.root!;
+
+    final target = await _resolveUnderRoot(root.directory, args['path']);
+    if (target.error != null) return target.error!;
+    final entity = target.entity!;
+    if (entity is! File || !await entity.exists()) {
+      return _json({'success': false, 'error': 'file_not_found'});
+    }
+
+    final maxBytes = _intArg(
+      args['max_bytes'],
+      fallback: 100000,
+      min: 1,
+      max: 200000,
+    );
+    final stat = await entity.stat();
+    if (stat.size > maxBytes) {
+      return _json({
+        'success': false,
+        'error': 'file_too_large',
+        'size': stat.size,
+        'max_bytes': maxBytes,
+      });
+    }
+
+    try {
+      final content = await entity.readAsString();
+      return _json({
+        'success': true,
+        'root_id': root.config.id,
+        'path': _relative(root.directory, entity.path),
+        'size': stat.size,
+        'encoding': 'utf8',
+        'content': content,
+      });
+    } on FormatException {
+      final bytes = await entity.readAsBytes();
+      return _json({
+        'success': true,
+        'root_id': root.config.id,
+        'path': _relative(root.directory, entity.path),
+        'size': stat.size,
+        'encoding': 'base64',
+        'content_base64': base64Encode(bytes),
+      });
+    }
+  }
+
+  Future<String> writeFile(Map<String, dynamic> args) async {
+    final rootResult = await _resolveRoot(args, FileRootPermission.write);
+    if (rootResult.error != null) return rootResult.error!;
+    final root = rootResult.root!;
+
+    final content = args['content'];
+    if (content is! String) {
+      return _json({'success': false, 'error': 'missing_content'});
+    }
+    final contentBytes = utf8.encode(content);
+    if (contentBytes.length > 500000) {
+      return _json({
+        'success': false,
+        'error': 'content_too_large',
+        'size': contentBytes.length,
+        'max_bytes': 500000,
+      });
+    }
+
+    final target = await _resolveUnderRoot(root.directory, args['path']);
+    if (target.error != null) return target.error!;
+    final entity = target.entity!;
+    final file = File(entity.path);
+    final parent = Directory(path.dirname(file.path));
+    if (!await parent.exists()) {
+      if (args['create_parents'] == true) {
+        await parent.create(recursive: true);
+      } else {
+        return _json({'success': false, 'error': 'parent_not_found'});
+      }
+    }
+
+    if (await file.exists() && args['overwrite'] != true) {
+      return _json({'success': false, 'error': 'file_exists'});
+    }
+
+    await file.writeAsString(content);
+    final stat = await file.stat();
+    return _json({
+      'success': true,
+      'root_id': root.config.id,
+      'path': _relative(root.directory, file.path),
+      'size': stat.size,
+      'encoding': 'utf8',
+    });
+  }
+
+  Future<String> searchFiles(Map<String, dynamic> args) async {
+    final rootResult = await _resolveRoot(args, FileRootPermission.search);
+    if (rootResult.error != null) return rootResult.error!;
+    final root = rootResult.root!;
+
+    final query = args['query'];
+    if (query is! String || query.trim().isEmpty) {
+      return _json({'success': false, 'error': 'missing_query'});
+    }
+
+    final target = await _resolveUnderRoot(root.directory, args['path']);
+    if (target.error != null) return target.error!;
+    final entity = target.entity!;
+    if (entity is! Directory || !await entity.exists()) {
+      return _json({'success': false, 'error': 'directory_not_found'});
+    }
+
+    final limit = _intArg(args['limit'], fallback: 25, min: 1, max: 100);
+    final maxFileBytes = _intArg(
+      args['max_file_bytes'],
+      fallback: 200000,
+      min: 1,
+      max: 500000,
+    );
+    final needle = query.toLowerCase();
+    final matches = <Map<String, dynamic>>[];
+
+    await for (final child in entity.list(
+      recursive: true,
+      followLinks: false,
+    )) {
+      if (child is! File) continue;
+      if (!await _pathResolvesInsideRoot(root.directory, child.path)) continue;
+      final stat = await child.stat();
+      if (stat.size > maxFileBytes) continue;
+
+      String content;
+      try {
+        content = await child.readAsString();
+      } on FormatException {
+        continue;
+      }
+
+      final lines = const LineSplitter().convert(content);
+      for (var i = 0; i < lines.length; i++) {
+        final line = lines[i];
+        if (!line.toLowerCase().contains(needle)) continue;
+        matches.add({
+          'path': _relative(root.directory, child.path),
+          'line': i + 1,
+          'preview': line.trim(),
+        });
+        if (matches.length >= limit) {
+          return _json({
+            'success': true,
+            'root_id': root.config.id,
+            'query': query,
+            'matches': matches,
+            'truncated': true,
+          });
+        }
+      }
+    }
+
+    return _json({
+      'success': true,
+      'root_id': root.config.id,
+      'query': query,
+      'matches': matches,
+      'truncated': false,
+    });
+  }
+
+  Future<({String? error, _ResolvedRoot? root})> _resolveRoot(
+    Map<String, dynamic> args,
+    FileRootPermission permission,
+  ) async {
+    final rootId = args['root_id'];
+    if (rootId is! String || rootId.trim().isEmpty) {
+      return (
+        error: _json({'success': false, 'error': 'missing_root_id'}),
+        root: null,
+      );
+    }
+
+    AllowedFileRoot? root;
+    for (final candidate in _settings.allowedFileRoots) {
+      if (candidate.id == rootId) {
+        root = candidate;
+        break;
+      }
+    }
+    if (root == null) {
+      return (
+        error: _json({'success': false, 'error': 'root_not_found'}),
+        root: null,
+      );
+    }
+    if (!root.allows(_actor, permission)) {
+      return (
+        error: _json({
+          'success': false,
+          'error': 'permission_denied',
+          'permission': permission.storageKey,
+        }),
+        root: null,
+      );
+    }
+
+    final directory = Directory(root.path);
+    if (!await directory.exists()) {
+      return (
+        error: _json({'success': false, 'error': 'root_not_found_on_disk'}),
+        root: null,
+      );
+    }
+
+    return (
+      error: null,
+      root: _ResolvedRoot(
+        root,
+        Directory(await directory.resolveSymbolicLinks()),
+      ),
+    );
+  }
+
+  Future<({String? error, FileSystemEntity? entity})> _resolveUnderRoot(
+    Directory root,
+    dynamic relativePath,
+  ) async {
+    if (relativePath != null && relativePath is! String) {
+      return (
+        error: _json({'success': false, 'error': 'invalid_path'}),
+        entity: null,
+      );
+    }
+
+    final rawPath = (relativePath as String?)?.trim();
+    if (rawPath != null && rawPath.isNotEmpty && path.isAbsolute(rawPath)) {
+      return (
+        error: _json({'success': false, 'error': 'absolute_path_not_allowed'}),
+        entity: null,
+      );
+    }
+    final normalizedRelative = path.normalize(rawPath ?? '');
+    if (normalizedRelative == '..' ||
+        normalizedRelative.startsWith('..${path.separator}') ||
+        normalizedRelative.split(path.separator).contains('..')) {
+      return (
+        error: _json({'success': false, 'error': 'path_outside_allowed_root'}),
+        entity: null,
+      );
+    }
+
+    final combined = rawPath == null || rawPath.isEmpty
+        ? root.path
+        : path.join(root.path, normalizedRelative);
+    final normalized = path.normalize(combined);
+    final existingAncestor = await _nearestExistingAncestor(normalized);
+    final resolvedAncestor = await existingAncestor.resolveSymbolicLinks();
+    final suffix = path.relative(normalized, from: existingAncestor.path);
+    final resolvedPath = suffix == '.'
+        ? path.normalize(resolvedAncestor)
+        : path.normalize(path.join(resolvedAncestor, suffix));
+
+    if (!path.isWithin(root.path, resolvedPath) && resolvedPath != root.path) {
+      return (
+        error: _json({'success': false, 'error': 'path_outside_allowed_root'}),
+        entity: null,
+      );
+    }
+
+    final type = await FileSystemEntity.type(resolvedPath, followLinks: false);
+    if (type == FileSystemEntityType.link) {
+      return (
+        error: _json({'success': false, 'error': 'path_outside_allowed_root'}),
+        entity: null,
+      );
+    }
+    return (
+      error: null,
+      entity: type == FileSystemEntityType.directory
+          ? Directory(resolvedPath)
+          : File(resolvedPath),
+    );
+  }
+
+  Future<bool> _pathResolvesInsideRoot(
+    Directory root,
+    String entityPath,
+  ) async {
+    try {
+      final isDirectory = await FileSystemEntity.isDirectory(entityPath);
+      final resolved = isDirectory
+          ? await Directory(entityPath).resolveSymbolicLinks()
+          : await File(entityPath).resolveSymbolicLinks();
+      return path.isWithin(root.path, resolved) || resolved == root.path;
+    } on FileSystemException {
+      return false;
+    }
+  }
+
+  Future<Directory> _nearestExistingAncestor(String targetPath) async {
+    var current = Directory(targetPath);
+    while (!await current.exists()) {
+      final parentPath = path.dirname(current.path);
+      if (parentPath == current.path) break;
+      current = Directory(parentPath);
+    }
+    return current;
+  }
+
+  String _relative(Directory root, String entityPath) {
+    final rel = path.relative(entityPath, from: root.path);
+    return rel == '.' ? '' : rel;
+  }
+
+  int _intArg(
+    dynamic value, {
+    required int fallback,
+    required int min,
+    required int max,
+  }) {
+    final parsed = value is int
+        ? value
+        : value is num
+        ? value.toInt()
+        : value is String
+        ? int.tryParse(value) ?? fallback
+        : fallback;
+    return parsed.clamp(min, max).toInt();
+  }
+
+  String _json(Map<String, dynamic> value) => jsonEncode(value);
+}

--- a/lib/chat/services/local_file_tools.dart
+++ b/lib/chat/services/local_file_tools.dart
@@ -177,6 +177,7 @@ class _LocalFileTools {
     for (final root in _settings.allowedFileRoots) {
       final permissions = root.permissionsFor(_actor);
       if (permissions.isEmpty) continue;
+      if (!await Directory(root.path).exists()) continue;
       roots.add({
         'id': root.id,
         'label': root.label,

--- a/lib/chat/services/system_prompt.dart
+++ b/lib/chat/services/system_prompt.dart
@@ -23,7 +23,7 @@ Today's date is $date.
 
 ## Workflow Rules
 
-1. **Progressive disclosure**: Start with `show_preset` for a compact overview (algorithm names, parameter counts). Use `show_slot` to see parameter summaries for a specific slot — paginate with `offset`/`limit` if `has_more` is true. Use `show_parameter` for full detail (enum value lists, mapping details) before editing.
+1. **Progressive disclosure**: Start with `show_preset` for a compact overview (algorithm names, parameter counts). Use `show_slot` to see parameter summaries for a specific slot. Use `show_parameter` for full detail (enum value lists, mapping details) before editing. If any tool returns a `tool_reference`, use `read_reference` to page through it or `search_reference` to find relevant sections.
 2. **Search by name, inspect by info, add by GUID**: Use `search_algorithms` to find algorithms and get GUIDs. Use `algorithm_info` when you need the full documentation/help metadata for an algorithm. Add with the GUID.
 3. **Respect signal flow**: Sources in lower slots, processors in higher slots. Adding to an occupied slot inserts and shifts — always `show_preset` after adding to verify layout.
 4. **Move, don't remove-and-readd**: Use `move_algorithm` to reorder. Removing destroys all parameter values and mappings.
@@ -35,7 +35,7 @@ Today's date is $date.
 ## Tool Reference
 
 - **Parameter identification**: 0-based index (int) or exact name (string). For approximate references ("the mix knob"), use `show_slot` to find the exact name.
-- **Pagination**: `show_slot` returns 10 parameters per page by default. Use `offset` and `limit` to page through large algorithms. Response includes `parameter_count`, `offset`, and `has_more` for navigation.
+- **Large tool results**: Any tool may return `type: "tool_reference"` with a `reference_id` instead of the full payload. Use `read_reference` with `offset`/`limit` to page through it, or `search_reference` with a query to find relevant sections.
 - **Partial updates**: `edit_slot` updates parameters without re-specifying the algorithm. `edit_parameter` updates value, mapping, or both. Mapping updates are partial — existing mappings are preserved.
 - **Routing buses**: Check `valid_enum_values` for available bus names. Common: "None", "Input 1"-"Input 12", "Output 1"-"Output 8", "Aux 1"+, "ES-5 L", "ES-5 R".
 - **Move direction**: "up" = lower slot number (earlier in signal flow), "down" = higher slot number.

--- a/lib/chat/services/system_prompt.dart
+++ b/lib/chat/services/system_prompt.dart
@@ -24,7 +24,7 @@ Today's date is $date.
 ## Workflow Rules
 
 1. **Progressive disclosure**: Start with `show_preset` for a compact overview (algorithm names, parameter counts). Use `show_slot` to see parameter summaries for a specific slot — paginate with `offset`/`limit` if `has_more` is true. Use `show_parameter` for full detail (enum value lists, mapping details) before editing.
-2. **Search by name, add by GUID**: Use `search_algorithms` to find algorithms and get GUIDs. Add with the GUID.
+2. **Search by name, inspect by info, add by GUID**: Use `search_algorithms` to find algorithms and get GUIDs. Use `algorithm_info` when you need the full documentation/help metadata for an algorithm. Add with the GUID.
 3. **Respect signal flow**: Sources in lower slots, processors in higher slots. Adding to an occupied slot inserts and shifts — always `show_preset` after adding to verify layout.
 4. **Move, don't remove-and-readd**: Use `move_algorithm` to reorder. Removing destroys all parameter values and mappings.
 5. **Never guess enum values**: Always `show_parameter` first to see exact `valid_enum_values` before setting an enum parameter. `show_slot` tells you which parameters are enums (`is_enum: true`) but does NOT include the values list. For numeric parameters, `show_slot` gives you the range.
@@ -46,6 +46,7 @@ Today's date is $date.
   - `i2c`: `is_i2c_enabled`, `i2c_cc` (0-255), `is_i2c_symmetric`, `i2c_min`, `i2c_max`. I2C *sets* the parameter value directly.
   - `performance_page`: 0-30.
 - **Search**: Results sorted by relevance. Use first match unless ambiguous — then present top results and ask.
+- **Algorithm help**: `algorithm_info` returns the same metadata source as the app's algorithm Help screen: description, categories, ports, specifications, parameters, and features.
 
 ## Response Style
 

--- a/lib/chat/services/tool_bridge_service.dart
+++ b/lib/chat/services/tool_bridge_service.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:nt_helper/chat/models/llm_types.dart';
 import 'package:nt_helper/mcp/tool_registry.dart';
 
@@ -30,27 +28,6 @@ class ToolBridgeService {
     String name,
     Map<String, dynamic> arguments,
   ) async {
-    final entry = _registry.findByName(name);
-    if (entry == null) {
-      return jsonEncode({'success': false, 'error': 'Unknown tool: $name'});
-    }
-
-    try {
-      return await entry
-          .handler(arguments)
-          .timeout(
-            entry.timeout,
-            onTimeout: () => jsonEncode({
-              'success': false,
-              'error':
-                  'Tool execution timed out after ${entry.timeout.inSeconds} seconds',
-            }),
-          );
-    } catch (e) {
-      return jsonEncode({
-        'success': false,
-        'error': 'Tool execution failed: $e',
-      });
-    }
+    return _registry.executeTool(name, arguments);
   }
 }

--- a/lib/chat/ui/chat_input_bar.dart
+++ b/lib/chat/ui/chat_input_bar.dart
@@ -125,26 +125,6 @@ class _ChatInputBarState extends State<ChatInputBar> {
     _focusNode.requestFocus();
   }
 
-  Future<void> _attachImages() async {
-    final result = await FilePicker.pickFiles(
-      type: FileType.image,
-      allowMultiple: true,
-      withData: false,
-    );
-    if (result == null || !mounted) return;
-    for (final file in result.files) {
-      if (!_canAddAttachment()) break;
-      if (file.size > _maxImageBytes) {
-        _showAttachmentError('${file.name} is larger than 10 MB.');
-        continue;
-      }
-      final bytes = file.bytes ?? await _readFileBytes(file.path);
-      if (bytes == null) continue;
-      if (!mounted) return;
-      _addImage(bytes, name: file.name);
-    }
-  }
-
   Future<void> _attachFiles() async {
     final result = await FilePicker.pickFiles(
       allowMultiple: true,
@@ -183,13 +163,6 @@ class _ChatInputBarState extends State<ChatInputBar> {
       if (!mounted) return;
       _addFile(bytes, name: file.name, mimeType: mimeType);
     }
-  }
-
-  Future<void> _pasteImage() async {
-    final bytes = await Pasteboard.image;
-    if (!mounted || bytes == null || bytes.isEmpty) return;
-    if (!_canAddAttachment()) return;
-    _addImage(bytes, name: 'clipboard.png');
   }
 
   Future<void> _handlePasteShortcut() async {
@@ -417,7 +390,7 @@ class _ChatInputBarState extends State<ChatInputBar> {
                 4 // SizedBox before send button
                 -
                 48; // send/cancel IconButton width
-            _availableWidth -= 120; // attach file/image and paste IconButtons
+            _availableWidth -= 40; // attachment IconButton width
             if (!_isExpanded) {
               _availableWidth -= 40; // settings IconButton width
             }
@@ -440,32 +413,12 @@ class _ChatInputBarState extends State<ChatInputBar> {
                         ),
                 ),
                 Semantics(
-                  label: 'Attach file',
+                  label: 'Attach image or file',
                   button: true,
                   child: IconButton(
                     icon: const Icon(Icons.attach_file, size: 20),
-                    tooltip: 'Attach file',
+                    tooltip: 'Attach image or file',
                     onPressed: widget.isProcessing ? null : _attachFiles,
-                    visualDensity: VisualDensity.compact,
-                  ),
-                ),
-                Semantics(
-                  label: 'Attach image',
-                  button: true,
-                  child: IconButton(
-                    icon: const Icon(Icons.image_outlined, size: 20),
-                    tooltip: 'Attach image',
-                    onPressed: widget.isProcessing ? null : _attachImages,
-                    visualDensity: VisualDensity.compact,
-                  ),
-                ),
-                Semantics(
-                  label: 'Paste image',
-                  button: true,
-                  child: IconButton(
-                    icon: const Icon(Icons.content_paste, size: 20),
-                    tooltip: 'Paste image',
-                    onPressed: widget.isProcessing ? null : _pasteImage,
                     visualDensity: VisualDensity.compact,
                   ),
                 ),

--- a/lib/chat/ui/chat_input_bar.dart
+++ b/lib/chat/ui/chat_input_bar.dart
@@ -1,10 +1,25 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:cross_file/cross_file.dart';
+import 'package:desktop_drop/desktop_drop.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:nt_helper/chat/models/chat_message.dart';
 import 'package:nt_helper/services/key_binding_service.dart';
+import 'package:pasteboard/pasteboard.dart';
+import 'package:path/path.dart' as path;
 
 class ChatInputBar extends StatefulWidget {
   final bool isProcessing;
-  final ValueChanged<String> onSend;
+  final void Function(
+    String text,
+    List<ChatImageAttachment> imageAttachments,
+    List<ChatFileAttachment> fileAttachments,
+  )
+  onSend;
   final VoidCallback onCancel;
   final VoidCallback onSettings;
   final FocusNode? focusNode;
@@ -23,11 +38,19 @@ class ChatInputBar extends StatefulWidget {
 }
 
 class _ChatInputBarState extends State<ChatInputBar> {
+  static const _maxAttachments = 6;
+  static const _maxImageBytes = 10 * 1024 * 1024;
+  static const _maxPdfBytes = 5 * 1024 * 1024;
+  static const _maxTextFileBytes = 100 * 1024;
+
   final _controller = TextEditingController();
   FocusNode? _ownedFocusNode;
   bool _isExpanded = false;
   bool _hasTyped = false;
+  bool _isDragOver = false;
   double _availableWidth = 0;
+  final List<ChatImageAttachment> _imageAttachments = [];
+  final List<ChatFileAttachment> _fileAttachments = [];
 
   FocusNode get _focusNode =>
       widget.focusNode ?? (_ownedFocusNode ??= FocusNode());
@@ -86,10 +109,284 @@ class _ChatInputBarState extends State<ChatInputBar> {
 
   void _handleSend() {
     final text = _controller.text.trim();
-    if (text.isEmpty) return;
-    widget.onSend(text);
+    if (text.isEmpty && _imageAttachments.isEmpty && _fileAttachments.isEmpty) {
+      return;
+    }
+    widget.onSend(
+      text,
+      List.unmodifiable(_imageAttachments),
+      List.unmodifiable(_fileAttachments),
+    );
     _controller.clear();
+    setState(() {
+      _imageAttachments.clear();
+      _fileAttachments.clear();
+    });
     _focusNode.requestFocus();
+  }
+
+  Future<void> _attachImages() async {
+    final result = await FilePicker.pickFiles(
+      type: FileType.image,
+      allowMultiple: true,
+      withData: false,
+    );
+    if (result == null || !mounted) return;
+    for (final file in result.files) {
+      if (!_canAddAttachment()) break;
+      if (file.size > _maxImageBytes) {
+        _showAttachmentError('${file.name} is larger than 10 MB.');
+        continue;
+      }
+      final bytes = file.bytes ?? await _readFileBytes(file.path);
+      if (bytes == null) continue;
+      if (!mounted) return;
+      _addImage(bytes, name: file.name);
+    }
+  }
+
+  Future<void> _attachFiles() async {
+    final result = await FilePicker.pickFiles(
+      allowMultiple: true,
+      withData: false,
+    );
+    if (result == null || !mounted) return;
+    for (final file in result.files) {
+      if (!_canAddAttachment()) break;
+      final mimeType = _mimeTypeForName(file.name);
+      if (mimeType.startsWith('image/')) {
+        if (file.size > _maxImageBytes) {
+          _showAttachmentError('${file.name} is larger than 10 MB.');
+          continue;
+        }
+        final bytes = file.bytes ?? await _readFileBytes(file.path);
+        if (bytes == null) continue;
+        if (!mounted) return;
+        _addImage(bytes, name: file.name);
+        continue;
+      }
+      if (!_isAttachableFileMime(mimeType)) {
+        _showAttachmentError(
+          '${file.name} is not a supported attachment type.',
+        );
+        continue;
+      }
+      final maxBytes = _maxBytesForMime(mimeType);
+      if (file.size > maxBytes) {
+        _showAttachmentError(
+          '${file.name} is larger than ${_formatBytes(maxBytes)}.',
+        );
+        continue;
+      }
+      final bytes = file.bytes ?? await _readFileBytes(file.path);
+      if (bytes == null) continue;
+      if (!mounted) return;
+      _addFile(bytes, name: file.name, mimeType: mimeType);
+    }
+  }
+
+  Future<void> _pasteImage() async {
+    final bytes = await Pasteboard.image;
+    if (!mounted || bytes == null || bytes.isEmpty) return;
+    if (!_canAddAttachment()) return;
+    _addImage(bytes, name: 'clipboard.png');
+  }
+
+  Future<void> _handlePasteShortcut() async {
+    final bytes = await Pasteboard.image;
+    if (!mounted) return;
+    if (bytes != null && bytes.isNotEmpty && _canAddAttachment()) {
+      _addImage(bytes, name: 'clipboard.png');
+      return;
+    }
+
+    final data = await Clipboard.getData(Clipboard.kTextPlain);
+    if (!mounted || data?.text == null) return;
+    _replaceSelection(data!.text!);
+  }
+
+  void _replaceSelection(String text) {
+    final value = _controller.value;
+    final selection = value.selection;
+    final replacement = selection.isValid
+        ? value.text.replaceRange(selection.start, selection.end, text)
+        : value.text + text;
+    final offset = selection.isValid
+        ? selection.start + text.length
+        : replacement.length;
+    _controller.value = value.copyWith(
+      text: replacement,
+      selection: TextSelection.collapsed(offset: offset),
+      composing: TextRange.empty,
+    );
+  }
+
+  Future<void> _attachDroppedFiles(List<XFile> files) async {
+    if (widget.isProcessing) return;
+    for (final file in files) {
+      if (!_canAddAttachment()) break;
+      final fileName = file.name.isNotEmpty
+          ? file.name
+          : path.basename(file.path);
+      final mimeType = _mimeTypeForName(fileName);
+      final size = await file.length();
+      if (!mounted) return;
+
+      if (mimeType.startsWith('image/')) {
+        if (size > _maxImageBytes) {
+          _showAttachmentError('$fileName is larger than 10 MB.');
+          continue;
+        }
+        _addImage(await file.readAsBytes(), name: fileName);
+        continue;
+      }
+
+      if (!_isAttachableFileMime(mimeType)) {
+        _showAttachmentError('$fileName is not a supported attachment type.');
+        continue;
+      }
+      final maxBytes = _maxBytesForMime(mimeType);
+      if (size > maxBytes) {
+        _showAttachmentError(
+          '$fileName is larger than ${_formatBytes(maxBytes)}.',
+        );
+        continue;
+      }
+      _addFile(await file.readAsBytes(), name: fileName, mimeType: mimeType);
+    }
+  }
+
+  Future<List<int>?> _readFileBytes(String? filePath) async {
+    if (filePath == null) return null;
+    return File(filePath).readAsBytes();
+  }
+
+  void _addImage(List<int> bytes, {String? name}) {
+    if (bytes.length > _maxImageBytes) {
+      _showAttachmentError('${name ?? 'Image'} is larger than 10 MB.');
+      return;
+    }
+    final fileName = name ?? 'image.png';
+    final mimeType = _mimeTypeForName(fileName);
+    setState(() {
+      _imageAttachments.add(
+        ChatImageAttachment(
+          data: base64Encode(bytes),
+          mimeType: mimeType,
+          name: fileName,
+        ),
+      );
+    });
+  }
+
+  void _addFile(
+    List<int> bytes, {
+    required String name,
+    required String mimeType,
+  }) {
+    String? textContent;
+    if (_isTextFileMime(mimeType)) {
+      try {
+        textContent = utf8.decode(bytes);
+      } on FormatException {
+        _showAttachmentError('$name is not valid UTF-8 text.');
+        return;
+      }
+    }
+    setState(() {
+      _fileAttachments.add(
+        ChatFileAttachment(
+          name: name,
+          data: base64Encode(bytes),
+          mimeType: mimeType,
+          sizeBytes: bytes.length,
+          textContent: textContent,
+        ),
+      );
+    });
+  }
+
+  bool _canAddAttachment() {
+    if (_imageAttachments.length + _fileAttachments.length < _maxAttachments) {
+      return true;
+    }
+    _showAttachmentError('Attach up to $_maxAttachments files per message.');
+    return false;
+  }
+
+  bool _isAttachableFileMime(String mimeType) {
+    return mimeType == 'application/pdf' || _isTextFileMime(mimeType);
+  }
+
+  bool _isTextFileMime(String mimeType) {
+    return mimeType == 'application/json' || mimeType.startsWith('text/');
+  }
+
+  int _maxBytesForMime(String mimeType) {
+    return mimeType == 'application/pdf' ? _maxPdfBytes : _maxTextFileBytes;
+  }
+
+  String _formatBytes(int bytes) {
+    if (bytes >= 1024 * 1024) return '${bytes ~/ (1024 * 1024)} MB';
+    return '${bytes ~/ 1024} KB';
+  }
+
+  void _showAttachmentError(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  void _removeImage(int index) {
+    setState(() => _imageAttachments.removeAt(index));
+  }
+
+  void _removeFile(int index) {
+    setState(() => _fileAttachments.removeAt(index));
+  }
+
+  String _mimeTypeForName(String fileName) {
+    switch (path.extension(fileName).toLowerCase()) {
+      case '.png':
+        return 'image/png';
+      case '.jpg':
+      case '.jpeg':
+        return 'image/jpeg';
+      case '.webp':
+        return 'image/webp';
+      case '.gif':
+        return 'image/gif';
+      case '.pdf':
+        return 'application/pdf';
+      case '.json':
+      case '.ntpreset':
+      case '.preset':
+        return 'application/json';
+      case '.txt':
+      case '.md':
+      case '.markdown':
+      case '.csv':
+      case '.yaml':
+      case '.yml':
+      case '.toml':
+      case '.xml':
+      case '.lua':
+      case '.dart':
+      case '.js':
+      case '.ts':
+      case '.py':
+      case '.sh':
+        return 'text/plain';
+      case '.syx':
+      case '.o':
+      case '.wasm':
+      case '.bin':
+      case '.dat':
+        return 'application/octet-stream';
+      default:
+        return 'application/octet-stream';
+    }
   }
 
   @override
@@ -103,7 +400,7 @@ class _ChatInputBarState extends State<ChatInputBar> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Container(
+    final content = Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
       decoration: BoxDecoration(
         color: theme.colorScheme.surface,
@@ -120,6 +417,7 @@ class _ChatInputBarState extends State<ChatInputBar> {
                 4 // SizedBox before send button
                 -
                 48; // send/cancel IconButton width
+            _availableWidth -= 120; // attach file/image and paste IconButtons
             if (!_isExpanded) {
               _availableWidth -= 40; // settings IconButton width
             }
@@ -141,60 +439,120 @@ class _ChatInputBarState extends State<ChatInputBar> {
                           ),
                         ),
                 ),
+                Semantics(
+                  label: 'Attach file',
+                  button: true,
+                  child: IconButton(
+                    icon: const Icon(Icons.attach_file, size: 20),
+                    tooltip: 'Attach file',
+                    onPressed: widget.isProcessing ? null : _attachFiles,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ),
+                Semantics(
+                  label: 'Attach image',
+                  button: true,
+                  child: IconButton(
+                    icon: const Icon(Icons.image_outlined, size: 20),
+                    tooltip: 'Attach image',
+                    onPressed: widget.isProcessing ? null : _attachImages,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ),
+                Semantics(
+                  label: 'Paste image',
+                  button: true,
+                  child: IconButton(
+                    icon: const Icon(Icons.content_paste, size: 20),
+                    tooltip: 'Paste image',
+                    onPressed: widget.isProcessing ? null : _pasteImage,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ),
                 Expanded(
-                  child: Shortcuts(
-                    shortcuts: {
-                      LogicalKeySet(LogicalKeyboardKey.enter):
-                          const _SendIntent(),
-                      for (final key
-                          in _digitKeys) ...<SingleActivator, Intent>{
-                        SingleActivator(key):
-                            const DoNothingAndStopPropagationTextIntent(),
-                        SingleActivator(key, shift: true):
-                            const DoNothingAndStopPropagationTextIntent(),
-                      },
-                      for (final activator
-                          in KeyBindingService().globalShortcuts.keys)
-                        activator:
-                            const DoNothingAndStopPropagationTextIntent(),
-                    },
-                    child: Actions(
-                      actions: {
-                        _SendIntent: CallbackAction<_SendIntent>(
-                          onInvoke: (_) {
-                            if (!widget.isProcessing) _handleSend();
-                            return null;
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (_imageAttachments.isNotEmpty)
+                        _ImageAttachmentStrip(
+                          attachments: _imageAttachments,
+                          onRemove: _removeImage,
+                        ),
+                      if (_fileAttachments.isNotEmpty)
+                        _FileAttachmentStrip(
+                          attachments: _fileAttachments,
+                          onRemove: _removeFile,
+                        ),
+                      Shortcuts(
+                        shortcuts: {
+                          LogicalKeySet(LogicalKeyboardKey.enter):
+                              const _SendIntent(),
+                          SingleActivator(LogicalKeyboardKey.keyV, meta: true):
+                              const _PasteIntent(),
+                          SingleActivator(
+                            LogicalKeyboardKey.keyV,
+                            control: true,
+                          ): const _PasteIntent(),
+                          for (final key
+                              in _digitKeys) ...<SingleActivator, Intent>{
+                            SingleActivator(key):
+                                const DoNothingAndStopPropagationTextIntent(),
+                            SingleActivator(key, shift: true):
+                                const DoNothingAndStopPropagationTextIntent(),
                           },
-                        ),
-                      },
-                      child: TextField(
-                        controller: _controller,
-                        focusNode: _focusNode,
-                        decoration: InputDecoration(
-                          hintText: _hasTyped
-                              ? null
-                              : 'Ask about your preset...',
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(24),
-                            borderSide: BorderSide.none,
+                          for (final activator
+                              in KeyBindingService().globalShortcuts.keys)
+                            activator:
+                                const DoNothingAndStopPropagationTextIntent(),
+                        },
+                        child: Actions(
+                          actions: {
+                            _SendIntent: CallbackAction<_SendIntent>(
+                              onInvoke: (_) {
+                                if (!widget.isProcessing) _handleSend();
+                                return null;
+                              },
+                            ),
+                            _PasteIntent: CallbackAction<_PasteIntent>(
+                              onInvoke: (_) {
+                                if (!widget.isProcessing) {
+                                  unawaited(_handlePasteShortcut());
+                                }
+                                return null;
+                              },
+                            ),
+                          },
+                          child: TextField(
+                            controller: _controller,
+                            focusNode: _focusNode,
+                            decoration: InputDecoration(
+                              hintText: _hasTyped
+                                  ? null
+                                  : 'Ask about your preset...',
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(24),
+                                borderSide: BorderSide.none,
+                              ),
+                              filled: true,
+                              fillColor:
+                                  theme.colorScheme.surfaceContainerHighest,
+                              contentPadding: const EdgeInsets.symmetric(
+                                horizontal: 16,
+                                vertical: 10,
+                              ),
+                              isDense: true,
+                            ),
+                            enabled: !widget.isProcessing,
+                            textInputAction: TextInputAction.send,
+                            onSubmitted: widget.isProcessing
+                                ? null
+                                : (_) => _handleSend(),
+                            maxLines: 3,
+                            minLines: 1,
                           ),
-                          filled: true,
-                          fillColor: theme.colorScheme.surfaceContainerHighest,
-                          contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 16,
-                            vertical: 10,
-                          ),
-                          isDense: true,
                         ),
-                        enabled: !widget.isProcessing,
-                        textInputAction: TextInputAction.send,
-                        onSubmitted: widget.isProcessing
-                            ? null
-                            : (_) => _handleSend(),
-                        maxLines: 3,
-                        minLines: 1,
                       ),
-                    ),
+                    ],
                   ),
                 ),
                 const SizedBox(width: 4),
@@ -230,11 +588,159 @@ class _ChatInputBarState extends State<ChatInputBar> {
         ),
       ),
     );
+    if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
+      return DropTarget(
+        onDragEntered: (_) => setState(() => _isDragOver = true),
+        onDragExited: (_) => setState(() => _isDragOver = false),
+        onDragDone: (details) async {
+          setState(() => _isDragOver = false);
+          await _attachDroppedFiles(details.files);
+        },
+        child: Stack(
+          children: [
+            content,
+            if (_isDragOver)
+              Positioned.fill(
+                child: IgnorePointer(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.primary.withValues(alpha: 0.08),
+                      border: Border(
+                        top: BorderSide(
+                          color: theme.colorScheme.primary,
+                          width: 2,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      );
+    }
+    return content;
   }
 }
 
 class _SendIntent extends Intent {
   const _SendIntent();
+}
+
+class _PasteIntent extends Intent {
+  const _PasteIntent();
+}
+
+class _ImageAttachmentStrip extends StatelessWidget {
+  final List<ChatImageAttachment> attachments;
+  final ValueChanged<int> onRemove;
+
+  const _ImageAttachmentStrip({
+    required this.attachments,
+    required this.onRemove,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      height: 58,
+      alignment: Alignment.centerLeft,
+      margin: const EdgeInsets.only(bottom: 6),
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: attachments.length,
+        separatorBuilder: (_, _) => const SizedBox(width: 6),
+        itemBuilder: (context, index) {
+          final attachment = attachments[index];
+          return Stack(
+            clipBehavior: Clip.none,
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(6),
+                child: Image.memory(
+                  base64Decode(attachment.data),
+                  width: 52,
+                  height: 52,
+                  fit: BoxFit.cover,
+                ),
+              ),
+              Positioned(
+                top: -6,
+                right: -6,
+                child: Material(
+                  color: theme.colorScheme.surface,
+                  shape: const CircleBorder(),
+                  child: Tooltip(
+                    message: 'Remove image attachment',
+                    child: Semantics(
+                      label: 'Remove image attachment',
+                      button: true,
+                      child: InkWell(
+                        customBorder: const CircleBorder(),
+                        onTap: () => onRemove(index),
+                        child: Icon(
+                          Icons.cancel,
+                          size: 18,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _FileAttachmentStrip extends StatelessWidget {
+  final List<ChatFileAttachment> attachments;
+  final ValueChanged<int> onRemove;
+
+  const _FileAttachmentStrip({
+    required this.attachments,
+    required this.onRemove,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      height: 36,
+      alignment: Alignment.centerLeft,
+      margin: const EdgeInsets.only(bottom: 6),
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: attachments.length,
+        separatorBuilder: (_, _) => const SizedBox(width: 6),
+        itemBuilder: (context, index) {
+          final attachment = attachments[index];
+          return InputChip(
+            avatar: Icon(
+              attachment.mimeType == 'application/pdf'
+                  ? Icons.picture_as_pdf
+                  : Icons.description_outlined,
+              size: 16,
+            ),
+            label: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 160),
+              child: Text(
+                attachment.name,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.labelSmall,
+              ),
+            ),
+            onDeleted: () => onRemove(index),
+            visualDensity: VisualDensity.compact,
+          );
+        },
+      ),
+    );
+  }
 }
 
 const _digitKeys = [

--- a/lib/chat/ui/chat_message_bubble.dart
+++ b/lib/chat/ui/chat_message_bubble.dart
@@ -65,12 +65,34 @@ class _UserBubbleState extends State<_UserBubble> {
                 borderRadius: BorderRadius.circular(16),
               ),
               child: Semantics(
-                label: 'You said: ${widget.message.content}',
-                child: Text(
-                  widget.message.content,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: theme.colorScheme.onPrimaryContainer,
-                  ),
+                label: _userMessageSemanticsLabel(widget.message),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (widget.message.hasImageAttachments) ...[
+                      _MessageImageGrid(
+                        attachments: widget.message.imageAttachments,
+                      ),
+                      if (widget.message.content.isNotEmpty ||
+                          widget.message.hasFileAttachments)
+                        const SizedBox(height: 8),
+                    ],
+                    if (widget.message.hasFileAttachments) ...[
+                      _MessageFileChips(
+                        attachments: widget.message.fileAttachments,
+                      ),
+                      if (widget.message.content.isNotEmpty)
+                        const SizedBox(height: 8),
+                    ],
+                    if (widget.message.content.isNotEmpty)
+                      Text(
+                        widget.message.content,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onPrimaryContainer,
+                        ),
+                      ),
+                  ],
                 ),
               ),
             ),
@@ -85,6 +107,96 @@ class _UserBubbleState extends State<_UserBubble> {
       ),
     );
   }
+}
+
+class _MessageFileChips extends StatelessWidget {
+  final List<ChatFileAttachment> attachments;
+
+  const _MessageFileChips({required this.attachments});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Wrap(
+      spacing: 6,
+      runSpacing: 6,
+      alignment: WrapAlignment.end,
+      children: [
+        for (final attachment in attachments)
+          Semantics(
+            label: 'Attached file ${attachment.name}',
+            child: Chip(
+              avatar: Icon(
+                attachment.mimeType == 'application/pdf'
+                    ? Icons.picture_as_pdf
+                    : Icons.description_outlined,
+                size: 16,
+                color: theme.colorScheme.onPrimaryContainer,
+              ),
+              label: Text(
+                attachment.name,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onPrimaryContainer,
+                ),
+              ),
+              backgroundColor: theme.colorScheme.primaryContainer,
+              side: BorderSide(color: theme.colorScheme.outlineVariant),
+              visualDensity: VisualDensity.compact,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _MessageImageGrid extends StatelessWidget {
+  final List<ChatImageAttachment> attachments;
+
+  const _MessageImageGrid({required this.attachments});
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 6,
+      runSpacing: 6,
+      alignment: WrapAlignment.end,
+      children: [
+        for (final attachment in attachments)
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: Image.memory(
+              base64Decode(attachment.data),
+              width: 140,
+              height: 100,
+              fit: BoxFit.cover,
+              semanticLabel: attachment.name == null
+                  ? 'Attached image'
+                  : 'Attached image ${attachment.name}',
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+String _userMessageSemanticsLabel(ChatMessage message) {
+  final parts = <String>['You said: ${message.content}'];
+  if (message.hasImageAttachments) {
+    parts.add(
+      message.imageAttachments.length == 1
+          ? '1 image attached'
+          : '${message.imageAttachments.length} images attached',
+    );
+  }
+  if (message.hasFileAttachments) {
+    parts.add(
+      message.fileAttachments.length == 1
+          ? '1 file attached'
+          : '${message.fileAttachments.length} files attached',
+    );
+  }
+  return parts.join('. ');
 }
 
 class _AssistantBubble extends StatefulWidget {

--- a/lib/chat/ui/chat_panel.dart
+++ b/lib/chat/ui/chat_panel.dart
@@ -110,7 +110,7 @@ class _ChatPanelState extends State<ChatPanel> {
         const Expanded(child: _EmptyState()),
         ChatInputBar(
           isProcessing: false,
-          onSend: (text) => _send(context, text),
+          onSend: (text, images, files) => _send(context, text, images, files),
           onCancel: () {},
           onSettings: () => _openSettings(context),
           focusNode: _inputFocusNode,
@@ -214,7 +214,7 @@ class _ChatPanelState extends State<ChatPanel> {
           ),
         ChatInputBar(
           isProcessing: state.isProcessing,
-          onSend: (text) => _send(context, text),
+          onSend: (text, images, files) => _send(context, text, images, files),
           onCancel: () => context.read<ChatCubit>().cancelProcessing(),
           onSettings: () => _openSettings(context),
           focusNode: _inputFocusNode,
@@ -253,9 +253,19 @@ class _ChatPanelState extends State<ChatPanel> {
     );
   }
 
-  void _send(BuildContext context, String text) {
+  void _send(
+    BuildContext context,
+    String text,
+    List<ChatImageAttachment> imageAttachments,
+    List<ChatFileAttachment> fileAttachments,
+  ) {
     final settings = _loadSettings();
-    context.read<ChatCubit>().sendMessage(text, settings);
+    context.read<ChatCubit>().sendMessage(
+      text,
+      settings,
+      imageAttachments: imageAttachments,
+      fileAttachments: fileAttachments,
+    );
   }
 
   void _openSettings(BuildContext context) {

--- a/lib/chat/ui/chat_panel.dart
+++ b/lib/chat/ui/chat_panel.dart
@@ -245,7 +245,12 @@ class _ChatPanelState extends State<ChatPanel> {
           const Spacer(),
           _ContextStatusButton(
             state: readyState,
-            onPressed: () => _openContextDetails(context, readyState),
+            summary: context.read<ChatCubit>().contextSummary,
+            settings: _loadSettings(),
+            onCompact: (settings) {
+              context.read<ChatCubit>().compactContext(settings);
+            },
+            onClearChat: () => _confirmClearChat(context),
           ),
         ],
       ),
@@ -274,69 +279,136 @@ class _ChatPanelState extends State<ChatPanel> {
     );
   }
 
-  void _openContextDetails(BuildContext context, ChatReady state) {
+  Future<void> _confirmClearChat(BuildContext context) async {
     final cubit = context.read<ChatCubit>();
-    final settings = _loadSettings();
-    final summary = cubit.contextSummary;
-    showDialog<void>(
+    final confirmed = await showDialog<bool>(
       context: context,
       builder: (dialogContext) => AlertDialog(
-        title: const Text('Context'),
-        content: SizedBox(
-          width: 320,
-          child: _ContextDetails(state: state, summary: summary),
+        title: const Text('Clear chat?'),
+        content: const Text(
+          'This removes the visible conversation and current model context.',
         ),
         actions: [
           TextButton(
-            onPressed:
-                state.isProcessing || summary.isEmpty || !settings.hasApiKey
-                ? null
-                : () {
-                    Navigator.of(dialogContext).pop();
-                    cubit.compactContext(settings);
-                  },
-            child: const Text('Compact'),
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            style: TextButton.styleFrom(
+              foregroundColor: Theme.of(dialogContext).colorScheme.error,
+            ),
+            child: const Text('Clear chat'),
           ),
-          TextButton(
-            onPressed: state.messages.isEmpty && summary.isEmpty
-                ? null
-                : () {
-                    Navigator.of(dialogContext).pop();
-                    cubit.clearChat();
-                  },
-            child: const Text('Clear'),
+          FilledButton(
+            autofocus: true,
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Cancel'),
           ),
         ],
       ),
     );
+
+    if (confirmed == true && context.mounted) {
+      cubit.clearChat();
+    }
   }
 }
 
+enum _ContextMenuAction { compact, clear }
+
 class _ContextStatusButton extends StatelessWidget {
   final ChatReady state;
-  final VoidCallback onPressed;
+  final ChatContextSummary summary;
+  final ChatSettings settings;
+  final ValueChanged<ChatSettings> onCompact;
+  final VoidCallback onClearChat;
 
-  const _ContextStatusButton({required this.state, required this.onPressed});
+  const _ContextStatusButton({
+    required this.state,
+    required this.summary,
+    required this.settings,
+    required this.onCompact,
+    required this.onClearChat,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final progress = _contextProgress(state);
     final percent = (progress * 100).round();
+    final canCompact =
+        !state.isProcessing && !summary.isEmpty && settings.hasApiKey;
+    final canClear = state.messages.isNotEmpty || !summary.isEmpty;
     return Semantics(
       label: 'Context status, $percent percent used',
       button: true,
-      child: IconButton(
+      child: PopupMenuButton<_ContextMenuAction>(
         tooltip: 'Context status',
-        visualDensity: VisualDensity.compact,
-        onPressed: onPressed,
+        position: PopupMenuPosition.under,
+        onSelected: (action) {
+          switch (action) {
+            case _ContextMenuAction.compact:
+              onCompact(settings);
+            case _ContextMenuAction.clear:
+              onClearChat();
+          }
+        },
+        itemBuilder: (context) => [
+          PopupMenuItem<_ContextMenuAction>(
+            enabled: false,
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+            child: SizedBox(
+              width: 320,
+              child: Theme(
+                data: theme,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text('Context', style: theme.textTheme.titleMedium),
+                    const SizedBox(height: 12),
+                    _ContextDetails(state: state, summary: summary),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          const PopupMenuDivider(),
+          PopupMenuItem<_ContextMenuAction>(
+            enabled: canCompact,
+            value: _ContextMenuAction.compact,
+            child: const Row(
+              children: [
+                Icon(Icons.compress, size: 18),
+                SizedBox(width: 12),
+                Text('Compact context'),
+              ],
+            ),
+          ),
+          PopupMenuItem<_ContextMenuAction>(
+            enabled: canClear,
+            value: _ContextMenuAction.clear,
+            child: Row(
+              children: [
+                Icon(
+                  Icons.delete_outline,
+                  size: 18,
+                  color: canClear ? theme.colorScheme.error : null,
+                ),
+                const SizedBox(width: 12),
+                Text(
+                  'Clear chat...',
+                  style: canClear
+                      ? TextStyle(color: theme.colorScheme.error)
+                      : null,
+                ),
+              ],
+            ),
+          ),
+        ],
         icon: CustomPaint(
           size: const Size.square(22),
           painter: _ContextArcPainter(
             progress: progress,
-            color: _contextColor(Theme.of(context).colorScheme, progress),
-            trackColor: Theme.of(
-              context,
-            ).colorScheme.outlineVariant.withValues(alpha: 0.7),
+            color: _contextColor(theme.colorScheme, progress),
+            trackColor: theme.colorScheme.outlineVariant.withValues(alpha: 0.7),
           ),
         ),
       ),

--- a/lib/chat/ui/chat_panel.dart
+++ b/lib/chat/ui/chat_panel.dart
@@ -182,7 +182,7 @@ class _ChatPanelState extends State<ChatPanel> {
 
     return Column(
       children: [
-        _buildHeader(context),
+        _buildHeader(context, state),
         Expanded(
           child: ExcludeFocus(
             child: messages.isEmpty
@@ -223,8 +223,9 @@ class _ChatPanelState extends State<ChatPanel> {
     );
   }
 
-  Widget _buildHeader(BuildContext context) {
+  Widget _buildHeader(BuildContext context, [ChatReady? state]) {
     final theme = Theme.of(context);
+    final readyState = state ?? const ChatReady();
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       decoration: BoxDecoration(
@@ -242,11 +243,9 @@ class _ChatPanelState extends State<ChatPanel> {
           const SizedBox(width: 8),
           Text('Chat', style: theme.textTheme.titleSmall),
           const Spacer(),
-          IconButton(
-            icon: const Icon(Icons.delete_outline, size: 18),
-            tooltip: 'Clear chat',
-            visualDensity: VisualDensity.compact,
-            onPressed: () => context.read<ChatCubit>().clearChat(),
+          _ContextStatusButton(
+            state: readyState,
+            onPressed: () => _openContextDetails(context, readyState),
           ),
         ],
       ),
@@ -272,6 +271,214 @@ class _ChatPanelState extends State<ChatPanel> {
     showDialog<bool>(
       context: context,
       builder: (_) => const ChatSettingsDialog(),
+    );
+  }
+
+  void _openContextDetails(BuildContext context, ChatReady state) {
+    final cubit = context.read<ChatCubit>();
+    final settings = _loadSettings();
+    final summary = cubit.contextSummary;
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Context'),
+        content: SizedBox(
+          width: 320,
+          child: _ContextDetails(state: state, summary: summary),
+        ),
+        actions: [
+          TextButton(
+            onPressed:
+                state.isProcessing || summary.isEmpty || !settings.hasApiKey
+                ? null
+                : () {
+                    Navigator.of(dialogContext).pop();
+                    cubit.compactContext(settings);
+                  },
+            child: const Text('Compact'),
+          ),
+          TextButton(
+            onPressed: state.messages.isEmpty && summary.isEmpty
+                ? null
+                : () {
+                    Navigator.of(dialogContext).pop();
+                    cubit.clearChat();
+                  },
+            child: const Text('Clear'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ContextStatusButton extends StatelessWidget {
+  final ChatReady state;
+  final VoidCallback onPressed;
+
+  const _ContextStatusButton({required this.state, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = _contextProgress(state);
+    final percent = (progress * 100).round();
+    return Semantics(
+      label: 'Context status, $percent percent used',
+      button: true,
+      child: IconButton(
+        tooltip: 'Context status',
+        visualDensity: VisualDensity.compact,
+        onPressed: onPressed,
+        icon: CustomPaint(
+          size: const Size.square(22),
+          painter: _ContextArcPainter(
+            progress: progress,
+            color: _contextColor(Theme.of(context).colorScheme, progress),
+            trackColor: Theme.of(
+              context,
+            ).colorScheme.outlineVariant.withValues(alpha: 0.7),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ContextArcPainter extends CustomPainter {
+  final double progress;
+  final Color color;
+  final Color trackColor;
+
+  const _ContextArcPainter({
+    required this.progress,
+    required this.color,
+    required this.trackColor,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rect = Offset.zero & size;
+    final strokeWidth = 2.5;
+    final inset = strokeWidth / 2;
+    final arcRect = rect.deflate(inset);
+    final track = Paint()
+      ..color = trackColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+    final foreground = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+
+    canvas.drawArc(arcRect, -1.5708, 6.2832, false, track);
+    canvas.drawArc(
+      arcRect,
+      -1.5708,
+      6.2832 * progress.clamp(0.0, 1.0),
+      false,
+      foreground,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _ContextArcPainter oldDelegate) {
+    return oldDelegate.progress != progress ||
+        oldDelegate.color != color ||
+        oldDelegate.trackColor != trackColor;
+  }
+}
+
+class _ContextDetails extends StatelessWidget {
+  final ChatReady state;
+  final ChatContextSummary summary;
+
+  const _ContextDetails({required this.state, required this.summary});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final progress = _contextProgress(state);
+    final used = _formatNumber(state.contextInputTokens);
+    final window = _formatNumber(state.contextWindowTokens);
+    final hasAttachments =
+        summary.imageAttachments > 0 || summary.fileAttachments > 0;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            CustomPaint(
+              size: const Size.square(32),
+              painter: _ContextArcPainter(
+                progress: progress,
+                color: _contextColor(theme.colorScheme, progress),
+                trackColor: theme.colorScheme.outlineVariant,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Text(
+                '${(progress * 100).round()}% used\n$used / $window input tokens',
+                style: theme.textTheme.bodyMedium,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        Text('Breakdown', style: theme.textTheme.titleSmall),
+        const SizedBox(height: 8),
+        _ContextDetailRow('Messages', summary.messageCount.toString()),
+        _ContextDetailRow(
+          'Turns',
+          '${summary.userMessages} user / ${summary.assistantMessages} assistant',
+        ),
+        _ContextDetailRow(
+          'Tools',
+          '${summary.toolCalls} calls / ${summary.toolResults} results',
+        ),
+        if (hasAttachments)
+          _ContextDetailRow(
+            'Attachments',
+            '${summary.imageAttachments} images / ${summary.fileAttachments} files',
+          ),
+        _ContextDetailRow(
+          'Text',
+          '~${_formatNumber(summary.approxCharacters)} chars',
+        ),
+      ],
+    );
+  }
+}
+
+class _ContextDetailRow extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _ContextDetailRow(this.label, this.value);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 96,
+            child: Text(
+              label,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          Expanded(child: Text(value, style: theme.textTheme.bodySmall)),
+        ],
+      ),
     );
   }
 }
@@ -342,11 +549,24 @@ class _TokenUsageBar extends StatelessWidget {
       ),
     );
   }
+}
 
-  String _formatNumber(int n) {
-    if (n >= 1000) return '${(n / 1000).toStringAsFixed(1)}k';
-    return n.toString();
-  }
+double _contextProgress(ChatReady state) {
+  if (state.contextWindowTokens <= 0) return 0;
+  return (state.contextInputTokens / state.contextWindowTokens).clamp(0.0, 1.0);
+}
+
+Color _contextColor(ColorScheme colors, double progress) {
+  const compactionThreshold = 0.85;
+  final thresholdProgress = progress / compactionThreshold;
+  if (thresholdProgress >= 0.9) return colors.error;
+  if (thresholdProgress >= 0.7) return Colors.orange.shade700;
+  return Colors.green.shade700;
+}
+
+String _formatNumber(int n) {
+  if (n >= 1000) return '${(n / 1000).toStringAsFixed(1)}k';
+  return n.toString();
 }
 
 // Display item types for grouping tool messages

--- a/lib/chat/ui/chat_settings_dialog.dart
+++ b/lib/chat/ui/chat_settings_dialog.dart
@@ -535,7 +535,7 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
   ];
 
   List<Widget> _buildLocalContextSettings(ThemeData theme) => [
-    const SizedBox(height: 20),
+    const SizedBox(height: 24),
     Semantics(
       header: true,
       child: Text('Allowed File Roots', style: theme.textTheme.titleSmall),
@@ -550,7 +550,7 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
       ),
     for (var i = 0; i < _allowedRoots.length; i++) ...[
       _buildAllowedRootEditor(theme, i),
-      const SizedBox(height: 12),
+      const SizedBox(height: 16),
     ],
     OutlinedButton.icon(
       onPressed: _addAllowedRoot,
@@ -569,7 +569,7 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
   Widget _buildAllowedRootEditor(ThemeData theme, int index) {
     final root = _allowedRoots[index];
     return Container(
-      padding: const EdgeInsets.all(12),
+      padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         border: Border.all(color: theme.colorScheme.outlineVariant),
         borderRadius: BorderRadius.circular(8),
@@ -629,27 +629,50 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
               ),
             ],
           ),
-          const SizedBox(height: 8),
-          _buildPermissionRow(theme, index, FileRootActor.chat, 'Chat'),
-          _buildPermissionRow(theme, index, FileRootActor.mcp, 'MCP'),
+          const SizedBox(height: 16),
+          _buildPermissionTable(theme, index),
         ],
       ),
     );
   }
 
-  Widget _buildPermissionRow(
+  Widget _buildPermissionTable(ThemeData theme, int index) {
+    final headerStyle = theme.textTheme.labelSmall?.copyWith(
+      color: theme.colorScheme.onSurfaceVariant,
+    );
+    return Table(
+      columnWidths: const {
+        0: FixedColumnWidth(64),
+        1: FixedColumnWidth(72),
+        2: FixedColumnWidth(72),
+        3: FixedColumnWidth(80),
+      },
+      defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+      children: [
+        TableRow(
+          children: [
+            const SizedBox.shrink(),
+            _permissionHeader('Read', headerStyle),
+            _permissionHeader('Write', headerStyle),
+            _permissionHeader('Search', headerStyle),
+          ],
+        ),
+        _permissionTableRow(theme, index, FileRootActor.chat, 'Chat'),
+        _permissionTableRow(theme, index, FileRootActor.mcp, 'MCP'),
+      ],
+    );
+  }
+
+  TableRow _permissionTableRow(
     ThemeData theme,
     int index,
     FileRootActor actor,
     String label,
   ) {
-    return Wrap(
-      spacing: 4,
-      runSpacing: 0,
-      crossAxisAlignment: WrapCrossAlignment.center,
+    return TableRow(
       children: [
-        SizedBox(
-          width: 44,
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
           child: Text(label, style: theme.textTheme.bodySmall),
         ),
         _buildPermissionCheckbox(index, actor, FileRootPermission.read, 'Read'),
@@ -669,6 +692,13 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
     );
   }
 
+  Widget _permissionHeader(String label, TextStyle? style) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Center(child: Text(label, style: style)),
+    );
+  }
+
   Widget _buildPermissionCheckbox(
     int index,
     FileRootActor actor,
@@ -679,11 +709,14 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
     return Semantics(
       label: '${actor.storageKey} ${permission.storageKey} permission',
       checked: checked,
-      child: FilterChip(
-        label: Text(label),
-        selected: checked,
-        onSelected: (value) => _setPermission(index, actor, permission, value),
-        visualDensity: VisualDensity.compact,
+      button: true,
+      child: Center(
+        child: Checkbox(
+          value: checked,
+          onChanged: (value) =>
+              _setPermission(index, actor, permission, value ?? false),
+          semanticLabel: '$label permission for ${actor.storageKey}',
+        ),
       ),
     );
   }

--- a/lib/chat/ui/chat_settings_dialog.dart
+++ b/lib/chat/ui/chat_settings_dialog.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:nt_helper/chat/models/allowed_file_root.dart';
 import 'package:nt_helper/chat/models/chat_settings.dart';
 import 'package:nt_helper/chat/services/codex_auth_service.dart';
 import 'package:nt_helper/services/settings_service.dart';
 import 'package:nt_helper/ui/widgets/digit_shortcut_blocker.dart';
+import 'package:path/path.dart' as path;
+import 'package:uuid/uuid.dart';
 
 class ChatSettingsDialog extends StatefulWidget {
   const ChatSettingsDialog({super.key});
@@ -23,10 +27,12 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
 
   final _settings = SettingsService();
   final _codexAuthService = CodexAuthService();
+  final _uuid = const Uuid();
   late LlmProviderType _provider;
   late bool _useAnthropicSubscription;
   late bool _useOpenaiSubscription;
   late bool _allowCodexAuthRefresh;
+  late List<AllowedFileRoot> _allowedRoots;
   late final TextEditingController _anthropicKeyController;
   late final TextEditingController _openaiKeyController;
   late final TextEditingController _anthropicModelController;
@@ -78,6 +84,7 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
     _openaiBaseUrlController = TextEditingController(
       text: _settings.openaiBaseUrl,
     );
+    _allowedRoots = _settings.allowedFileRoots.toList();
     _showAdvanced =
         _settings.openaiBaseUrl != null && _settings.openaiBaseUrl!.isNotEmpty;
     if (_isOpenaiSubscription) {
@@ -125,7 +132,71 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
           ? _openaiBaseUrlController.text.trim()
           : '',
     );
+    await _settings.setAllowedFileRoots(_allowedRoots);
     if (mounted) Navigator.of(context).pop(true);
+  }
+
+  Future<void> _addAllowedRoot() async {
+    final selected = await FilePicker.getDirectoryPath(
+      dialogTitle: 'Choose Allowed Root',
+    );
+    if (selected == null || !mounted) return;
+    final baseName = path.basename(selected);
+    setState(() {
+      _allowedRoots = [
+        ..._allowedRoots,
+        AllowedFileRoot.chatReadSearch(
+          id: _uuid.v4(),
+          label: baseName.isEmpty ? 'Allowed Root' : baseName,
+          path: selected,
+        ),
+      ];
+    });
+  }
+
+  Future<void> _chooseAllowedRootDirectory(int index) async {
+    final current = _allowedRoots[index];
+    final selected = await FilePicker.getDirectoryPath(
+      dialogTitle: 'Choose Allowed Root',
+      initialDirectory: current.path.trim().isEmpty ? null : current.path,
+    );
+    if (selected == null || !mounted) return;
+    setState(() {
+      _allowedRoots[index] = current.copyWith(path: selected);
+    });
+  }
+
+  void _updateRoot(int index, AllowedFileRoot root) {
+    setState(() => _allowedRoots[index] = root);
+  }
+
+  void _removeRoot(int index) {
+    setState(() {
+      _allowedRoots = [
+        ..._allowedRoots.take(index),
+        ..._allowedRoots.skip(index + 1),
+      ];
+    });
+  }
+
+  void _setPermission(
+    int index,
+    FileRootActor actor,
+    FileRootPermission permission,
+    bool enabled,
+  ) {
+    final root = _allowedRoots[index];
+    final permissions = {...root.permissionsFor(actor)};
+    if (enabled) {
+      permissions.add(permission);
+    } else {
+      permissions.remove(permission);
+    }
+    final acl = {
+      for (final entry in root.acl.entries) entry.key: {...entry.value},
+      actor: permissions,
+    };
+    _updateRoot(index, root.copyWith(acl: acl));
   }
 
   Future<void> _validateCodexAuth() async {
@@ -190,7 +261,7 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
       title: Semantics(header: true, child: const Text('Chat Settings')),
       content: SizedBox(
         width: 400,
-        height: 460,
+        height: 520,
         child: SingleChildScrollView(
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -214,6 +285,7 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
               ),
               if (_isOpenAI) ..._buildOpenAISettings(theme),
               if (!_isOpenAI) ..._buildAnthropicSettings(theme),
+              ..._buildLocalContextSettings(theme),
               const SizedBox(height: 16),
               Text(
                 _isOpenaiSubscription
@@ -461,4 +533,158 @@ class _ChatSettingsDialogState extends State<ChatSettingsDialog> {
       ),
     ],
   ];
+
+  List<Widget> _buildLocalContextSettings(ThemeData theme) => [
+    const SizedBox(height: 20),
+    Semantics(
+      header: true,
+      child: Text('Allowed File Roots', style: theme.textTheme.titleSmall),
+    ),
+    const SizedBox(height: 8),
+    if (_allowedRoots.isEmpty)
+      Text(
+        'No folders are available to chat or MCP file tools.',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    for (var i = 0; i < _allowedRoots.length; i++) ...[
+      _buildAllowedRootEditor(theme, i),
+      const SizedBox(height: 12),
+    ],
+    OutlinedButton.icon(
+      onPressed: _addAllowedRoot,
+      icon: const Icon(Icons.create_new_folder_outlined),
+      label: const Text('Add Folder'),
+    ),
+    const SizedBox(height: 4),
+    Text(
+      'Each folder grants separate read, write, and search permissions for chat and external MCP.',
+      style: theme.textTheme.bodySmall?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
+    ),
+  ];
+
+  Widget _buildAllowedRootEditor(ThemeData theme, int index) {
+    final root = _allowedRoots[index];
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: DigitShortcutBlocker(
+                  child: TextFormField(
+                    key: ValueKey('file_root_label_${root.id}'),
+                    initialValue: root.label,
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      labelText: 'Label',
+                      isDense: true,
+                    ),
+                    onChanged: (value) =>
+                        _updateRoot(index, root.copyWith(label: value.trim())),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              IconButton(
+                tooltip: 'Remove allowed root',
+                icon: const Icon(Icons.delete_outline),
+                onPressed: () => _removeRoot(index),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: DigitShortcutBlocker(
+                  child: TextFormField(
+                    key: ValueKey('file_root_path_${root.id}'),
+                    initialValue: root.path,
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      labelText: 'Path',
+                      isDense: true,
+                    ),
+                    onChanged: (value) =>
+                        _updateRoot(index, root.copyWith(path: value.trim())),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              IconButton(
+                tooltip: 'Choose folder',
+                icon: const Icon(Icons.folder_open),
+                onPressed: () => _chooseAllowedRootDirectory(index),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          _buildPermissionRow(theme, index, FileRootActor.chat, 'Chat'),
+          _buildPermissionRow(theme, index, FileRootActor.mcp, 'MCP'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPermissionRow(
+    ThemeData theme,
+    int index,
+    FileRootActor actor,
+    String label,
+  ) {
+    return Wrap(
+      spacing: 4,
+      runSpacing: 0,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        SizedBox(
+          width: 44,
+          child: Text(label, style: theme.textTheme.bodySmall),
+        ),
+        _buildPermissionCheckbox(index, actor, FileRootPermission.read, 'Read'),
+        _buildPermissionCheckbox(
+          index,
+          actor,
+          FileRootPermission.write,
+          'Write',
+        ),
+        _buildPermissionCheckbox(
+          index,
+          actor,
+          FileRootPermission.search,
+          'Search',
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPermissionCheckbox(
+    int index,
+    FileRootActor actor,
+    FileRootPermission permission,
+    String label,
+  ) {
+    final checked = _allowedRoots[index].allows(actor, permission);
+    return Semantics(
+      label: '${actor.storageKey} ${permission.storageKey} permission',
+      checked: checked,
+      child: FilterChip(
+        label: Text(label),
+        selected: checked,
+        onSelected: (value) => _setPermission(index, actor, permission, value),
+        visualDensity: VisualDensity.compact,
+      ),
+    );
+  }
 }

--- a/lib/mcp/tool_reference_store.dart
+++ b/lib/mcp/tool_reference_store.dart
@@ -1,0 +1,200 @@
+import 'dart:convert';
+
+class ToolReferenceStore {
+  static const referenceThresholdChars = 20000;
+  static const defaultReadLimitChars = 8000;
+  static const maxReadLimitChars = 16000;
+  static const defaultSearchLimit = 20;
+  static const maxSearchLimit = 50;
+  static const defaultSearchContextChars = 120;
+  static const maxSearchContextChars = 500;
+  static const maxReferences = 32;
+
+  static const readToolName = 'read_reference';
+  static const searchToolName = 'search_reference';
+
+  final _references = <String, _ToolReference>{};
+  int _counter = 0;
+
+  bool get isEmpty => _references.isEmpty;
+
+  void clear() {
+    _references.clear();
+  }
+
+  bool shouldReference(String toolName, String result) {
+    if (toolName == readToolName || toolName == searchToolName) return false;
+    return result.length > referenceThresholdChars;
+  }
+
+  String storeIfLarge({required String toolName, required String result}) {
+    if (!shouldReference(toolName, result)) return result;
+    final reference = _store(toolName: toolName, content: result);
+    return jsonEncode({
+      'success': true,
+      'type': 'tool_reference',
+      'reference_id': reference.id,
+      'tool_name': reference.toolName,
+      'total_chars': reference.content.length,
+      'instructions':
+          'This tool result was stored as a reference because it is large. '
+          'Use read_reference with reference_id to page through it, or '
+          'search_reference with reference_id and query to find relevant parts.',
+    });
+  }
+
+  Future<String> readReference(Map<String, dynamic> args) async {
+    final reference = _lookup(args['reference_id']);
+    if (reference == null) {
+      return _error('reference_not_found');
+    }
+
+    final offset = _intArg(args['offset'], fallback: 0, min: 0);
+    final limit = _intArg(
+      args['limit'],
+      fallback: defaultReadLimitChars,
+      min: 1,
+      max: maxReadLimitChars,
+    );
+    if (offset >= reference.content.length) {
+      return jsonEncode({
+        'success': true,
+        'reference_id': reference.id,
+        'tool_name': reference.toolName,
+        'offset': offset,
+        'limit': limit,
+        'content': '',
+        'total_chars': reference.content.length,
+        'has_more': false,
+        'next_offset': null,
+      });
+    }
+
+    final end = (offset + limit).clamp(0, reference.content.length);
+    return jsonEncode({
+      'success': true,
+      'reference_id': reference.id,
+      'tool_name': reference.toolName,
+      'offset': offset,
+      'limit': limit,
+      'content': reference.content.substring(offset, end),
+      'total_chars': reference.content.length,
+      'has_more': end < reference.content.length,
+      'next_offset': end < reference.content.length ? end : null,
+    });
+  }
+
+  Future<String> searchReference(Map<String, dynamic> args) async {
+    final reference = _lookup(args['reference_id']);
+    if (reference == null) {
+      return _error('reference_not_found');
+    }
+
+    final query = args['query'];
+    if (query is! String || query.trim().isEmpty) {
+      return _error('missing_query');
+    }
+
+    final startOffset = _intArg(args['start_offset'], fallback: 0, min: 0);
+    final limit = _intArg(
+      args['limit'],
+      fallback: defaultSearchLimit,
+      min: 1,
+      max: maxSearchLimit,
+    );
+    final contextChars = _intArg(
+      args['context_chars'],
+      fallback: defaultSearchContextChars,
+      min: 0,
+      max: maxSearchContextChars,
+    );
+
+    final content = reference.content;
+    final lowerContent = content.toLowerCase();
+    final lowerQuery = query.toLowerCase();
+    final matches = <Map<String, dynamic>>[];
+    var searchFrom = startOffset.clamp(0, content.length);
+
+    while (matches.length < limit && searchFrom < content.length) {
+      final matchOffset = lowerContent.indexOf(lowerQuery, searchFrom);
+      if (matchOffset < 0) break;
+      final previewStart = (matchOffset - contextChars).clamp(
+        0,
+        content.length,
+      );
+      final previewEnd = (matchOffset + query.length + contextChars).clamp(
+        0,
+        content.length,
+      );
+      matches.add({
+        'offset': matchOffset,
+        'preview': content.substring(previewStart, previewEnd),
+      });
+      searchFrom = matchOffset + query.length;
+    }
+
+    return jsonEncode({
+      'success': true,
+      'reference_id': reference.id,
+      'tool_name': reference.toolName,
+      'query': query,
+      'matches': matches,
+      'truncated': matches.length >= limit,
+      'next_start_offset': matches.length >= limit ? searchFrom : null,
+      'total_chars': content.length,
+    });
+  }
+
+  _ToolReference _store({required String toolName, required String content}) {
+    if (_references.length >= maxReferences) {
+      _references.remove(_references.keys.first);
+    }
+    final id = 'ref_${DateTime.now().millisecondsSinceEpoch}_${_counter++}';
+    final reference = _ToolReference(
+      id: id,
+      toolName: toolName,
+      content: content,
+    );
+    _references[id] = reference;
+    return reference;
+  }
+
+  _ToolReference? _lookup(Object? rawId) {
+    if (rawId is! String || rawId.isEmpty) return null;
+    return _references[rawId];
+  }
+
+  static int _intArg(
+    Object? value, {
+    required int fallback,
+    int? min,
+    int? max,
+  }) {
+    final parsed = switch (value) {
+      int v => v,
+      num v => v.toInt(),
+      String v => int.tryParse(v),
+      _ => null,
+    };
+    var result = parsed ?? fallback;
+    if (min != null && result < min) result = min;
+    if (max != null && result > max) result = max;
+    return result;
+  }
+
+  static String _error(String error) {
+    return jsonEncode({'success': false, 'error': error});
+  }
+}
+
+class _ToolReference {
+  const _ToolReference({
+    required this.id,
+    required this.toolName,
+    required this.content,
+  });
+
+  final String id;
+  final String toolName;
+  final String content;
+}

--- a/lib/mcp/tool_registry.dart
+++ b/lib/mcp/tool_registry.dart
@@ -7,6 +7,7 @@ import 'package:nt_helper/chat/services/memory_service.dart';
 import 'package:nt_helper/chat/services/memory_tools.dart';
 import 'package:nt_helper/chat/utils/image_result_detector.dart';
 import 'package:nt_helper/cubit/disting_cubit.dart';
+import 'package:nt_helper/mcp/tool_reference_store.dart';
 import 'package:nt_helper/mcp/tools/algorithm_tools.dart';
 import 'package:nt_helper/mcp/tools/disting_tools.dart';
 import 'package:nt_helper/services/disting_controller.dart';
@@ -44,15 +45,22 @@ class ToolRegistry {
   };
 
   final List<ToolRegistryEntry> _entries = [];
+  final ToolReferenceStore _referenceStore;
   late final DistingController _controller;
   late final MCPAlgorithmTools _algoTools;
   late final DistingTools _distingTools;
 
-  ToolRegistry(DistingCubit distingCubit, {MemoryService? memoryService}) {
+  ToolRegistry(
+    DistingCubit distingCubit, {
+    MemoryService? memoryService,
+    List<ToolRegistryEntry> extraEntries = const [],
+    ToolReferenceStore? referenceStore,
+  }) : _referenceStore = referenceStore ?? ToolReferenceStore() {
     _controller = DistingControllerImpl(distingCubit);
     _algoTools = MCPAlgorithmTools(_controller, distingCubit);
     _distingTools = DistingTools(_controller, distingCubit);
     _registerAll();
+    _entries.addAll(extraEntries);
     if (memoryService != null) {
       registerMemoryTools(_entries, memoryService);
       registerLocalFileTools(_entries, actor: FileRootActor.chat);
@@ -66,6 +74,44 @@ class ToolRegistry {
       if (entry.name == name) return entry;
     }
     return null;
+  }
+
+  Future<String> executeTool(
+    String name,
+    Map<String, dynamic> arguments,
+  ) async {
+    final entry = findByName(name);
+    if (entry == null) {
+      return jsonEncode({'success': false, 'error': 'Unknown tool: $name'});
+    }
+    return _executeEntry(entry, arguments);
+  }
+
+  Future<String> _executeEntry(
+    ToolRegistryEntry entry,
+    Map<String, dynamic> arguments,
+  ) async {
+    try {
+      final resultJson = await entry
+          .handler(arguments)
+          .timeout(
+            entry.timeout,
+            onTimeout: () => jsonEncode({
+              'success': false,
+              'error':
+                  'Tool execution timed out after ${entry.timeout.inSeconds} seconds',
+            }),
+          );
+      return _referenceStore.storeIfLarge(
+        toolName: entry.name,
+        result: resultJson,
+      );
+    } catch (e) {
+      return jsonEncode({
+        'success': false,
+        'error': 'Tool execution failed: ${e.toString()}',
+      });
+    }
   }
 
   /// Apply all registered tools to an MCP server instance.
@@ -96,34 +142,14 @@ class ToolRegistry {
         }),
       ),
       callback: (args, extra) async {
-        try {
-          final resultJson = await entry
-              .handler(args)
-              .timeout(
-                entry.timeout,
-                onTimeout: () => jsonEncode({
-                  'success': false,
-                  'error':
-                      'Tool execution timed out after ${entry.timeout.inSeconds} seconds',
-                }),
-              );
-          final image = tryParseImageResult(resultJson);
-          if (image != null) {
-            return CallToolResult.fromContent([
-              ImageContent(data: image.data, mimeType: image.mimeType),
-            ]);
-          }
-          return CallToolResult.fromContent([TextContent(text: resultJson)]);
-        } catch (e) {
+        final resultJson = await _executeEntry(entry, args);
+        final image = tryParseImageResult(resultJson);
+        if (image != null) {
           return CallToolResult.fromContent([
-            TextContent(
-              text: jsonEncode({
-                'success': false,
-                'error': 'Tool execution failed: ${e.toString()}',
-              }),
-            ),
+            ImageContent(data: image.data, mimeType: image.mimeType),
           ]);
         }
+        return CallToolResult.fromContent([TextContent(text: resultJson)]);
       },
     );
   }
@@ -144,10 +170,87 @@ class ToolRegistry {
   }
 
   void _registerAll() {
+    _registerReferenceTools();
     _registerSearchTools();
     _registerShowTools();
     _registerEditTools();
     _registerPresetTools();
+  }
+
+  void _registerReferenceTools() {
+    _entries.add(
+      ToolRegistryEntry(
+        name: ToolReferenceStore.readToolName,
+        description:
+            'Read a page from a large tool result reference returned by any tool.',
+        inputSchema: {
+          'properties': {
+            'reference_id': {
+              'type': 'string',
+              'description': 'Reference ID returned by a previous tool result.',
+            },
+            'offset': {
+              'type': 'integer',
+              'minimum': 0,
+              'description':
+                  'Character offset to start reading from. Default: 0.',
+            },
+            'limit': {
+              'type': 'integer',
+              'minimum': 1,
+              'maximum': ToolReferenceStore.maxReadLimitChars,
+              'description':
+                  'Maximum characters to return. Default: 8000, max: 16000.',
+            },
+          },
+          'required': ['reference_id'],
+        },
+        handler: _referenceStore.readReference,
+        timeout: const Duration(seconds: 5),
+      ),
+    );
+
+    _entries.add(
+      ToolRegistryEntry(
+        name: ToolReferenceStore.searchToolName,
+        description:
+            'Search within a large tool result reference returned by any tool.',
+        inputSchema: {
+          'properties': {
+            'reference_id': {
+              'type': 'string',
+              'description': 'Reference ID returned by a previous tool result.',
+            },
+            'query': {
+              'type': 'string',
+              'description': 'Case-insensitive text to search for.',
+            },
+            'start_offset': {
+              'type': 'integer',
+              'minimum': 0,
+              'description':
+                  'Character offset to begin searching from. Default: 0.',
+            },
+            'limit': {
+              'type': 'integer',
+              'minimum': 1,
+              'maximum': ToolReferenceStore.maxSearchLimit,
+              'description': 'Maximum matches to return. Default: 20, max: 50.',
+            },
+            'context_chars': {
+              'type': 'integer',
+              'minimum': 0,
+              'maximum': ToolReferenceStore.maxSearchContextChars,
+              'description':
+                  'Context characters around each match. Default: 120, max: 500.',
+            },
+          },
+          'required': ['reference_id', 'query'],
+        },
+        handler: _referenceStore.searchReference,
+        timeout: const Duration(seconds: 5),
+      ),
+    );
   }
 
   void _registerSearchTools() {
@@ -250,9 +353,9 @@ class ToolRegistry {
       ToolRegistryEntry(
         name: 'show_slot',
         description:
-            'Show a slot with its algorithm info and a page of parameter summaries (name, current value, range). '
+            'Show a slot with its algorithm info and parameter summaries (name, current value, range). '
             'Does NOT include enum value lists or full mapping details — use show_parameter for those. '
-            'Parameters with mappings show has_mapping: true. Supports pagination via offset/limit.',
+            'Parameters with mappings show has_mapping: true. Large results are returned as references that can be read or searched.',
         inputSchema: {
           'properties': {
             'slot_index': {
@@ -261,26 +364,10 @@ class ToolRegistry {
               'maximum': 31,
               'description': 'Slot index (0-31).',
             },
-            'offset': {
-              'type': 'integer',
-              'minimum': 0,
-              'description': 'Parameter offset for pagination (default: 0).',
-            },
-            'limit': {
-              'type': 'integer',
-              'minimum': 1,
-              'maximum': 100,
-              'description':
-                  'Max parameters to return (default: 10, max: 100).',
-            },
           },
           'required': ['slot_index'],
         },
-        handler: (args) => _algoTools.showSlot(
-          args['slot_index'],
-          offset: (args['offset'] as int?) ?? 0,
-          limit: (args['limit'] as int?) ?? 10,
-        ),
+        handler: (args) => _algoTools.showSlot(args['slot_index']),
       ),
     );
 

--- a/lib/mcp/tool_registry.dart
+++ b/lib/mcp/tool_registry.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 
 import 'package:mcp_dart/mcp_dart.dart';
+import 'package:nt_helper/chat/models/allowed_file_root.dart';
+import 'package:nt_helper/chat/services/local_file_tools.dart';
 import 'package:nt_helper/chat/services/memory_service.dart';
 import 'package:nt_helper/chat/services/memory_tools.dart';
 import 'package:nt_helper/chat/utils/image_result_detector.dart';
@@ -36,6 +38,10 @@ class ToolRegistry {
     'memory_append_daily',
     'memory_read_daily',
   };
+  static const _chatOnlyToolNames = {
+    ..._memoryToolNames,
+    ...localFileToolNames,
+  };
 
   final List<ToolRegistryEntry> _entries = [];
   late final DistingController _controller;
@@ -49,6 +55,7 @@ class ToolRegistry {
     _registerAll();
     if (memoryService != null) {
       registerMemoryTools(_entries, memoryService);
+      registerLocalFileTools(_entries, actor: FileRootActor.chat);
     }
   }
 
@@ -65,50 +72,60 @@ class ToolRegistry {
   /// Memory tools are excluded — they are for the in-app chat only.
   void applyToMcpServer(McpServer server) {
     for (final entry in _entries) {
-      if (_memoryToolNames.contains(entry.name)) continue;
-      server.registerTool(
-        entry.name,
-        description: entry.description,
-        inputSchema: ToolInputSchema.fromJson(
-          _deepCastMap({
-            'type': 'object',
-            'properties': entry.inputSchema['properties'] ?? {},
-            if (entry.inputSchema['required'] != null)
-              'required': entry.inputSchema['required'],
-          }),
-        ),
-        callback: (args, extra) async {
-          try {
-            final resultJson = await entry
-                .handler(args)
-                .timeout(
-                  entry.timeout,
-                  onTimeout: () => jsonEncode({
-                    'success': false,
-                    'error':
-                        'Tool execution timed out after ${entry.timeout.inSeconds} seconds',
-                  }),
-                );
-            final image = tryParseImageResult(resultJson);
-            if (image != null) {
-              return CallToolResult.fromContent([
-                ImageContent(data: image.data, mimeType: image.mimeType),
-              ]);
-            }
-            return CallToolResult.fromContent([TextContent(text: resultJson)]);
-          } catch (e) {
-            return CallToolResult.fromContent([
-              TextContent(
-                text: jsonEncode({
+      if (_chatOnlyToolNames.contains(entry.name)) continue;
+      _registerMcpEntry(server, entry);
+    }
+
+    final mcpFileEntries = <ToolRegistryEntry>[];
+    registerLocalFileTools(mcpFileEntries, actor: FileRootActor.mcp);
+    for (final entry in mcpFileEntries) {
+      _registerMcpEntry(server, entry);
+    }
+  }
+
+  void _registerMcpEntry(McpServer server, ToolRegistryEntry entry) {
+    server.registerTool(
+      entry.name,
+      description: entry.description,
+      inputSchema: ToolInputSchema.fromJson(
+        _deepCastMap({
+          'type': 'object',
+          'properties': entry.inputSchema['properties'] ?? {},
+          if (entry.inputSchema['required'] != null)
+            'required': entry.inputSchema['required'],
+        }),
+      ),
+      callback: (args, extra) async {
+        try {
+          final resultJson = await entry
+              .handler(args)
+              .timeout(
+                entry.timeout,
+                onTimeout: () => jsonEncode({
                   'success': false,
-                  'error': 'Tool execution failed: ${e.toString()}',
+                  'error':
+                      'Tool execution timed out after ${entry.timeout.inSeconds} seconds',
                 }),
-              ),
+              );
+          final image = tryParseImageResult(resultJson);
+          if (image != null) {
+            return CallToolResult.fromContent([
+              ImageContent(data: image.data, mimeType: image.mimeType),
             ]);
           }
-        },
-      );
-    }
+          return CallToolResult.fromContent([TextContent(text: resultJson)]);
+        } catch (e) {
+          return CallToolResult.fromContent([
+            TextContent(
+              text: jsonEncode({
+                'success': false,
+                'error': 'Tool execution failed: ${e.toString()}',
+              }),
+            ),
+          ]);
+        }
+      },
+    );
   }
 
   /// Recursively cast Map literals to `Map<String, dynamic>` for mcp_dart.

--- a/lib/mcp/tool_registry.dart
+++ b/lib/mcp/tool_registry.dart
@@ -173,6 +173,33 @@ class ToolRegistry {
 
     _entries.add(
       ToolRegistryEntry(
+        name: 'algorithm_info',
+        description:
+            'Show documentation-style metadata for an algorithm, matching the parameter editor Help screen: description, categories, ports, specifications, parameters, and features. Requires either guid or name.',
+        inputSchema: {
+          'properties': {
+            'guid': {
+              'type': 'string',
+              'description': 'Algorithm GUID, for example "clck".',
+            },
+            'name': {
+              'type': 'string',
+              'description': 'Algorithm name. Used if guid is omitted.',
+            },
+            'expand_features': {
+              'type': 'boolean',
+              'description':
+                  'If true, expand feature-provided parameters into the parameter list. Default: false.',
+            },
+          },
+        },
+        handler: (args) => _algoTools.algorithmInfo(args),
+        timeout: const Duration(seconds: 5),
+      ),
+    );
+
+    _entries.add(
+      ToolRegistryEntry(
         name: 'search_parameters',
         description:
             'Search for parameters by name within the current preset or a specific slot. Uses exact or partial name matching.',

--- a/lib/mcp/tools/algorithm_tools.dart
+++ b/lib/mcp/tools/algorithm_tools.dart
@@ -634,12 +634,12 @@ class MCPAlgorithmTools {
     );
   }
 
-  /// Show a slot with paginated parameter summaries.
+  /// Show a slot with parameter summaries.
   /// Use show_parameter for full detail (enum value lists, mapping details).
   Future<String> showSlot(
     dynamic identifier, {
     int offset = 0,
-    int limit = 10,
+    int? limit,
   }) async {
     if (identifier == null) {
       return jsonEncode(
@@ -692,7 +692,7 @@ class MCPAlgorithmTools {
           'algorithm': {'guid': '', 'name': ''},
           'parameter_count': 0,
           'offset': 0,
-          'limit': limit,
+          'limit': 0,
           'has_more': false,
           'parameters': <dynamic>[],
         }),
@@ -709,7 +709,8 @@ class MCPAlgorithmTools {
 
     final totalCount = parameters.length;
     final clampedOffset = offset.clamp(0, totalCount);
-    final endIndex = (clampedOffset + limit).clamp(0, totalCount);
+    final effectiveLimit = limit ?? (totalCount - clampedOffset);
+    final endIndex = (clampedOffset + effectiveLimit).clamp(0, totalCount);
     final hasMore = endIndex < totalCount;
 
     final parametersJson = <Map<String, dynamic>>[];
@@ -730,7 +731,7 @@ class MCPAlgorithmTools {
         'algorithm': {'guid': algorithm.guid, 'name': algorithm.name},
         'parameter_count': totalCount,
         'offset': clampedOffset,
-        'limit': limit,
+        'limit': effectiveLimit,
         'has_more': hasMore,
         'parameters': parametersJson,
       }),

--- a/lib/mcp/tools/algorithm_tools.dart
+++ b/lib/mcp/tools/algorithm_tools.dart
@@ -137,6 +137,20 @@ class MCPAlgorithmTools {
     }
   }
 
+  /// MCP Tool: Retrieves documentation-style metadata for a specific algorithm.
+  ///
+  /// This is the public, compact tool shape for the same data used by
+  /// [getAlgorithmDetails]. It accepts short parameter names that fit the
+  /// simplified MCP/chat tool set, then delegates to the existing metadata
+  /// implementation used by the algorithm documentation UI.
+  Future<String> algorithmInfo(Map<String, dynamic> params) {
+    return getAlgorithmDetails({
+      'algorithm_guid': params['guid'] ?? params['algorithm_guid'],
+      'algorithm_name': params['name'] ?? params['algorithm_name'],
+      'expand_features': params['expand_features'] ?? false,
+    });
+  }
+
   /// MCP Tool: Lists algorithms, optionally filtered by category or a text query.
   /// Parameters:
   ///   - category (string, optional): Filter by category.
@@ -349,7 +363,7 @@ class MCPAlgorithmTools {
           'message':
               'No algorithms found matching "$query". Try searching by algorithm name or category.',
           'suggestions':
-              'Use `list_algorithms` to browse by category or `get_algorithm_details` for specific algorithms.',
+              'Use `search_algorithms` with a broader query or `algorithm_info` for specific algorithms.',
         }),
       );
     }

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -1,5 +1,9 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:nt_helper/chat/models/allowed_file_root.dart';
 import 'package:nt_helper/chat/models/chat_settings.dart';
 import 'package:nt_helper/domain/disting_nt_sysex.dart';
 import 'package:nt_helper/domain/i_disting_midi_manager.dart';
@@ -7,7 +11,6 @@ import 'package:nt_helper/services/database_integrity_service.dart';
 import 'package:nt_helper/ui/widgets/digit_shortcut_blocker.dart';
 import 'package:nt_helper/ui/widgets/rtt_stats_dialog.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'dart:io';
 
 /// Application theme with Material 3 enabled
 ThemeData appTheme() {
@@ -67,6 +70,8 @@ class SettingsService {
   static const String _openaiSubscriptionModelKey = 'openai_subscription_model';
   static const String _openaiBaseUrlKey = 'openai_base_url';
   static const String _allowCodexAuthRefreshKey = 'allow_codex_auth_refresh';
+  static const String _chatLocalDirectoryKey = 'chat_local_directory';
+  static const String _allowedFileRootsKey = 'allowed_file_roots';
   static const String _uiScaleKey = 'ui_scale';
   static const String _autoCenterOnSelectionKey = 'auto_center_on_selection';
   static const String _showBackwardConnectionsKey = 'show_backward_connections';
@@ -107,6 +112,8 @@ class SettingsService {
     _openaiSubscriptionModelKey,
     _openaiBaseUrlKey,
     _allowCodexAuthRefreshKey,
+    _chatLocalDirectoryKey,
+    _allowedFileRootsKey,
     _uiScaleKey,
     _autoCenterOnSelectionKey,
     _showBackwardConnectionsKey,
@@ -207,6 +214,23 @@ class SettingsService {
   double _clampUiScale(double value) {
     final clamped = value.clamp(minUiScale, maxUiScale);
     return (clamped * 10).roundToDouble() / 10;
+  }
+
+  Map<String, dynamic> _deepStringMap(Map value) {
+    return value.map((key, entryValue) {
+      if (entryValue is Map) {
+        return MapEntry(key.toString(), _deepStringMap(entryValue));
+      }
+      if (entryValue is List) {
+        return MapEntry(
+          key.toString(),
+          entryValue
+              .map((item) => item is Map ? _deepStringMap(item) : item)
+              .toList(),
+        );
+      }
+      return MapEntry(key.toString(), entryValue);
+    });
   }
 
   /// Get the request timeout in milliseconds
@@ -506,6 +530,67 @@ class SettingsService {
   /// Set whether nt_helper may refresh Codex ChatGPT auth.
   Future<bool> setAllowCodexAuthRefresh(bool value) async {
     return await _prefs?.setBool(_allowCodexAuthRefreshKey, value) ?? false;
+  }
+
+  /// Local directory the chat assistant may access through chat-only tools.
+  String? get chatLocalDirectory => _prefs?.getString(_chatLocalDirectoryKey);
+
+  /// Set the local directory the chat assistant may access.
+  Future<bool> setChatLocalDirectory(String value) async {
+    if (value.trim().isEmpty) {
+      return await _prefs?.remove(_chatLocalDirectoryKey) ?? false;
+    }
+    return await _prefs?.setString(_chatLocalDirectoryKey, value.trim()) ??
+        false;
+  }
+
+  /// Named filesystem roots available to chat and/or MCP tools.
+  List<AllowedFileRoot> get allowedFileRoots {
+    final raw = _prefs?.getString(_allowedFileRootsKey);
+    if (raw != null && raw.trim().isNotEmpty) {
+      try {
+        final decoded = jsonDecode(raw);
+        if (decoded is List) {
+          final roots = decoded
+              .whereType<Map>()
+              .map((item) => AllowedFileRoot.fromJson(_deepStringMap(item)))
+              .where((root) => root.isValid)
+              .toList(growable: false);
+          return List.unmodifiable(roots);
+        }
+      } on Object {
+        return const [];
+      }
+    }
+
+    final legacyDirectory = chatLocalDirectory?.trim();
+    if (legacyDirectory == null || legacyDirectory.isEmpty) {
+      return const [];
+    }
+    return [
+      AllowedFileRoot.chatReadSearch(
+        id: 'local_context',
+        label: 'Local Context',
+        path: legacyDirectory,
+      ),
+    ];
+  }
+
+  /// Persist named filesystem roots available to chat and/or MCP tools.
+  Future<bool> setAllowedFileRoots(List<AllowedFileRoot> roots) async {
+    final normalized = roots
+        .where((root) => root.isValid)
+        .map((root) => root.toJson())
+        .toList(growable: false);
+    await _prefs?.remove(_chatLocalDirectoryKey);
+    if (normalized.isEmpty) {
+      return await _prefs?.remove(_allowedFileRootsKey) ?? false;
+    }
+    return await _prefs?.setString(
+          _allowedFileRootsKey,
+          jsonEncode(normalized),
+        ) ??
+        false;
   }
 
   /// Get the OpenAI base URL (for LM Studio, OpenRouter, etc.)

--- a/lib/ui/cpu_monitor_widget.dart
+++ b/lib/ui/cpu_monitor_widget.dart
@@ -8,7 +8,11 @@ import 'package:nt_helper/services/settings_service.dart';
 /// Shows the two main CPU usage numbers with a tooltip containing slot breakdown.
 /// Automatically pauses CPU monitoring when not visible and resumes when visible.
 class CpuMonitorWidget extends StatefulWidget {
-  const CpuMonitorWidget({super.key});
+  const CpuMonitorWidget({super.key, this.paused = false});
+
+  /// Temporarily hides the widget and pauses polling while another workflow
+  /// owns the same device communication path.
+  final bool paused;
 
   @override
   State<CpuMonitorWidget> createState() => _CpuMonitorWidgetState();
@@ -43,7 +47,7 @@ class _CpuMonitorWidgetState extends State<CpuMonitorWidget> {
       valueListenable: SettingsService().cpuMonitorEnabledNotifier,
       builder: (context, cpuMonitorEnabled, _) {
         // Check if CPU monitor is disabled in settings
-        if (!cpuMonitorEnabled) {
+        if (!cpuMonitorEnabled || widget.paused) {
           _updateVisibility(false);
           return const SizedBox.shrink();
         }

--- a/lib/ui/cpu_monitor_widget.dart
+++ b/lib/ui/cpu_monitor_widget.dart
@@ -17,6 +17,7 @@ class CpuMonitorWidget extends StatefulWidget {
 class _CpuMonitorWidgetState extends State<CpuMonitorWidget> {
   late DistingCubit _distingCubit;
   bool _isVisible = false;
+  CpuUsage? _lastCpuUsage;
 
   @override
   void didChangeDependencies() {
@@ -78,24 +79,18 @@ class _CpuMonitorWidgetState extends State<CpuMonitorWidget> {
             return StreamBuilder<CpuUsage?>(
               stream: _distingCubit.cpuUsageStream,
               builder: (context, snapshot) {
-                if (!snapshot.hasData) {
-                  // Show placeholder while loading
-                  return _buildCpuDisplay(
-                    context: context,
-                    cpu1: null,
-                    cpu2: null,
-                    slotUsages: [],
-                    isLoading: true,
-                  );
+                final currentCpuUsage = snapshot.data;
+                if (currentCpuUsage != null) {
+                  _lastCpuUsage = currentCpuUsage;
                 }
 
-                final cpuUsage = snapshot.data;
+                final cpuUsage = currentCpuUsage ?? _lastCpuUsage;
                 return _buildCpuDisplay(
                   context: context,
                   cpu1: cpuUsage?.cpu1,
                   cpu2: cpuUsage?.cpu2,
                   slotUsages: cpuUsage?.slotUsages ?? [],
-                  isLoading: false,
+                  isWaitingForSample: cpuUsage == null,
                 );
               },
             );
@@ -117,7 +112,7 @@ class _CpuMonitorWidgetState extends State<CpuMonitorWidget> {
     required int? cpu1,
     required int? cpu2,
     required List<int> slotUsages,
-    required bool isLoading,
+    required bool isWaitingForSample,
   }) {
     final theme = Theme.of(context);
 
@@ -137,11 +132,11 @@ class _CpuMonitorWidgetState extends State<CpuMonitorWidget> {
       cpu1: cpu1,
       cpu2: cpu2,
       slotUsages: slotUsages,
-      isLoading: isLoading,
+      isWaitingForSample: isWaitingForSample,
     );
 
-    final semanticLabel = isLoading
-        ? 'CPU monitor: loading'
+    final semanticLabel = isWaitingForSample
+        ? 'CPU monitor: waiting for usage sample'
         : 'CPU usage: Core 1 ${cpu1 ?? 0}%, Core 2 ${cpu2 ?? 0}%${isHighUsage ? ', warning: high usage' : ''}';
 
     return Semantics(
@@ -169,17 +164,12 @@ class _CpuMonitorWidgetState extends State<CpuMonitorWidget> {
                     : theme.colorScheme.onSurfaceVariant,
               ),
               const SizedBox(width: 4),
-              if (isLoading)
-                SizedBox(
-                  width: 12,
-                  height: 12,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                )
-              else
-                Text('${cpu1 ?? 0}% | ${cpu2 ?? 0}%', style: textStyle),
+              Text(
+                isWaitingForSample
+                    ? '--% | --%'
+                    : '${cpu1 ?? 0}% | ${cpu2 ?? 0}%',
+                style: textStyle,
+              ),
             ],
           ),
         ),
@@ -192,10 +182,10 @@ class _CpuMonitorWidgetState extends State<CpuMonitorWidget> {
     required int? cpu1,
     required int? cpu2,
     required List<int> slotUsages,
-    required bool isLoading,
+    required bool isWaitingForSample,
   }) {
-    if (isLoading) {
-      return 'Loading CPU usage...';
+    if (isWaitingForSample) {
+      return 'Waiting for CPU usage sample...';
     }
 
     final buffer = StringBuffer();

--- a/lib/ui/synchronized_screen.dart
+++ b/lib/ui/synchronized_screen.dart
@@ -1709,7 +1709,7 @@ class _SynchronizedScreenState extends State<SynchronizedScreen>
           // CPU Monitor Widget - only in wide-screen mode
           if (isWideScreen) ...[
             const SizedBox(width: 16),
-            const CpuMonitorWidget(),
+            CpuMonitorWidget(paused: _showChatPanel),
           ],
           // Spacer for FAB so it doesn't cover the version/CPU info
           const SizedBox(width: 80),

--- a/lib/ui/widgets/parameter_editor_view.dart
+++ b/lib/ui/widgets/parameter_editor_view.dart
@@ -55,14 +55,22 @@ class ParameterEditorView extends StatelessWidget {
     // Determine the display string to use
     // For partial enums (like unit 16 file/folder), prefer enum string over valueString,
     // but only if the enum string is non-empty
-    // For unit 16: only use valueString if value is 0 (the only value with a valid string "Off")
-    // Otherwise show raw integer for values 1-6
+    // Unit 16 is also used by parameters whose firmware value string carries
+    // the useful display unit (for example Looper envelope times). Some ES-5
+    // output parameters can return a stale "Off" string after moving away from
+    // value 0, so suppress only that known stale case.
+    final unit16ValueString =
+        valueString.value.isNotEmpty &&
+            !(parameterInfo.unit == 16 &&
+                value.value != 0 &&
+                valueString.value == 'Off')
+        ? valueString.value
+        : null;
+
     final effectiveDisplayString = currentValueHasEnumString
         ? enumStrings.values[value.value]
         : (parameterInfo.unit == 16
-              ? (value.value == 0 && valueString.value.isNotEmpty
-                    ? valueString.value
-                    : null)
+              ? unit16ValueString
               : (valueString.value.isNotEmpty ? valueString.value : null));
 
     return ParameterViewRow(

--- a/lib/ui/widgets/section_parameter_list_view.dart
+++ b/lib/ui/widgets/section_parameter_list_view.dart
@@ -635,6 +635,8 @@ class _SectionParameterListViewState extends State<SectionParameterListView> {
                 ),
               ),
             ),
+          if (widget.onToggleSpreadsheetEditingMode != null)
+            const SizedBox(width: 8),
           Tooltip(
             message: _isCollapsed ? 'Expand all' : 'Collapse all',
             child: IconButton.filledTonal(

--- a/test/chat/cubit/chat_cubit_test.dart
+++ b/test/chat/cubit/chat_cubit_test.dart
@@ -51,6 +51,9 @@ void main() {
 
     when(() => toolRegistry.entries).thenReturn(const []);
     when(() => toolRegistry.findByName(any())).thenReturn(null);
+    when(
+      () => toolRegistry.executeTool(any(), any()),
+    ).thenAnswer((_) async => '{"success":true}');
     when(() => memoryService.readMemory()).thenAnswer((_) async => '');
     when(() => memoryService.readDailyLogs()).thenAnswer((_) async => '');
     when(
@@ -663,5 +666,228 @@ void main() {
             'Got: ${lastMessages.map((m) => m.role.name).join(', ')}',
       );
     });
+
+    test(
+      'recomputes compaction need after resolving the next provider window',
+      () async {
+        final firstProvider = MockLlmProvider();
+        final secondProvider = MockLlmProvider();
+        when(() => firstProvider.dispose()).thenReturn(null);
+        when(() => secondProvider.dispose()).thenReturn(null);
+        when(
+          () => firstProvider.resolveContextWindowTokens(),
+        ).thenAnswer((_) async => 1000);
+        when(
+          () => secondProvider.resolveContextWindowTokens(),
+        ).thenAnswer((_) async => 2000);
+        when(
+          () => firstProvider.sendMessages(
+            messages: any(named: 'messages'),
+            tools: any(named: 'tools'),
+            systemPrompt: any(named: 'systemPrompt'),
+          ),
+        ).thenAnswer(
+          (_) async => const LlmResponse(
+            content: 'near the small window',
+            isComplete: true,
+            usage: LlmUsage(inputTokens: 900, outputTokens: 10),
+          ),
+        );
+        when(
+          () => secondProvider.sendMessages(
+            messages: any(named: 'messages'),
+            tools: any(named: 'tools'),
+            systemPrompt: any(named: 'systemPrompt'),
+          ),
+        ).thenAnswer(
+          (_) async => const LlmResponse(
+            content: 'fits the larger window',
+            isComplete: true,
+            usage: LlmUsage(inputTokens: 950, outputTokens: 10),
+          ),
+        );
+
+        final providers = [firstProvider, secondProvider];
+        var providerIndex = 0;
+        final cubit = ChatCubit(
+          toolRegistry: toolRegistry,
+          memoryService: memoryService,
+          providerFactory: (_) => providers[providerIndex++],
+        );
+        addTearDown(cubit.close);
+
+        await cubit.sendMessage('first', _settings);
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        expect((cubit.state as ChatReady).isProcessing, isFalse);
+
+        await cubit.sendMessage('second', _settings);
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        verify(
+          () => secondProvider.sendMessages(
+            messages: any(named: 'messages'),
+            tools: any(named: 'tools'),
+            systemPrompt: any(named: 'systemPrompt'),
+          ),
+        ).called(1);
+        expect((cubit.state as ChatReady).contextWindowTokens, 2000);
+      },
+    );
+
+    test('keeps existing history when automatic compaction fails', () async {
+      final firstProvider = MockLlmProvider();
+      final compactionProvider = MockLlmProvider();
+      when(() => firstProvider.dispose()).thenReturn(null);
+      when(() => compactionProvider.dispose()).thenReturn(null);
+      when(
+        () => firstProvider.resolveContextWindowTokens(),
+      ).thenAnswer((_) async => 1000);
+      when(
+        () => compactionProvider.resolveContextWindowTokens(),
+      ).thenAnswer((_) async => 1000);
+      when(
+        () => firstProvider.sendMessages(
+          messages: any(named: 'messages'),
+          tools: any(named: 'tools'),
+          systemPrompt: any(named: 'systemPrompt'),
+        ),
+      ).thenAnswer(
+        (_) async => const LlmResponse(
+          content: 'near the limit',
+          isComplete: true,
+          usage: LlmUsage(inputTokens: 900, outputTokens: 10),
+        ),
+      );
+      when(
+        () => compactionProvider.sendMessages(
+          messages: any(named: 'messages'),
+          tools: any(named: 'tools'),
+          systemPrompt: any(named: 'systemPrompt'),
+        ),
+      ).thenThrow(Exception('compaction API down'));
+
+      final providers = [firstProvider, compactionProvider];
+      var providerIndex = 0;
+      final cubit = ChatCubit(
+        toolRegistry: toolRegistry,
+        memoryService: memoryService,
+        providerFactory: (_) => providers[providerIndex++],
+      );
+      addTearDown(cubit.close);
+
+      await cubit.sendMessage('first', _settings);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(cubit.contextSummary.messageCount, 2);
+
+      await cubit.sendMessage('second', _settings);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final state = cubit.state as ChatReady;
+      expect(state.isProcessing, isFalse);
+      expect(state.messages.last.content, contains('Compaction failed'));
+      expect(cubit.contextSummary.messageCount, 2);
+    });
+  });
+
+  group('Memory cache coherence', () {
+    test(
+      'waits for memory_write refresh before building next system prompt',
+      () async {
+        final refreshCompleter = Completer<String>();
+        var readMemoryCalls = 0;
+        when(() => memoryService.readMemory()).thenAnswer((_) {
+          readMemoryCalls++;
+          if (readMemoryCalls == 1) {
+            return Future.value('old memory');
+          }
+          return refreshCompleter.future;
+        });
+
+        final memoryWriteTool = ToolRegistryEntry(
+          name: 'memory_write',
+          description: 'Write memory.',
+          inputSchema: const {'properties': {}},
+          handler: (_) async => '{"success":true}',
+        );
+        when(() => toolRegistry.entries).thenReturn([memoryWriteTool]);
+        when(
+          () => toolRegistry.executeTool('memory_write', any()),
+        ).thenAnswer((_) async => '{"success":true}');
+
+        var providerCallCount = 0;
+        String? secondTurnSystemPrompt;
+        final provider = MockLlmProvider();
+        when(() => provider.dispose()).thenReturn(null);
+        when(
+          () => provider.sendMessages(
+            messages: any(named: 'messages'),
+            tools: any(named: 'tools'),
+            systemPrompt: any(named: 'systemPrompt'),
+          ),
+        ).thenAnswer((invocation) async {
+          providerCallCount++;
+          switch (providerCallCount) {
+            case 1:
+              return const LlmResponse(
+                isComplete: false,
+                toolCalls: [
+                  LlmToolCall(
+                    id: 'memory_call',
+                    name: 'memory_write',
+                    arguments: {'content': 'updated memory'},
+                  ),
+                ],
+              );
+            case 2:
+              return const LlmResponse(
+                content: 'saved',
+                isComplete: true,
+                usage: LlmUsage(inputTokens: 10, outputTokens: 5),
+              );
+            default:
+              secondTurnSystemPrompt =
+                  invocation.namedArguments[#systemPrompt] as String?;
+              return const LlmResponse(
+                content: 'using memory',
+                isComplete: true,
+                usage: LlmUsage(inputTokens: 10, outputTokens: 5),
+              );
+          }
+        });
+
+        final cubit = ChatCubit(
+          toolRegistry: toolRegistry,
+          memoryService: memoryService,
+          providerFactory: (_) => provider,
+        );
+        addTearDown(cubit.close);
+
+        await cubit.sendMessage('remember this', _settings);
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        expect(providerCallCount, 2);
+        expect(readMemoryCalls, 2);
+
+        final secondSend = cubit.sendMessage(
+          'what do you remember?',
+          _settings,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          providerCallCount,
+          2,
+          reason:
+              'Second turn should wait for the queued memory refresh before '
+              'calling the provider.',
+        );
+
+        refreshCompleter.complete('updated memory');
+        await secondSend;
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        expect(providerCallCount, 3);
+        expect(secondTurnSystemPrompt, contains('updated memory'));
+        expect(secondTurnSystemPrompt, isNot(contains('old memory')));
+      },
+    );
   });
 }

--- a/test/chat/cubit/chat_cubit_test.dart
+++ b/test/chat/cubit/chat_cubit_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -11,6 +12,8 @@ import 'package:nt_helper/chat/models/llm_types.dart';
 import 'package:nt_helper/chat/providers/llm_provider.dart';
 import 'package:nt_helper/chat/services/memory_service.dart';
 import 'package:nt_helper/mcp/tool_registry.dart';
+import 'package:nt_helper/services/settings_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class MockToolRegistry extends Mock implements ToolRegistry {}
 
@@ -24,6 +27,12 @@ const _settings = ChatSettings(
   provider: LlmProviderType.anthropic,
   anthropicApiKey: 'test-key',
   anthropicModel: 'claude-haiku-4-5-20251001',
+);
+
+const _openAiSettings = ChatSettings(
+  provider: LlmProviderType.openai,
+  openaiApiKey: 'test-key',
+  openaiModel: 'gpt-5-nano',
 );
 
 void main() {
@@ -47,6 +56,151 @@ void main() {
     when(
       () => memoryService.saveSessionSnapshot(any()),
     ).thenAnswer((_) async {});
+  });
+
+  group('Attachment validation', () {
+    blocTest<ChatCubit, ChatState>(
+      'rejects provider-unsupported binary file attachments before sending',
+      build: () {
+        return ChatCubit(
+          toolRegistry: toolRegistry,
+          memoryService: memoryService,
+          providerFactory: (_) => throw StateError('provider should not run'),
+        );
+      },
+      act: (cubit) async {
+        await cubit.sendMessage(
+          'read this',
+          _openAiSettings,
+          fileAttachments: const [
+            ChatFileAttachment(
+              name: 'manual.pdf',
+              data: 'JVBERi0xLjQ=',
+              mimeType: 'application/pdf',
+              sizeBytes: 8,
+            ),
+          ],
+        );
+      },
+      expect: () => [
+        isA<ChatReady>()
+            .having((s) => s.isProcessing, 'isProcessing', true)
+            .having((s) => s.messages, 'messages', hasLength(1))
+            .having(
+              (s) => s.messages.single.fileAttachments.single.name,
+              'file attachment',
+              'manual.pdf',
+            ),
+        isA<ChatReady>()
+            .having((s) => s.isProcessing, 'isProcessing', false)
+            .having((s) => s.messages, 'messages', hasLength(2))
+            .having(
+              (s) => s.messages.last.content,
+              'validation message',
+              contains('Unsupported attachment for OpenAI API: manual.pdf'),
+            ),
+      ],
+    );
+
+    test('does not persist attachments into a legacy uploads folder', () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        'nt_helper_chat_uploads_',
+      );
+      try {
+        SharedPreferences.setMockInitialValues({
+          'chat_local_directory': tempDir.path,
+        });
+        await SettingsService().init();
+        final provider = MockLlmProvider();
+        when(() => provider.dispose()).thenReturn(null);
+        when(
+          () => provider.sendMessages(
+            messages: any(named: 'messages'),
+            tools: any(named: 'tools'),
+            systemPrompt: any(named: 'systemPrompt'),
+          ),
+        ).thenAnswer(
+          (_) async => const LlmResponse(content: 'ok', isComplete: true),
+        );
+        final cubit = ChatCubit(
+          toolRegistry: toolRegistry,
+          memoryService: memoryService,
+          providerFactory: (_) => provider,
+        );
+
+        await cubit.sendMessage(
+          'look',
+          _settings,
+          imageAttachments: const [
+            ChatImageAttachment(
+              data: 'AQID',
+              mimeType: 'image/png',
+              name: 'clip.png',
+            ),
+          ],
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        expect(await Directory('${tempDir.path}/uploads').exists(), isFalse);
+      } finally {
+        if (await tempDir.exists()) {
+          await tempDir.delete(recursive: true);
+        }
+      }
+    });
+
+    blocTest<ChatCubit, ChatState>(
+      'uses plural placeholder text for multiple image-only attachments',
+      build: () {
+        final provider = MockLlmProvider();
+        when(() => provider.dispose()).thenReturn(null);
+        when(
+          () => provider.sendMessages(
+            messages: any(named: 'messages'),
+            tools: any(named: 'tools'),
+            systemPrompt: any(named: 'systemPrompt'),
+          ),
+        ).thenAnswer(
+          (_) async => const LlmResponse(content: 'ok', isComplete: true),
+        );
+        return ChatCubit(
+          toolRegistry: toolRegistry,
+          memoryService: memoryService,
+          providerFactory: (_) => provider,
+        );
+      },
+      act: (cubit) async {
+        await cubit.sendMessage(
+          '',
+          _settings,
+          imageAttachments: const [
+            ChatImageAttachment(
+              data: 'AQID',
+              mimeType: 'image/png',
+              name: 'one.png',
+            ),
+            ChatImageAttachment(
+              data: 'BAUG',
+              mimeType: 'image/png',
+              name: 'two.png',
+            ),
+          ],
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      },
+      expect: () => [
+        isA<ChatReady>()
+            .having((s) => s.isProcessing, 'isProcessing', true)
+            .having(
+              (s) => s.messages.single.content,
+              'content',
+              'Attached images.',
+            ),
+        isA<ChatReady>()
+            .having((s) => s.isProcessing, 'isProcessing', false)
+            .having((s) => s.messages.last.content, 'assistant response', 'ok'),
+      ],
+    );
   });
 
   group('Bug 1: permanent thinking spinner — onDone without isFinal', () {

--- a/test/chat/cubit/chat_cubit_test.dart
+++ b/test/chat/cubit/chat_cubit_test.dart
@@ -567,6 +567,9 @@ void main() {
       final provider = MockLlmProvider();
       when(() => provider.dispose()).thenReturn(null);
       when(
+        () => provider.resolveContextWindowTokens(),
+      ).thenAnswer((_) async => 200000);
+      when(
         () => provider.sendMessages(
           messages: any(named: 'messages'),
           tools: any(named: 'tools'),
@@ -597,11 +600,11 @@ void main() {
             );
           case 3:
             // Turn 1, iteration 3: final response with high tokens to trigger
-            // compaction (limit/2 = 100000 for haiku's 200000).
+            // compaction (85% of the provider's 200000 token window).
             return const LlmResponse(
               content: 'Done with tools.',
               isComplete: true,
-              usage: LlmUsage(inputTokens: 110000, outputTokens: 500),
+              usage: LlmUsage(inputTokens: 171000, outputTokens: 500),
             );
           case 4:
             // Compaction loop: simple final response

--- a/test/chat/providers/model_context_window_test.dart
+++ b/test/chat/providers/model_context_window_test.dart
@@ -6,7 +6,6 @@ import 'package:http/testing.dart';
 import 'package:nt_helper/chat/providers/anthropic_provider.dart';
 import 'package:nt_helper/chat/providers/model_context_window.dart';
 import 'package:nt_helper/chat/providers/openai_provider.dart';
-import 'package:nt_helper/chat/providers/openai_subscription_provider.dart';
 
 void main() {
   group('Model context window resolution', () {
@@ -39,14 +38,47 @@ void main() {
       },
     );
 
-    test('OpenAI subscription provider infers known model families', () async {
-      final provider = OpenAISubscriptionProvider(
-        model: 'gpt-5.4-mini',
-        allowAuthRefresh: false,
-      );
+    test('OpenAI subscription resolver uses Codex model metadata', () async {
+      late http.Request capturedRequest;
+      final contextWindow =
+          await OpenAIContextWindowResolver.resolveSubscription(
+            model: 'gpt-5.5',
+            headers: const {
+              'Authorization': 'Bearer token',
+              'ChatGPT-Account-ID': 'account',
+              'version': '0.135.0',
+            },
+            client: MockClient((request) async {
+              capturedRequest = request;
+              return http.Response(
+                jsonEncode({
+                  'models': [
+                    {'slug': 'gpt-5.5', 'context_window': 272000},
+                  ],
+                }),
+                200,
+              );
+            }),
+            clientVersion: '0.135.0',
+            baseUrl: 'https://example.test/backend-api/codex/responses',
+          );
 
-      expect(await provider.resolveContextWindowTokens(), 400000);
-      provider.dispose();
+      expect(contextWindow, 272000);
+      expect(capturedRequest.method, 'GET');
+      expect(
+        capturedRequest.url.toString(),
+        'https://example.test/backend-api/codex/models?model=gpt-5.5&client_version=0.135.0',
+      );
+      expect(capturedRequest.headers['Authorization'], 'Bearer token');
+      expect(capturedRequest.headers['ChatGPT-Account-ID'], 'account');
+    });
+
+    test('OpenAI subscription resolver falls back by product model family', () {
+      expect(OpenAIContextWindowResolver.inferSubscription('gpt-5.5'), 272000);
+      expect(
+        OpenAIContextWindowResolver.inferSubscription('gpt-5.4-mini'),
+        400000,
+      );
     });
 
     test('Anthropic provider uses Models API max input tokens', () async {

--- a/test/chat/providers/model_context_window_test.dart
+++ b/test/chat/providers/model_context_window_test.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:nt_helper/chat/providers/anthropic_provider.dart';
+import 'package:nt_helper/chat/providers/model_context_window.dart';
+import 'package:nt_helper/chat/providers/openai_provider.dart';
+import 'package:nt_helper/chat/providers/openai_subscription_provider.dart';
+
+void main() {
+  group('Model context window resolution', () {
+    test(
+      'OpenAI provider uses compatible model metadata when available',
+      () async {
+        late http.Request capturedRequest;
+        final provider = OpenAIProvider(
+          apiKey: 'test-key',
+          model: 'custom-model',
+          baseUrl: 'https://example.test/v1/chat/completions',
+          client: MockClient((request) async {
+            capturedRequest = request;
+            return http.Response(
+              jsonEncode({'id': 'custom-model', 'context_window': 222000}),
+              200,
+            );
+          }),
+        );
+
+        final contextWindow = await provider.resolveContextWindowTokens();
+
+        expect(contextWindow, 222000);
+        expect(capturedRequest.method, 'GET');
+        expect(
+          capturedRequest.url.toString(),
+          'https://example.test/v1/models/custom-model',
+        );
+        expect(capturedRequest.headers['Authorization'], 'Bearer test-key');
+      },
+    );
+
+    test('OpenAI subscription provider infers known model families', () async {
+      final provider = OpenAISubscriptionProvider(
+        model: 'gpt-5.4-mini',
+        allowAuthRefresh: false,
+      );
+
+      expect(await provider.resolveContextWindowTokens(), 400000);
+      provider.dispose();
+    });
+
+    test('Anthropic provider uses Models API max input tokens', () async {
+      late http.Request capturedRequest;
+      final provider = AnthropicProvider(
+        apiKey: 'test-key',
+        model: 'claude-test-model',
+        client: MockClient((request) async {
+          capturedRequest = request;
+          return http.Response(
+            jsonEncode({
+              'id': 'claude-test-model',
+              'max_input_tokens': 333000,
+              'max_tokens': 64000,
+            }),
+            200,
+          );
+        }),
+      );
+
+      final contextWindow = await provider.resolveContextWindowTokens();
+
+      expect(contextWindow, 333000);
+      expect(capturedRequest.method, 'GET');
+      expect(
+        capturedRequest.url.toString(),
+        'https://api.anthropic.com/v1/models/claude-test-model',
+      );
+      expect(capturedRequest.headers['x-api-key'], 'test-key');
+      expect(capturedRequest.headers['anthropic-version'], '2023-06-01');
+      provider.dispose();
+    });
+
+    test('Anthropic resolver falls back by provider model family', () {
+      expect(
+        AnthropicContextWindowResolver.infer('claude-sonnet-4-6'),
+        1000000,
+      );
+      expect(
+        AnthropicContextWindowResolver.infer('claude-haiku-4-5-20251001'),
+        200000,
+      );
+    });
+  });
+}

--- a/test/chat/providers/openai_subscription_provider_test.dart
+++ b/test/chat/providers/openai_subscription_provider_test.dart
@@ -157,6 +157,73 @@ void main() {
       );
       expect(client.requests.last.headers['Authorization'], 'Bearer new-token');
     });
+
+    test(
+      'sends PDFs as input files but leaves text attachments inline',
+      () async {
+        final auth = _FakeAuthService(
+          const CodexAuthSnapshot(
+            accessToken: 'token',
+            refreshToken: 'refresh',
+            accountId: 'account',
+          ),
+        );
+        final client = _QueueClient([
+          (_) => _sseResponse([
+            {'type': 'response.output_text.delta', 'delta': 'ok'},
+          ]),
+        ]);
+        final provider = OpenAISubscriptionProvider(
+          model: 'gpt-5.4-mini',
+          allowAuthRefresh: false,
+          authService: auth,
+          client: client,
+        );
+        addTearDown(provider.dispose);
+
+        await provider.sendMessages(
+          messages: [
+            LlmMessage.user(
+              '--- Attached file: notes.txt ---\nhello',
+              fileAttachments: const [
+                LlmFileAttachment(
+                  name: 'notes.txt',
+                  data: 'aGVsbG8=',
+                  mimeType: 'text/plain',
+                  sizeBytes: 5,
+                  textContent: 'hello',
+                ),
+                LlmFileAttachment(
+                  name: 'manual.pdf',
+                  data: 'JVBERi0xLjQ=',
+                  mimeType: 'application/pdf',
+                  sizeBytes: 8,
+                ),
+              ],
+            ),
+          ],
+          tools: const [],
+        );
+
+        final body =
+            jsonDecode(client.requests.single.body) as Map<String, dynamic>;
+        final input = body['input'] as List<dynamic>;
+        final content = input.single['content'] as List<dynamic>;
+        final inputFiles = content
+            .whereType<Map<String, dynamic>>()
+            .where((part) => part['type'] == 'input_file')
+            .toList();
+
+        expect(inputFiles, hasLength(1));
+        expect(inputFiles.single['filename'], 'manual.pdf');
+        expect(
+          content.whereType<Map<String, dynamic>>().singleWhere(
+            (part) => part['type'] == 'input_text',
+          )['text'],
+          contains('notes.txt'),
+        );
+      },
+    );
   });
 }
 

--- a/test/chat/providers/openai_subscription_provider_test.dart
+++ b/test/chat/providers/openai_subscription_provider_test.dart
@@ -46,6 +46,41 @@ class _QueueClient extends http.BaseClient {
 
 void main() {
   group('OpenAISubscriptionProvider', () {
+    test('resolves context window from Codex models endpoint', () async {
+      final auth = _FakeAuthService(
+        const CodexAuthSnapshot(
+          accessToken: 'token',
+          refreshToken: 'refresh',
+          accountId: 'account',
+        ),
+      );
+      final client = _QueueClient([
+        (_) => _jsonResponse({
+          'models': [
+            {'slug': 'gpt-5.5', 'context_window': 272000},
+          ],
+        }),
+      ]);
+      final provider = OpenAISubscriptionProvider(
+        model: 'gpt-5.5',
+        allowAuthRefresh: false,
+        authService: auth,
+        client: client,
+      );
+      addTearDown(provider.dispose);
+
+      final contextWindow = await provider.resolveContextWindowTokens();
+
+      expect(contextWindow, 272000);
+      expect(client.requests.single.method, 'GET');
+      expect(
+        client.requests.single.url.toString(),
+        'https://chatgpt.com/backend-api/codex/models?model=gpt-5.5&client_version=0.135.0',
+      );
+      expect(client.requests.single.headers['Authorization'], 'Bearer token');
+      expect(client.requests.single.headers['ChatGPT-Account-ID'], 'account');
+    });
+
     test('parses text, tool calls, and usage from Responses SSE', () async {
       final auth = _FakeAuthService(
         const CodexAuthSnapshot(
@@ -230,6 +265,14 @@ void main() {
 http.StreamedResponse _sseResponse(List<Map<String, dynamic>> events) {
   final body = events.map((e) => 'data: ${jsonEncode(e)}\n\n').join();
   return _textResponse(200, body);
+}
+
+http.StreamedResponse _jsonResponse(Map<String, dynamic> body) {
+  return http.StreamedResponse(
+    Stream.value(utf8.encode(jsonEncode(body))),
+    200,
+    headers: const {'content-type': 'application/json'},
+  );
 }
 
 http.StreamedResponse _textResponse(int statusCode, String body) {

--- a/test/chat/services/chat_service_rate_limit_test.dart
+++ b/test/chat/services/chat_service_rate_limit_test.dart
@@ -14,6 +14,7 @@ class MockToolRegistry extends Mock implements ToolRegistry {}
 
 void main() {
   late MockLlmProvider provider;
+  late MockToolRegistry toolRegistry;
   late ToolBridgeService toolBridge;
   late ChatService chatService;
 
@@ -24,7 +25,7 @@ void main() {
 
   setUp(() {
     provider = MockLlmProvider();
-    final toolRegistry = MockToolRegistry();
+    toolRegistry = MockToolRegistry();
     when(() => toolRegistry.entries).thenReturn(const []);
     toolBridge = ToolBridgeService(toolRegistry);
     chatService = ChatService(
@@ -32,6 +33,127 @@ void main() {
       toolBridge: toolBridge,
       systemPrompt: 'test',
     );
+  });
+
+  group('Tool references', () {
+    test('large tool result reference is sent to the next model call', () async {
+      const referenceResult =
+          '{"success":true,"type":"tool_reference","reference_id":"ref_1","tool_name":"large_tool","total_chars":25004,"instructions":"Use read_reference or search_reference."}';
+      when(() => toolRegistry.entries).thenReturn([
+        ToolRegistryEntry(
+          name: 'large_tool',
+          description: 'Returns a large text payload.',
+          inputSchema: const {'properties': {}},
+          handler: (_) async => 'unused',
+        ),
+      ]);
+      when(
+        () => toolRegistry.executeTool('large_tool', any()),
+      ).thenAnswer((_) async => referenceResult);
+
+      var callCount = 0;
+      List<LlmMessage>? secondCallMessages;
+      when(
+        () => provider.sendMessages(
+          messages: any(named: 'messages'),
+          tools: any(named: 'tools'),
+          systemPrompt: any(named: 'systemPrompt'),
+        ),
+      ).thenAnswer((invocation) async {
+        callCount++;
+        if (callCount == 1) {
+          return const LlmResponse(
+            isComplete: false,
+            toolCalls: [
+              LlmToolCall(id: 'tc_large', name: 'large_tool', arguments: {}),
+            ],
+          );
+        }
+
+        secondCallMessages =
+            invocation.namedArguments[#messages] as List<LlmMessage>;
+        return const LlmResponse(content: 'done', isComplete: true);
+      });
+
+      final events = await chatService.runAgenticLoop([
+        LlmMessage.user('run the large tool'),
+      ]).toList();
+
+      expect(events.whereType<ChatLoopError>(), isEmpty);
+      expect(secondCallMessages, isNotNull);
+      final toolMessage = secondCallMessages!.singleWhere(
+        (message) => message.role == LlmRole.tool,
+      );
+
+      expect(toolMessage.content, referenceResult);
+      expect(toolMessage.content, contains('"type":"tool_reference"'));
+      expect(toolMessage.content, contains('"reference_id":"ref_1"'));
+    });
+  });
+
+  group('Usage accounting', () {
+    test('aggregates cache tokens into final usage and context peak', () async {
+      var callCount = 0;
+      when(
+        () => provider.sendMessages(
+          messages: any(named: 'messages'),
+          tools: any(named: 'tools'),
+          systemPrompt: any(named: 'systemPrompt'),
+        ),
+      ).thenAnswer((_) async {
+        callCount++;
+        return switch (callCount) {
+          1 => const LlmResponse(
+            isComplete: false,
+            toolCalls: [
+              LlmToolCall(id: 'tc_small', name: 'small_tool', arguments: {}),
+            ],
+            usage: LlmUsage(
+              inputTokens: 100,
+              outputTokens: 10,
+              cacheCreationInputTokens: 30,
+              cacheReadInputTokens: 20,
+            ),
+          ),
+          _ => const LlmResponse(
+            content: 'done',
+            isComplete: true,
+            usage: LlmUsage(
+              inputTokens: 50,
+              outputTokens: 5,
+              cacheReadInputTokens: 200,
+            ),
+          ),
+        };
+      });
+      when(() => toolRegistry.entries).thenReturn([
+        ToolRegistryEntry(
+          name: 'small_tool',
+          description: 'Returns a small payload.',
+          inputSchema: const {'properties': {}},
+          handler: (_) async => 'unused',
+        ),
+      ]);
+      when(
+        () => toolRegistry.executeTool('small_tool', any()),
+      ).thenAnswer((_) async => '{"success":true}');
+
+      final events = await chatService.runAgenticLoop([
+        LlmMessage.user('run the tool'),
+      ]).toList();
+
+      final finalMessage = events
+          .whereType<ChatLoopAssistantMessage>()
+          .singleWhere((event) => event.isFinal);
+      final usage = finalMessage.usage;
+
+      expect(usage, isNotNull);
+      expect(usage!.inputTokens, 150);
+      expect(usage.outputTokens, 15);
+      expect(usage.cacheCreationInputTokens, 30);
+      expect(usage.cacheReadInputTokens, 220);
+      expect(usage.contextInputTokens, 250);
+    });
   });
 
   group('Rate limit retry', () {

--- a/test/chat/services/local_file_tools_test.dart
+++ b/test/chat/services/local_file_tools_test.dart
@@ -65,6 +65,42 @@ void main() {
       expect(readResult['content'], 'hello modular\n');
     });
 
+    test('omits missing roots from listing but keeps stale-id error', () async {
+      final missingPath = '${tempDir.path}/unmounted';
+      await _setRoots(settings, [
+        _root(
+          id: 'mounted',
+          label: 'Mounted',
+          path: tempDir.path,
+          chat: {FileRootPermission.read},
+        ),
+        _root(
+          id: 'stale',
+          label: 'Stale SD',
+          path: missingPath,
+          chat: {FileRootPermission.read},
+        ),
+      ]);
+      final entries = _entriesFor(FileRootActor.chat);
+
+      final rootsResult = await _call(entries, 'list_allowed_roots', {});
+      final listResult = await _call(entries, 'list_files', {
+        'root_id': 'stale',
+      });
+
+      expect(rootsResult['success'], isTrue);
+      expect(
+        (rootsResult['roots'] as List).map((entry) => entry['id']),
+        contains('mounted'),
+      );
+      expect(
+        (rootsResult['roots'] as List).map((entry) => entry['id']),
+        isNot(contains('stale')),
+      );
+      expect(listResult['success'], isFalse);
+      expect(listResult['error'], 'root_not_found_on_disk');
+    });
+
     test('enforces search permission separately from read', () async {
       await _setRoots(settings, [
         _root(path: tempDir.path, chat: {FileRootPermission.read}),
@@ -295,13 +331,15 @@ Future<void> _setRoots(
 }
 
 AllowedFileRoot _root({
+  String id = 'sd',
+  String label = 'SD Card',
   required String path,
   Set<FileRootPermission> chat = const {},
   Set<FileRootPermission> mcp = const {},
 }) {
   return AllowedFileRoot(
-    id: 'sd',
-    label: 'SD Card',
+    id: id,
+    label: label,
     path: path,
     acl: {FileRootActor.chat: chat, FileRootActor.mcp: mcp},
   );

--- a/test/chat/services/local_file_tools_test.dart
+++ b/test/chat/services/local_file_tools_test.dart
@@ -1,0 +1,308 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/chat/models/allowed_file_root.dart';
+import 'package:nt_helper/chat/services/local_file_tools.dart';
+import 'package:nt_helper/mcp/tool_registry.dart';
+import 'package:nt_helper/services/settings_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('local file tools', () {
+    late Directory tempDir;
+    late SettingsService settings;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('nt_helper_tools_');
+      await File('${tempDir.path}/notes.txt').writeAsString('hello modular\n');
+      await Directory('${tempDir.path}/nested').create();
+      await File(
+        '${tempDir.path}/nested/patch.txt',
+      ).writeAsString('clock cv\n');
+      SharedPreferences.setMockInitialValues({});
+      settings = SettingsService();
+      await settings.init();
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('registers root-id tools', () {
+      final entries = <ToolRegistryEntry>[];
+
+      registerLocalFileTools(entries, actor: FileRootActor.chat);
+
+      final names = entries.map((entry) => entry.name).toSet();
+      expect(names, localFileToolNames);
+      expect(names, isNot(contains('write_workspace_file')));
+      expect(names, isNot(contains('list_uploaded_files')));
+    });
+
+    test('lists and reads files with chat read permission', () async {
+      await _setRoots(settings, [
+        _root(path: tempDir.path, chat: {FileRootPermission.read}),
+      ]);
+      final entries = _entriesFor(FileRootActor.chat);
+
+      final listResult = await _call(entries, 'list_files', {'root_id': 'sd'});
+      final readResult = await _call(entries, 'read_file', {
+        'root_id': 'sd',
+        'path': 'notes.txt',
+      });
+
+      expect(listResult['success'], isTrue);
+      expect(
+        (listResult['entries'] as List).map((entry) => entry['path']),
+        contains('notes.txt'),
+      );
+      expect(readResult['success'], isTrue);
+      expect(readResult['content'], 'hello modular\n');
+    });
+
+    test('enforces search permission separately from read', () async {
+      await _setRoots(settings, [
+        _root(path: tempDir.path, chat: {FileRootPermission.read}),
+      ]);
+
+      final result = await _call(
+        _entriesFor(FileRootActor.chat),
+        'search_files',
+        {'root_id': 'sd', 'query': 'clock'},
+      );
+
+      expect(result['success'], isFalse);
+      expect(result['error'], 'permission_denied');
+      expect(result['permission'], 'search');
+    });
+
+    test('searches text files with search permission', () async {
+      await _setRoots(settings, [
+        _root(path: tempDir.path, chat: {FileRootPermission.search}),
+      ]);
+
+      final result = await _call(
+        _entriesFor(FileRootActor.chat),
+        'search_files',
+        {'root_id': 'sd', 'query': 'clock'},
+      );
+
+      expect(result['success'], isTrue);
+      expect(result['matches'], hasLength(1));
+      expect(result['matches'][0]['path'], 'nested/patch.txt');
+    });
+
+    test('enforces chat and MCP ACLs independently', () async {
+      await _setRoots(settings, [
+        _root(
+          path: tempDir.path,
+          chat: {FileRootPermission.read},
+          mcp: {FileRootPermission.search},
+        ),
+      ]);
+
+      final chatRead = await _call(
+        _entriesFor(FileRootActor.chat),
+        'read_file',
+        {'root_id': 'sd', 'path': 'notes.txt'},
+      );
+      final mcpRead = await _call(_entriesFor(FileRootActor.mcp), 'read_file', {
+        'root_id': 'sd',
+        'path': 'notes.txt',
+      });
+      final mcpSearch = await _call(
+        _entriesFor(FileRootActor.mcp),
+        'search_files',
+        {'root_id': 'sd', 'query': 'hello'},
+      );
+
+      expect(chatRead['success'], isTrue);
+      expect(mcpRead['success'], isFalse);
+      expect(mcpRead['error'], 'permission_denied');
+      expect(mcpSearch['success'], isTrue);
+    });
+
+    test('writes UTF-8 text only with write permission', () async {
+      await _setRoots(settings, [
+        _root(path: tempDir.path, chat: {FileRootPermission.write}),
+      ]);
+
+      final writeResult =
+          await _call(_entriesFor(FileRootActor.chat), 'write_file', {
+            'root_id': 'sd',
+            'path': 'generated/out.txt',
+            'content': 'saved text\n',
+            'create_parents': true,
+          });
+
+      expect(writeResult['success'], isTrue);
+      expect(
+        await File('${tempDir.path}/generated/out.txt').readAsString(),
+        'saved text\n',
+      );
+    });
+
+    test('requires explicit overwrite for existing files', () async {
+      await _setRoots(settings, [
+        _root(path: tempDir.path, chat: {FileRootPermission.write}),
+      ]);
+      final entries = _entriesFor(FileRootActor.chat);
+
+      final withoutOverwrite = await _call(entries, 'write_file', {
+        'root_id': 'sd',
+        'path': 'notes.txt',
+        'content': 'replace\n',
+      });
+      final withOverwrite = await _call(entries, 'write_file', {
+        'root_id': 'sd',
+        'path': 'notes.txt',
+        'content': 'replace\n',
+        'overwrite': true,
+      });
+
+      expect(withoutOverwrite['success'], isFalse);
+      expect(withoutOverwrite['error'], 'file_exists');
+      expect(withOverwrite['success'], isTrue);
+      expect(
+        await File('${tempDir.path}/notes.txt').readAsString(),
+        'replace\n',
+      );
+    });
+
+    test('rejects path escape and absolute paths', () async {
+      await _setRoots(settings, [
+        _root(path: tempDir.path, chat: {FileRootPermission.read}),
+      ]);
+      final entries = _entriesFor(FileRootActor.chat);
+
+      final dotDot = await _call(entries, 'read_file', {
+        'root_id': 'sd',
+        'path': '../secret.txt',
+      });
+      final absolute = await _call(entries, 'read_file', {
+        'root_id': 'sd',
+        'path': '${tempDir.path}/notes.txt',
+      });
+
+      expect(dotDot['success'], isFalse);
+      expect(dotDot['error'], 'path_outside_allowed_root');
+      expect(absolute['success'], isFalse);
+      expect(absolute['error'], 'absolute_path_not_allowed');
+    });
+
+    test('rejects symlink escapes', () async {
+      final outside = await Directory.systemTemp.createTemp(
+        'nt_helper_outside_',
+      );
+      try {
+        await File('${outside.path}/secret.txt').writeAsString('secret');
+        await Link('${tempDir.path}/escape').create(outside.path);
+        await Link(
+          '${tempDir.path}/secret-link.txt',
+        ).create('${outside.path}/secret.txt');
+        await _setRoots(settings, [
+          _root(
+            path: tempDir.path,
+            chat: {
+              FileRootPermission.read,
+              FileRootPermission.write,
+              FileRootPermission.search,
+            },
+          ),
+        ]);
+
+        final readResult = await _call(
+          _entriesFor(FileRootActor.chat),
+          'read_file',
+          {'root_id': 'sd', 'path': 'escape/secret.txt'},
+        );
+        final symlinkFileRead = await _call(
+          _entriesFor(FileRootActor.chat),
+          'read_file',
+          {'root_id': 'sd', 'path': 'secret-link.txt'},
+        );
+        final writeResult = await _call(
+          _entriesFor(FileRootActor.chat),
+          'write_file',
+          {'root_id': 'sd', 'path': 'escape/new.txt', 'content': 'nope'},
+        );
+        final symlinkFileWrite = await _call(
+          _entriesFor(FileRootActor.chat),
+          'write_file',
+          {'root_id': 'sd', 'path': 'secret-link.txt', 'content': 'nope'},
+        );
+        final searchResult = await _call(
+          _entriesFor(FileRootActor.chat),
+          'search_files',
+          {'root_id': 'sd', 'query': 'secret'},
+        );
+        final listResult = await _call(
+          _entriesFor(FileRootActor.chat),
+          'list_files',
+          {'root_id': 'sd', 'recursive': true},
+        );
+
+        expect(readResult['success'], isFalse);
+        expect(readResult['error'], 'path_outside_allowed_root');
+        expect(symlinkFileRead['success'], isFalse);
+        expect(symlinkFileRead['error'], 'path_outside_allowed_root');
+        expect(writeResult['success'], isFalse);
+        expect(writeResult['error'], 'path_outside_allowed_root');
+        expect(symlinkFileWrite['success'], isFalse);
+        expect(symlinkFileWrite['error'], 'path_outside_allowed_root');
+        expect(searchResult['success'], isTrue);
+        expect(searchResult['matches'], isEmpty);
+        expect(listResult['success'], isTrue);
+        expect(
+          (listResult['entries'] as List).map((entry) => entry['path']),
+          isNot(contains('secret-link.txt')),
+        );
+      } finally {
+        if (await outside.exists()) {
+          await outside.delete(recursive: true);
+        }
+      }
+    });
+  });
+}
+
+List<ToolRegistryEntry> _entriesFor(FileRootActor actor) {
+  final entries = <ToolRegistryEntry>[];
+  registerLocalFileTools(entries, actor: actor);
+  return entries;
+}
+
+Future<Map<String, dynamic>> _call(
+  List<ToolRegistryEntry> entries,
+  String name,
+  Map<String, dynamic> args,
+) async {
+  final entry = entries.singleWhere((entry) => entry.name == name);
+  return jsonDecode(await entry.handler(args)) as Map<String, dynamic>;
+}
+
+Future<void> _setRoots(
+  SettingsService settings,
+  List<AllowedFileRoot> roots,
+) async {
+  final saved = await settings.setAllowedFileRoots(roots);
+  expect(saved, isTrue);
+}
+
+AllowedFileRoot _root({
+  required String path,
+  Set<FileRootPermission> chat = const {},
+  Set<FileRootPermission> mcp = const {},
+}) {
+  return AllowedFileRoot(
+    id: 'sd',
+    label: 'SD Card',
+    path: path,
+    acl: {FileRootActor.chat: chat, FileRootActor.mcp: mcp},
+  );
+}

--- a/test/chat/ui/chat_panel_test.dart
+++ b/test/chat/ui/chat_panel_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/chat/cubit/chat_cubit.dart';
+import 'package:nt_helper/chat/services/memory_service.dart';
+import 'package:nt_helper/chat/ui/chat_panel.dart';
+import 'package:nt_helper/mcp/tool_registry.dart';
+import 'package:nt_helper/services/settings_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockToolRegistry extends Mock implements ToolRegistry {}
+
+class _MockMemoryService extends Mock implements MemoryService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late ChatCubit cubit;
+  late _MockToolRegistry toolRegistry;
+  late _MockMemoryService memoryService;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SettingsService().init();
+    toolRegistry = _MockToolRegistry();
+    memoryService = _MockMemoryService();
+    when(() => toolRegistry.entries).thenReturn(const []);
+    when(
+      () => memoryService.saveSessionSnapshot(any()),
+    ).thenAnswer((_) async {});
+    cubit = ChatCubit(toolRegistry: toolRegistry, memoryService: memoryService);
+  });
+
+  tearDown(() async {
+    await cubit.close();
+  });
+
+  testWidgets('header uses context status arc instead of clear icon', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BlocProvider<ChatCubit>.value(
+            value: cubit,
+            child: const ChatPanel(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.delete_outline), findsNothing);
+    expect(find.byTooltip('Context status'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Context status'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Context'), findsOneWidget);
+    expect(find.text('Breakdown'), findsOneWidget);
+    expect(find.text('Compact'), findsOneWidget);
+    expect(find.text('Clear'), findsOneWidget);
+  });
+}

--- a/test/chat/ui/chat_panel_test.dart
+++ b/test/chat/ui/chat_panel_test.dart
@@ -1,8 +1,11 @@
+import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nt_helper/chat/cubit/chat_cubit.dart';
+import 'package:nt_helper/chat/cubit/chat_state.dart';
+import 'package:nt_helper/chat/models/chat_message.dart';
 import 'package:nt_helper/chat/services/memory_service.dart';
 import 'package:nt_helper/chat/ui/chat_panel.dart';
 import 'package:nt_helper/mcp/tool_registry.dart';
@@ -12,6 +15,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 class _MockToolRegistry extends Mock implements ToolRegistry {}
 
 class _MockMemoryService extends Mock implements MemoryService {}
+
+class _MockChatCubit extends MockCubit<ChatState> implements ChatCubit {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -58,7 +63,45 @@ void main() {
 
     expect(find.text('Context'), findsOneWidget);
     expect(find.text('Breakdown'), findsOneWidget);
-    expect(find.text('Compact'), findsOneWidget);
-    expect(find.text('Clear'), findsOneWidget);
+    expect(find.text('Compact context'), findsOneWidget);
+    expect(find.text('Clear chat...'), findsOneWidget);
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('clear chat menu item requires confirmation before clearing', (
+    tester,
+  ) async {
+    final mockCubit = _MockChatCubit();
+    when(() => mockCubit.state).thenReturn(
+      ChatReady(messages: [ChatMessage.user('keep me until confirmed')]),
+    );
+    when(
+      () => mockCubit.contextSummary,
+    ).thenReturn(const ChatContextSummary(messageCount: 1, userMessages: 1));
+    when(() => mockCubit.clearChat()).thenAnswer((_) async {});
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BlocProvider<ChatCubit>.value(
+            value: mockCubit,
+            child: const ChatPanel(),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byTooltip('Context status'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Clear chat...'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Clear chat?'), findsOneWidget);
+    verifyNever(() => mockCubit.clearChat());
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    verifyNever(() => mockCubit.clearChat());
   });
 }

--- a/test/mcp/algorithm_tools_test.dart
+++ b/test/mcp/algorithm_tools_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nt_helper/mcp/tools/algorithm_tools.dart';
+import 'package:nt_helper/mcp/tool_registry.dart';
 import 'package:nt_helper/services/algorithm_metadata_service.dart';
 import 'package:nt_helper/services/metadata_import_service.dart';
 import 'package:nt_helper/services/disting_controller_impl.dart';
@@ -66,6 +67,24 @@ void main() {
     });
 
     group('getAlgorithmDetails', () {
+      test('algorithmInfo accepts public guid argument', () async {
+        final result = await tools.algorithmInfo({'guid': 'clck'});
+
+        final decoded = jsonDecode(result);
+        expect(decoded['guid'], equals('clck'));
+        expect(decoded['name'], equals('Clock'));
+        expect(decoded['description'], isNotEmpty);
+        expect(decoded['parameters'], isList);
+      });
+
+      test('algorithmInfo accepts public name argument', () async {
+        final result = await tools.algorithmInfo({'name': 'Clock'});
+
+        final decoded = jsonDecode(result);
+        expect(decoded['guid'], equals('clck'));
+        expect(decoded['name'], equals('Clock'));
+      });
+
       test('should return algorithm details for valid GUID', () async {
         final result = await tools.getAlgorithmDetails({
           'algorithm_guid': 'clck',
@@ -157,6 +176,22 @@ void main() {
         } else {
           expect(decoded['guid'], equals('clck'));
         }
+      });
+    });
+
+    group('ToolRegistry algorithm_info', () {
+      test('registers shared chat and MCP tool entry', () async {
+        final registry = ToolRegistry(distingCubit);
+        final entry = registry.findByName('algorithm_info');
+
+        expect(entry, isNotNull);
+        expect(entry!.description, contains('Help screen'));
+        expect(entry.inputSchema['properties'], contains('guid'));
+        expect(entry.inputSchema['properties'], contains('name'));
+
+        final decoded = jsonDecode(await entry.handler({'guid': 'clck'}));
+        expect(decoded['guid'], equals('clck'));
+        expect(decoded['name'], equals('Clock'));
       });
     });
 

--- a/test/mcp/tool_registry_reference_test.dart
+++ b/test/mcp/tool_registry_reference_test.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/cubit/disting_cubit.dart';
+import 'package:nt_helper/mcp/tool_reference_store.dart';
+import 'package:nt_helper/mcp/tool_registry.dart';
+
+class MockDistingCubit extends Mock implements DistingCubit {}
+
+void main() {
+  group('ToolRegistry references', () {
+    test(
+      'large results become references that can be read and searched',
+      () async {
+        final largeResult =
+            '${'alpha ' * 2000}needle ${'beta ' * 2200}needle tail';
+        final registry = ToolRegistry(
+          MockDistingCubit(),
+          extraEntries: [
+            ToolRegistryEntry(
+              name: 'large_tool',
+              description: 'Returns a large result.',
+              inputSchema: const {'properties': {}},
+              handler: (_) async => largeResult,
+            ),
+          ],
+        );
+
+        final result =
+            jsonDecode(await registry.executeTool('large_tool', {}))
+                as Map<String, dynamic>;
+
+        expect(result['success'], isTrue);
+        expect(result['type'], 'tool_reference');
+        expect(result['tool_name'], 'large_tool');
+        expect(result['total_chars'], largeResult.length);
+        final referenceId = result['reference_id'] as String;
+
+        final page =
+            jsonDecode(
+                  await registry.executeTool(ToolReferenceStore.readToolName, {
+                    'reference_id': referenceId,
+                    'offset': 0,
+                    'limit': 64,
+                  }),
+                )
+                as Map<String, dynamic>;
+
+        expect(page['success'], isTrue);
+        expect(page['content'], largeResult.substring(0, 64));
+        expect(page['has_more'], isTrue);
+        expect(page['next_offset'], 64);
+
+        final search =
+            jsonDecode(
+                  await registry
+                      .executeTool(ToolReferenceStore.searchToolName, {
+                        'reference_id': referenceId,
+                        'query': 'needle',
+                        'limit': 2,
+                        'context_chars': 8,
+                      }),
+                )
+                as Map<String, dynamic>;
+
+        expect(search['success'], isTrue);
+        expect(search['matches'], hasLength(2));
+        expect(search['matches'][0]['preview'], contains('needle'));
+      },
+    );
+
+    test('reference tools are registered in the shared tool list', () {
+      final registry = ToolRegistry(MockDistingCubit());
+      final names = registry.entries.map((entry) => entry.name).toSet();
+
+      expect(names, contains(ToolReferenceStore.readToolName));
+      expect(names, contains(ToolReferenceStore.searchToolName));
+    });
+  });
+}

--- a/test/mcp/tools/algorithm_tools_audit_test.dart
+++ b/test/mcp/tools/algorithm_tools_audit_test.dart
@@ -459,14 +459,14 @@ void main() {
     });
   });
 
-  group('showSlot — pagination', () {
-    test('returns first page with default offset/limit', () async {
+  group('showSlot — result sizing', () {
+    test('returns all parameters by default', () async {
       final result = await algoTools.showSlot(0);
       final json = jsonDecode(result) as Map<String, dynamic>;
 
       expect(json['parameter_count'], equals(3));
       expect(json['offset'], equals(0));
-      expect(json['limit'], equals(10));
+      expect(json['limit'], equals(3));
       expect(json['has_more'], isFalse);
       expect((json['parameters'] as List).length, equals(3));
     });

--- a/test/services/settings_service_test.dart
+++ b/test/services/settings_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/chat/models/allowed_file_root.dart';
 import 'package:nt_helper/chat/models/chat_settings.dart';
 import 'package:nt_helper/services/settings_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -39,6 +40,9 @@ const Map<String, Object> _nonDefaultSeeds = {
   'openai_subscription_model': 'fake-openai-subscription-model',
   'openai_base_url': 'https://example.invalid/v1',
   'allow_codex_auth_refresh': true,
+  'chat_local_directory': '/tmp/nt-helper-chat-workspace',
+  'allowed_file_roots':
+      '[{"id":"seed","label":"Seed","path":"/tmp/seed","acl":{"chat":["read"],"mcp":["search"]}}]',
   'ui_scale': 1.4,
   'auto_center_on_selection': false,
   'show_backward_connections': false,
@@ -104,6 +108,8 @@ void main() {
           settings.allowCodexAuthRefresh,
           isNot(SettingsService.defaultAllowCodexAuthRefresh),
         );
+        expect(settings.chatLocalDirectory, isNotNull);
+        expect(settings.allowedFileRoots, isNotEmpty);
 
         await settings.resetToDefaults();
 
@@ -176,6 +182,8 @@ void main() {
           settings.allowCodexAuthRefresh,
           SettingsService.defaultAllowCodexAuthRefresh,
         );
+        expect(settings.chatLocalDirectory, isNull);
+        expect(settings.allowedFileRoots, isEmpty);
         expect(settings.dismissedUpdateVersion, isNull);
         expect(settings.lastUpdateCheckTimestamp, isNull);
         expect(settings.uiScale, SettingsService.defaultUiScale);
@@ -221,6 +229,91 @@ void main() {
         expect(settings.uiScaleNotifier.value, SettingsService.defaultUiScale);
       },
     );
+  });
+
+  group('SettingsService.allowedFileRoots', () {
+    late SettingsService settings;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      settings = SettingsService();
+      await settings.init();
+    });
+
+    test('migrates legacy chat local directory as chat read/search', () async {
+      SharedPreferences.setMockInitialValues({
+        'chat_local_directory': '/Volumes/DistingSD',
+      });
+      await settings.init();
+
+      final roots = settings.allowedFileRoots;
+
+      expect(roots, hasLength(1));
+      expect(roots.single.id, 'local_context');
+      expect(roots.single.label, 'Local Context');
+      expect(roots.single.path, '/Volumes/DistingSD');
+      expect(
+        roots.single.permissionsFor(FileRootActor.chat),
+        containsAll({FileRootPermission.read, FileRootPermission.search}),
+      );
+      expect(roots.single.permissionsFor(FileRootActor.mcp), isEmpty);
+    });
+
+    test('saves and loads ACL permissions', () async {
+      await settings.setAllowedFileRoots([
+        const AllowedFileRoot(
+          id: 'sd',
+          label: 'SD Card',
+          path: '/Volumes/DistingSD',
+          acl: {
+            FileRootActor.chat: {
+              FileRootPermission.read,
+              FileRootPermission.search,
+            },
+            FileRootActor.mcp: {FileRootPermission.read},
+          },
+        ),
+      ]);
+
+      final roots = settings.allowedFileRoots;
+
+      expect(roots, hasLength(1));
+      expect(roots.single.id, 'sd');
+      expect(
+        roots.single.permissionsFor(FileRootActor.chat),
+        containsAll({FileRootPermission.read, FileRootPermission.search}),
+      );
+      expect(roots.single.permissionsFor(FileRootActor.mcp), {
+        FileRootPermission.read,
+      });
+    });
+
+    test('saving allowed roots clears the legacy directory key', () async {
+      SharedPreferences.setMockInitialValues({
+        'chat_local_directory': '/Volumes/DistingSD',
+      });
+      await settings.init();
+      expect(settings.allowedFileRoots, isNotEmpty);
+
+      await settings.setAllowedFileRoots(const []);
+
+      expect(settings.chatLocalDirectory, isNull);
+      expect(settings.allowedFileRoots, isEmpty);
+    });
+
+    test('malformed stored root entries are ignored safely', () async {
+      SharedPreferences.setMockInitialValues({
+        'allowed_file_roots':
+            '[{"id":7,"label":"Bad","path":"/tmp/bad","acl":{"chat":["read"]}},'
+            '{"id":"ok","label":"OK","path":"/tmp/ok","acl":{"chat":["read"]}}]',
+      });
+      await settings.init();
+
+      final roots = settings.allowedFileRoots;
+
+      expect(roots, hasLength(1));
+      expect(roots.single.id, 'ok');
+    });
   });
 
   group('SettingsDialog routing visibility settings', () {

--- a/test/ui/cpu_monitor_widget_test.dart
+++ b/test/ui/cpu_monitor_widget_test.dart
@@ -1,0 +1,101 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/cubit/disting_cubit.dart';
+import 'package:nt_helper/domain/i_disting_midi_manager.dart';
+import 'package:nt_helper/models/cpu_usage.dart';
+import 'package:nt_helper/models/firmware_version.dart';
+import 'package:nt_helper/services/settings_service.dart';
+import 'package:nt_helper/ui/cpu_monitor_widget.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockDistingCubit extends Mock implements DistingCubit {}
+
+class _MockDistingMidiManager extends Mock implements IDistingMidiManager {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockDistingCubit cubit;
+  late StreamController<DistingState> stateController;
+  late StreamController<CpuUsage?> cpuUsageController;
+
+  DistingStateSynchronized synchronizedState() {
+    return DistingStateSynchronized(
+      disting: _MockDistingMidiManager(),
+      distingVersion: 'NT',
+      firmwareVersion: FirmwareVersion('1.10'),
+      presetName: 'Test',
+      algorithms: const [],
+      slots: const [],
+      unitStrings: const [],
+    );
+  }
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SettingsService().init();
+
+    cubit = _MockDistingCubit();
+    stateController = StreamController<DistingState>.broadcast();
+    cpuUsageController = StreamController<CpuUsage?>.broadcast();
+
+    when(() => cubit.state).thenReturn(synchronizedState());
+    when(() => cubit.stream).thenAnswer((_) => stateController.stream);
+    when(
+      () => cubit.cpuUsageStream,
+    ).thenAnswer((_) => cpuUsageController.stream);
+    when(() => cubit.resumeCpuMonitoring()).thenReturn(null);
+    when(() => cubit.pauseCpuMonitoring()).thenReturn(null);
+  });
+
+  tearDown(() async {
+    await stateController.close();
+    await cpuUsageController.close();
+  });
+
+  testWidgets('uses static placeholder before first CPU sample', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BlocProvider<DistingCubit>.value(
+            value: cubit,
+            child: const CpuMonitorWidget(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('--% | --%'), findsOneWidget);
+  });
+
+  testWidgets('keeps last CPU sample across null updates', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BlocProvider<DistingCubit>.value(
+            value: cubit,
+            child: const CpuMonitorWidget(),
+          ),
+        ),
+      ),
+    );
+
+    cpuUsageController.add(CpuUsage(cpu1: 12, cpu2: 34, slotUsages: const []));
+    await tester.pump();
+
+    expect(find.text('12% | 34%'), findsOneWidget);
+
+    cpuUsageController.add(null);
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('12% | 34%'), findsOneWidget);
+  });
+}

--- a/test/ui/cpu_monitor_widget_test.dart
+++ b/test/ui/cpu_monitor_widget_test.dart
@@ -98,4 +98,35 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsNothing);
     expect(find.text('12% | 34%'), findsOneWidget);
   });
+
+  testWidgets('pauses and hides while chat panel is open', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BlocProvider<DistingCubit>.value(
+            value: cubit,
+            child: const CpuMonitorWidget(),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('--% | --%'), findsOneWidget);
+    verify(() => cubit.resumeCpuMonitoring()).called(1);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BlocProvider<DistingCubit>.value(
+            value: cubit,
+            child: const CpuMonitorWidget(paused: true),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('--% | --%'), findsNothing);
+    expect(find.byType(CpuMonitorWidget), findsOneWidget);
+    verify(() => cubit.pauseCpuMonitoring()).called(1);
+  });
 }

--- a/test/ui/widgets/parameter_editor_view_test.dart
+++ b/test/ui/widgets/parameter_editor_view_test.dart
@@ -189,6 +189,42 @@ void main() {
       expect(parameterViewRow.displayString, isNull);
     });
 
+    testWidgets('Looper decay time keeps unit 16 firmware ms value string', (
+      tester,
+    ) async {
+      final slot = createTestSlot(
+        algorithmIndex: 0,
+        unit: ParameterUnits.modernHasStrings,
+        currentValue: 500,
+        valueString: '500 ms',
+        enumValues: [],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ParameterEditorView(
+              slot: slot,
+              parameterInfo: slot.parameters[0],
+              value: slot.values[0],
+              enumStrings: slot.enums[0],
+              mapping: slot.mappings[0],
+              valueString: slot.valueStrings[0],
+              unit: null,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final parameterViewRow = tester.widget<ParameterViewRow>(
+        find.byType(ParameterViewRow),
+      );
+      expect(parameterViewRow.displayString, equals('500 ms'));
+      expect(parameterViewRow.unit, isNull);
+    });
+
     testWidgets('Complete enum strings are passed as dropdown items', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- add chat attachment support, allowed file roots, and ACL-backed local file tooling
- add context status controls, provider-specific context window resolution, and safer compaction behavior
- add `algorithm_info` plus generic `tool_reference`, `read_reference`, and `search_reference` handling across chat and MCP tools
- simplify attachment actions and polish the parameter action button spacing

## Why

This brings the useful forked AI-chat functionality into the current shape without copying the oversized tool surface. File access is constrained by allowed roots and permissions, large tool responses are paged/searchable by reference, and context accounting now tracks provider metadata and cache-token usage more accurately.

## Validation

- `flutter analyze`
- focused chat/MCP harness tests
- full `flutter test` (`2679` tests passed)
