### PR TITLE
fix(gallery): load all plugins in paginated batches

### DIFF
--- a/lib/services/gallery_service.dart
+++ b/lib/services/gallery_service.dart
@@ -16,9 +16,15 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:nt_helper/utils/build_config.dart';
 
 /// GraphQL queries for the gallery
+const int _galleryPluginPageSize = 50;
+
 const String _getPluginsQuery = r'''
-  query GetPlugins($filter: PluginFilterInput) {
-    plugins(filter: $filter) {
+  query GetPlugins(
+    $filter: PluginFilterInput
+    $limit: Int!
+    $offset: Int!
+  ) {
+    plugins(filter: $filter, limit: $limit, offset: $offset) {
       slug
       name
       description
@@ -381,41 +387,54 @@ class GalleryService {
   /// Fetch plugins via GraphQL API
   Future<List<dynamic>> _fetchPluginsViaGraphQL() async {
     final endpoint = graphqlEndpoint;
+    final plugins = <dynamic>[];
+    var offset = 0;
 
-    final response = await http
-        .post(
-          Uri.parse(endpoint),
-          headers: {
-            'Content-Type': 'application/json; charset=utf-8',
-            'Accept': 'application/json; charset=utf-8',
-            'Accept-Charset': 'utf-8',
-            'User-Agent': 'Disting-NT-Helper/1.0',
-          },
-          body: json.encode({
-            'query': _getPluginsQuery,
-            'variables': {
-              'filter': {'verified': true},
+    while (true) {
+      final response = await http
+          .post(
+            Uri.parse(endpoint),
+            headers: {
+              'Content-Type': 'application/json; charset=utf-8',
+              'Accept': 'application/json; charset=utf-8',
+              'Accept-Charset': 'utf-8',
+              'User-Agent': 'Disting-NT-Helper/1.0',
             },
-          }),
-        )
-        .timeout(const Duration(seconds: 30));
+            body: json.encode({
+              'query': _getPluginsQuery,
+              'variables': {
+                'filter': {'verified': true},
+                'limit': _galleryPluginPageSize,
+                'offset': offset,
+              },
+            }),
+          )
+          .timeout(const Duration(seconds: 30));
 
-    if (response.statusCode != 200) {
-      throw GalleryException(
-        'GraphQL request failed: HTTP ${response.statusCode}',
-      );
+      if (response.statusCode != 200) {
+        throw GalleryException(
+          'GraphQL request failed: HTTP ${response.statusCode}',
+        );
+      }
+
+      // Explicitly decode as UTF-8 to handle special characters correctly
+      // (http package defaults to latin-1 if charset not specified in headers)
+      final jsonData =
+          json.decode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
+
+      if (jsonData.containsKey('errors')) {
+        throw GalleryException('GraphQL error: ${jsonData['errors']}');
+      }
+
+      final page = jsonData['data']['plugins'] as List<dynamic>;
+      plugins.addAll(page);
+
+      if (page.length < _galleryPluginPageSize) {
+        return plugins;
+      }
+
+      offset += _galleryPluginPageSize;
     }
-
-    // Explicitly decode as UTF-8 to handle special characters correctly
-    // (http package defaults to latin-1 if charset not specified in headers)
-    final jsonData =
-        json.decode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
-
-    if (jsonData.containsKey('errors')) {
-      throw GalleryException('GraphQL error: ${jsonData['errors']}');
-    }
-
-    return jsonData['data']['plugins'] as List<dynamic>;
   }
 
   /// Fetch categories via GraphQL API

--- a/test/services/gallery_service_pagination_test.dart
+++ b/test/services/gallery_service_pagination_test.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/services/gallery_service.dart';
+import 'package:nt_helper/services/settings_service.dart';
+import 'package:nt_helper/utils/app_directory.dart';
+
+class MockSettingsService extends Mock implements SettingsService {}
+
+void main() {
+  group('GalleryService GraphQL pagination', () {
+    late HttpServer server;
+    late StreamSubscription<HttpRequest> serverSubscription;
+    late MockSettingsService settingsService;
+    late List<({int limit, int offset})> pluginPageRequests;
+    late Directory tempRoot;
+    late int totalPlugins;
+
+    setUp(() async {
+      totalPlugins = 120;
+      resetAppDirectoryForTest();
+      tempRoot = Directory.systemTemp.createTempSync(
+        'gallery_service_pagination_test_',
+      );
+      await getAppDirectory(docsProvider: () async => tempRoot);
+
+      pluginPageRequests = [];
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      serverSubscription = server.listen((request) async {
+        final payload =
+            jsonDecode(await utf8.decoder.bind(request).join())
+                as Map<String, dynamic>;
+        final query = payload['query'] as String;
+
+        final Map<String, dynamic> responseBody;
+        if (query.contains('query GetPlugins')) {
+          final variables =
+              payload['variables'] as Map<String, dynamic>? ??
+              const <String, dynamic>{};
+          final limit = variables['limit'] as int? ?? 50;
+          final offset = variables['offset'] as int? ?? 0;
+          pluginPageRequests.add((limit: limit, offset: offset));
+
+          final end = offset + limit < totalPlugins
+              ? offset + limit
+              : totalPlugins;
+          final plugins = offset >= totalPlugins
+              ? <Map<String, dynamic>>[]
+              : [
+                  for (var index = offset; index < end; index++)
+                    {
+                      'slug': 'plugin-$index',
+                      'name': 'Plugin $index',
+                      'pluginType': 'CPP',
+                      'verified': true,
+                    },
+                ];
+
+          responseBody = {
+            'data': {'plugins': plugins},
+          };
+        } else {
+          responseBody = {
+            'data': {'categories': <Map<String, dynamic>>[]},
+          };
+        }
+
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(jsonEncode(responseBody));
+        await request.response.close();
+      });
+
+      settingsService = MockSettingsService();
+      when(
+        () => settingsService.graphqlEndpoint,
+      ).thenReturn('http://${server.address.host}:${server.port}/graphql');
+      when(
+        () => settingsService.galleryUrl,
+      ).thenReturn('https://example.invalid/gallery.json');
+    });
+
+    tearDown(() async {
+      await serverSubscription.cancel();
+      await server.close(force: true);
+      resetAppDirectoryForTest();
+      tempRoot.deleteSync(recursive: true);
+    });
+
+    test('loads every plugin in batches of 50', () async {
+      final service = GalleryService(settingsService: settingsService);
+
+      final gallery = await service.fetchGallery(forceRefresh: true);
+
+      expect(gallery.plugins, hasLength(120));
+      expect(gallery.plugins.first.id, 'plugin-0');
+      expect(gallery.plugins.last.id, 'plugin-119');
+      expect(pluginPageRequests, [
+        (limit: 50, offset: 0),
+        (limit: 50, offset: 50),
+        (limit: 50, offset: 100),
+      ]);
+    });
+
+    test(
+      'stops after an empty page when the total is a multiple of 50',
+      () async {
+        totalPlugins = 100;
+        final service = GalleryService(settingsService: settingsService);
+
+        final gallery = await service.fetchGallery(forceRefresh: true);
+
+        expect(gallery.plugins, hasLength(100));
+        expect(pluginPageRequests, [
+          (limit: 50, offset: 0),
+          (limit: 50, offset: 50),
+          (limit: 50, offset: 100),
+        ]);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- fetch verified gallery plugins from GraphQL in batches of 50
- continue with increasing offsets until the final short page
- cover galleries larger than one page and exact multiples of the page size

## Verification
- `flutter analyze`
- `flutter test` (3,335 tests)
- live GraphQL check: offset 0 returned 50; offset 50 returned 28 and included `nt-grids`