### PR TITLE
fix(ntx-8cv): stabilize settings and audio channel enablement

### DIFF
--- a/docs/ntx_8cv_hardware_validation.md
+++ b/docs/ntx_8cv_hardware_validation.md
@@ -24,7 +24,8 @@ not enter the bootloader or update firmware during this validation.
    select the input and output manually.
 2. Connect. Confirm that the page reaches **Connected** only after device
    information arrives, then records device-confirmed values for ES-5, Channel
-   Group, and (when supported) Mode.
+   Group, every individual audio-channel enable setting (1 through 8), and
+   (when supported) Mode.
 3. Change the persistent device ID to another valid value, reconnect, and
    confirm that the chosen ID is retained. Restore the actual device ID before
    continuing.
@@ -38,18 +39,25 @@ not enter the bootloader or update firmware during this validation.
 
 1. Set Channel Group to a different available eight-channel block. Confirm the
    page reports that exact value as device-confirmed only after the readback.
-   Confirm its explanation says this does not replace the disting NT's granular
-   channel-enable controls.
+   Confirm its explanation says this does not replace individual NTX-8CV
+   audio-channel enablement or alter disting NT algorithm routing.
 2. Toggle ES-5. Confirm the changed value becomes device-confirmed only after
    the readback and the page does not say an ES-5 change requires a reboot.
-3. With ES-5 enabled, select each Mode in turn: **8x8 CV**, **1x8 32bit
+3. In **1x8 32bit Audio** and **2x8 16bit Audio** modes, verify that all eight
+   **Audio channel** controls show the corresponding device state. Enable and
+   disable at least two different channels. For each, confirm only the selected
+   channel changes, the attempted value is not shown as confirmed until the
+   same channel/value is read back, and no external configurator is required.
+   In **8x8 CV** mode, confirm the eight controls remain visible but say that
+   audio-channel enablement is inapplicable and do not offer ineffective writes.
+4. With ES-5 enabled, select each Mode in turn: **8x8 CV**, **1x8 32bit
    Audio**, and **2x8 16bit Audio**. For every selection, confirm the mode is
    device-confirmed after readback, ES-5 remains enabled and available, and the
    page reports that an NTX-8CV reboot is required.
-4. If Mode is not exposed by the connected firmware, confirm Mode writes stay
+5. If Mode is not exposed by the connected firmware, confirm Mode writes stay
    disabled and the page says capability was not evidenced. Record this as a
    firmware/capability finding, not as a proof that the firmware is unsupported.
-5. For a recovery check where practical, interrupt a setting write by removing
+6. For a recovery check where practical, interrupt a setting write by removing
    the NTX-8CV connection before readback. Confirm the attempted value remains
    pending/failed, the last device-confirmed value remains visible when known,
    and the page labels the actual device state uncertain. Reconnect without
@@ -61,9 +69,13 @@ not enter the bootloader or update firmware during this validation.
 1. With a confirmed Mode change pending a reboot, activate **Reboot NTX-8CV**
    once. Confirm there is no confirmation dialog.
 2. Confirm only the selected NTX-8CV restarts. The add-on must reacquire its
-   endpoints, validate device information again, then refresh ES-5, Mode, and
-   Channel Group.
-3. Confirm the refreshed values match the device and that the Mode reboot
+   endpoints, validate device information again, then refresh ES-5, Mode,
+   Channel Group, and all eight audio-channel enable settings.
+3. Change one audio-channel enable state with another controller while the
+   add-on is connected, then use the page's refresh action. Confirm the page
+   reads and shows the hardware state without resending any pending or prior
+   value. Repeat after reconnect if practical.
+4. Confirm the refreshed values match the device and that the Mode reboot
    requirement is cleared. Confirm no retained pending/failed setting was sent
    automatically during reconnect or refresh.
 
@@ -81,6 +93,7 @@ Record one result for each platform tested:
 | Connection and settings-read result | pass / fail |
 | Channel Group result | pass / fail |
 | ES-5 result in all three Modes | pass / fail / Mode not evidenced |
+| Individual audio-channel enable/readback result | pass / fail / not applicable |
 | Failed-write, reconnect, and Retry send result | pass / not practical / fail |
 | Reboot, revalidation, and refresh result | pass / fail |
 | Disting NT remained independently connected | pass / fail |

--- a/docs/ntx_8cv_hardware_validation.md
+++ b/docs/ntx_8cv_hardware_validation.md
@@ -1,0 +1,92 @@
+# NTX-8CV end-of-development hardware validation
+
+Use this checklist with an NTX-8CV, a disting NT, and separate USB connections
+for both modules. It records the manual evidence required to accept the
+NTX-8CV add-on; it is not a prerequisite for fixture-driven development.
+
+Do not use the **Any** SysEx address (`127`) as the persistent device ID. Do
+not enter the bootloader or update firmware during this validation.
+
+## Setup
+
+1. Start the nt_helper build under test on one supported platform.
+2. Connect the NTX-8CV and disting NT through their own USB MIDI connections.
+3. Open **More options → Add-ons → NTX-8CV**.
+4. Record the platform, nt_helper build identity, the selected endpoint names,
+   and the chosen persistent SysEx device ID (`0` through `126`). Firmware and
+   serial text shown by the device-information exchange are opaque text; record
+   them verbatim only when sharing them is appropriate.
+
+## Connection and reads
+
+1. With exactly one input and one output endpoint advertised as `NTX-8CV`,
+   confirm that both are preselected. If discovery is unavailable or ambiguous,
+   select the input and output manually.
+2. Connect. Confirm that the page reaches **Connected** only after device
+   information arrives, then records device-confirmed values for ES-5, Channel
+   Group, and (when supported) Mode.
+3. Change the persistent device ID to another valid value, reconnect, and
+   confirm that the chosen ID is retained. Restore the actual device ID before
+   continuing.
+4. Disconnect the NTX-8CV USB cable, confirm the disconnected state, reconnect
+   it, and confirm the endpoints reappear without an automatic connection or
+   write.
+5. Verify that the disting NT remains independently connected and is not
+   rebooted or sent NTX-8CV configuration commands.
+
+## Immediate-write and confirmation behavior
+
+1. Set Channel Group to a different available eight-channel block. Confirm the
+   page reports that exact value as device-confirmed only after the readback.
+   Confirm its explanation says this does not replace the disting NT's granular
+   channel-enable controls.
+2. Toggle ES-5. Confirm the changed value becomes device-confirmed only after
+   the readback and the page does not say an ES-5 change requires a reboot.
+3. With ES-5 enabled, select each Mode in turn: **8x8 CV**, **1x8 32bit
+   Audio**, and **2x8 16bit Audio**. For every selection, confirm the mode is
+   device-confirmed after readback, ES-5 remains enabled and available, and the
+   page reports that an NTX-8CV reboot is required.
+4. If Mode is not exposed by the connected firmware, confirm Mode writes stay
+   disabled and the page says capability was not evidenced. Record this as a
+   firmware/capability finding, not as a proof that the firmware is unsupported.
+5. For a recovery check where practical, interrupt a setting write by removing
+   the NTX-8CV connection before readback. Confirm the attempted value remains
+   pending/failed, the last device-confirmed value remains visible when known,
+   and the page labels the actual device state uncertain. Reconnect without
+   changing the selected target, confirm no automatic retry occurs, then use
+   **Retry send** and confirm matching readback clears the pending state.
+
+## Reboot and refresh
+
+1. With a confirmed Mode change pending a reboot, activate **Reboot NTX-8CV**
+   once. Confirm there is no confirmation dialog.
+2. Confirm only the selected NTX-8CV restarts. The add-on must reacquire its
+   endpoints, validate device information again, then refresh ES-5, Mode, and
+   Channel Group.
+3. Confirm the refreshed values match the device and that the Mode reboot
+   requirement is cleared. Confirm no retained pending/failed setting was sent
+   automatically during reconnect or refresh.
+
+## Result record
+
+Record one result for each platform tested:
+
+| Field | Value |
+| --- | --- |
+| Date and tester | |
+| Platform and OS version | |
+| nt_helper build/commit | |
+| NTX-8CV endpoint names and persistent device ID | |
+| Firmware/serial text, if retained | |
+| Connection and settings-read result | pass / fail |
+| Channel Group result | pass / fail |
+| ES-5 result in all three Modes | pass / fail / Mode not evidenced |
+| Failed-write, reconnect, and Retry send result | pass / not practical / fail |
+| Reboot, revalidation, and refresh result | pass / fail |
+| Disting NT remained independently connected | pass / fail |
+| Notes and defects | |
+
+A failure or unexpected device behavior is acceptance-blocking until its cause
+is recorded and corrected. Preserve the completed record with the release or
+project evidence; physical validation is a final acceptance activity, not a
+requirement to begin or continue automated development.

--- a/docs/ntx_8cv_protocol.md
+++ b/docs/ntx_8cv_protocol.md
@@ -1,0 +1,38 @@
+# NTX-8CV SysEx protocol foundation
+
+`lib/domain/ntx_8cv/ntx_8cv_sysex.dart` is the dedicated NTX-8CV codec and
+single-device session. It is deliberately separate from the disting NT SysEx
+implementation: NTX-8CV frames use product byte `0x6A`, while the disting NT
+uses `0x6D`.
+
+## Documented frame forms
+
+All frames start with `F0 00 21 27 6A <device-id>` and end with `F7`.
+
+| Operation | Direction | Body after device ID |
+| --- | --- | --- |
+| Device information | host to device | `22` |
+| Device information response | device to host | `32 <NUL-terminated opaque ASCII fields>` |
+| Read setting | host to device | `31 <setting-id>` |
+| Setting response | device to host | `31 <setting-id> <value>` |
+| Write setting | host to device | `32 <setting-id> <value>` |
+| Reboot | host to device | `7F` |
+
+The protocol defines neither a checksum nor a setting-write acknowledgement.
+`Ntx8cvSession.writeAndConfirmSetting` therefore writes, reads the same
+setting, and succeeds only when the returned setting ID and value match. It
+never retries automatically. Session timeout is an injected implementation
+choice, not a manufacturer protocol claim.
+
+## Fixture-driven development
+
+`test/fixtures/ntx_8cv_sysex_fixtures.dart` holds deterministic frames used by
+`test/domain/ntx_8cv/ntx_8cv_sysex_test.dart`. The fixture firmware and serial
+strings are opaque sample text; they do not assert a device-version grammar or
+represent captured hardware data. The suite covers framing, response parsing,
+malformed input, selected-device matching, matching and mismatched readback,
+and a configurable no-response timeout without requiring an NTX-8CV.
+
+Physical hardware is not a prerequisite for feature development. When a task
+would materially benefit from an on-device result, request temporary NTX-8CV
+access from the product owner and retain the resulting validation evidence.

--- a/docs/ntx_8cv_protocol.md
+++ b/docs/ntx_8cv_protocol.md
@@ -24,6 +24,29 @@ setting, and succeeds only when the returned setting ID and value match. It
 never retries automatically. Session timeout is an injected implementation
 choice, not a manufacturer protocol claim.
 
+## Released audio-channel enable settings
+
+The released Expert Sleepers NTX-8CV configuration tool available for this
+follow-up identifies **Enable audio channel** controls 1 through 8 as boolean
+settings `0x04` through `0x0B`, in ascending channel order. Each setting uses
+`0` for disabled and `1` for enabled. This evidence is distinct from Channel
+Group (`0x00`), which selects an eight-channel block and is not a per-channel
+enable flag.
+
+nt_helper reads all eight audio-channel settings after identity validation and
+on a user-requested settings refresh. The controls are applicable only when a
+device-confirmed Mode is **1x8 32bit Audio** or **2x8 16bit Audio**; in **8x8
+CV** mode they remain visible but unavailable with an explanation. A write is
+still confirmed only by a matching read of the same channel setting.
+
+The setting IDs and boolean encoding were audited against the local released
+configuration-tool source, `ntx8cv_config_tool.html`: its Settings panel
+creates the eight controls with `settings.push([..., 4+i, setBool])`, labels
+them “Enable audio channel”, reads them with `0x31`, and writes them with
+`0x32`. They are also captured in the checked-in deterministic fixtures. No
+Channel Group value, inferred lane count, or disting NT algorithm parameter is
+used as a substitute.
+
 ## Fixture-driven development
 
 `test/fixtures/ntx_8cv_sysex_fixtures.dart` holds deterministic frames used by
@@ -31,7 +54,10 @@ choice, not a manufacturer protocol claim.
 strings are opaque sample text; they do not assert a device-version grammar or
 represent captured hardware data. The suite covers framing, response parsing,
 malformed input, selected-device matching, matching and mismatched readback,
-and a configurable no-response timeout without requiring an NTX-8CV.
+and a configurable no-response timeout without requiring an NTX-8CV. The
+fixtures also cover the released first audio-channel enable setting; cubit
+coverage exercises all eight setting IDs, individual writes, mismatched
+readback, timeout/uncertain state, refresh, reconnect, and reboot reacquisition.
 
 Physical hardware is not a prerequisite for feature development. When a task
 would materially benefit from an on-device result, request temporary NTX-8CV

--- a/lib/cubit/ntx_8cv_connection_cubit.dart
+++ b/lib/cubit/ntx_8cv_connection_cubit.dart
@@ -110,6 +110,7 @@ class Ntx8cvConnectionCubit extends Cubit<Ntx8cvConnectionState> {
     Ntx8cvMidiConnection? midiConnection,
     Ntx8cvConnectionStore? store,
     this.sessionTimeout = const Duration(seconds: 1),
+    this.rebootReconnectDelay = const Duration(seconds: 1),
   }) : _midiConnection = midiConnection ?? NativeNtx8cvMidiConnection(),
        _store = store ?? SharedPreferencesNtx8cvConnectionStore(),
        super(const Ntx8cvConnectionState());
@@ -117,6 +118,11 @@ class Ntx8cvConnectionCubit extends Cubit<Ntx8cvConnectionState> {
   final Ntx8cvMidiConnection _midiConnection;
   final Ntx8cvConnectionStore _store;
   final Duration sessionTimeout;
+
+  /// Waits briefly for the selected device to restart before its endpoints are
+  /// reacquired. It is configurable so fixture-based tests do not need a
+  /// physical NTX-8CV reboot delay.
+  final Duration rebootReconnectDelay;
   StreamSubscription<MidiSetupChange>? _setupSubscription;
   Ntx8cvMidiTransport? _transport;
   Ntx8cvSession? _session;
@@ -370,6 +376,79 @@ class Ntx8cvConnectionCubit extends Cubit<Ntx8cvConnectionState> {
         );
       }
     }
+  }
+
+  /// Reboots only the current identity-validated NTX-8CV, then reacquires its
+  /// selected endpoints and validates a fresh device-information response.
+  ///
+  /// The protocol has no reboot acknowledgement. A `true` result means the
+  /// command was sent and the selected target subsequently reconnected and
+  /// passed identity validation. This never sends the reboot command again.
+  Future<bool> rebootAndReconnect() async {
+    final session = _session;
+    if (!state.isConnected || session == null) return false;
+
+    emit(
+      state.copyWith(
+        status: Ntx8cvConnectionStatus.connecting,
+        statusMessage: 'Rebooting the selected NTX-8CV, then reconnecting.',
+        clearDeviceInformation: true,
+      ),
+    );
+
+    try {
+      await session.reboot();
+    } catch (_) {
+      await _closeActiveConnection();
+      if (!isClosed) {
+        emit(
+          state.copyWith(
+            status: Ntx8cvConnectionStatus.failed,
+            statusMessage:
+                'Could not send the reboot command to the selected NTX-8CV.',
+            clearDeviceInformation: true,
+          ),
+        );
+      }
+      return false;
+    }
+
+    // The command is scoped to the session that was created for the selected
+    // endpoint pair and device ID. Do not continue if another action replaced
+    // that session while the send was in flight.
+    if (!identical(_session, session)) return false;
+
+    await _closeActiveConnection();
+    if (isClosed) return false;
+    emit(
+      state.copyWith(
+        status: Ntx8cvConnectionStatus.disconnected,
+        statusMessage: 'Reacquiring the selected NTX-8CV after reboot.',
+        clearDeviceInformation: true,
+      ),
+    );
+
+    if (rebootReconnectDelay > Duration.zero) {
+      await Future<void>.delayed(rebootReconnectDelay);
+    }
+    if (isClosed) return false;
+
+    await refreshEndpoints();
+    if (!state.canConnect) {
+      emit(
+        state.copyWith(
+          status: Ntx8cvConnectionStatus.failed,
+          statusMessage:
+              'Could not reacquire the selected NTX-8CV after reboot. Check '
+              'its MIDI endpoints and reconnect it.',
+          clearDeviceInformation: true,
+        ),
+      );
+      return false;
+    }
+
+    await connect();
+    return state.isConnected;
   }
 
   Future<void> disconnect() async {

--- a/lib/cubit/ntx_8cv_connection_cubit.dart
+++ b/lib/cubit/ntx_8cv_connection_cubit.dart
@@ -175,6 +175,7 @@ class Ntx8cvConnectionCubit extends Cubit<Ntx8cvConnectionState> {
 
   /// Refreshes the available input and output endpoint lists.
   Future<void> refreshEndpoints() async {
+    if (!isClosed) emit(state.copyWith(isLoadingEndpoints: true));
     try {
       final devices = await _midiConnection.listDevices();
       final inputDevices =

--- a/lib/cubit/ntx_8cv_connection_cubit.dart
+++ b/lib/cubit/ntx_8cv_connection_cubit.dart
@@ -1,0 +1,495 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:flutter_midi_command/flutter_midi_command.dart';
+import 'package:nt_helper/domain/ntx_8cv/ntx_8cv_midi_connection.dart';
+import 'package:nt_helper/domain/ntx_8cv/ntx_8cv_sysex.dart';
+
+/// The connection phases shown by the independent NTX-8CV add-on.
+enum Ntx8cvConnectionStatus { disconnected, connecting, connected, failed }
+
+extension on Ntx8cvConnectionStatus {
+  String get label => switch (this) {
+    Ntx8cvConnectionStatus.disconnected => 'Disconnected',
+    Ntx8cvConnectionStatus.connecting => 'Connecting',
+    Ntx8cvConnectionStatus.connected => 'Connected',
+    Ntx8cvConnectionStatus.failed => 'Failed',
+  };
+}
+
+/// Immutable presentation state for the NTX-8CV endpoint connection.
+class Ntx8cvConnectionState {
+  const Ntx8cvConnectionState({
+    this.inputDevices = const [],
+    this.outputDevices = const [],
+    this.selectedInputDevice,
+    this.selectedOutputDevice,
+    this.deviceId = 0,
+    this.deviceIdText = '0',
+    this.deviceIdError,
+    this.status = Ntx8cvConnectionStatus.disconnected,
+    this.statusMessage,
+    this.deviceInformation,
+    this.isLoadingEndpoints = true,
+  });
+
+  final List<MidiDevice> inputDevices;
+  final List<MidiDevice> outputDevices;
+  final MidiDevice? selectedInputDevice;
+  final MidiDevice? selectedOutputDevice;
+  final int deviceId;
+  final String deviceIdText;
+  final String? deviceIdError;
+  final Ntx8cvConnectionStatus status;
+  final String? statusMessage;
+  final Ntx8cvDeviceInformation? deviceInformation;
+  final bool isLoadingEndpoints;
+
+  bool get isConnected => status == Ntx8cvConnectionStatus.connected;
+  bool get isConnecting => status == Ntx8cvConnectionStatus.connecting;
+  bool get canConnect =>
+      !isLoadingEndpoints &&
+      !isConnecting &&
+      selectedInputDevice != null &&
+      selectedOutputDevice != null &&
+      deviceIdError == null;
+
+  String get statusLabel => status.label;
+
+  Ntx8cvConnectionState copyWith({
+    List<MidiDevice>? inputDevices,
+    List<MidiDevice>? outputDevices,
+    MidiDevice? selectedInputDevice,
+    bool clearSelectedInputDevice = false,
+    MidiDevice? selectedOutputDevice,
+    bool clearSelectedOutputDevice = false,
+    int? deviceId,
+    String? deviceIdText,
+    String? deviceIdError,
+    bool clearDeviceIdError = false,
+    Ntx8cvConnectionStatus? status,
+    String? statusMessage,
+    bool clearStatusMessage = false,
+    Ntx8cvDeviceInformation? deviceInformation,
+    bool clearDeviceInformation = false,
+    bool? isLoadingEndpoints,
+  }) {
+    return Ntx8cvConnectionState(
+      inputDevices: inputDevices ?? this.inputDevices,
+      outputDevices: outputDevices ?? this.outputDevices,
+      selectedInputDevice: clearSelectedInputDevice
+          ? null
+          : selectedInputDevice ?? this.selectedInputDevice,
+      selectedOutputDevice: clearSelectedOutputDevice
+          ? null
+          : selectedOutputDevice ?? this.selectedOutputDevice,
+      deviceId: deviceId ?? this.deviceId,
+      deviceIdText: deviceIdText ?? this.deviceIdText,
+      deviceIdError: clearDeviceIdError
+          ? null
+          : deviceIdError ?? this.deviceIdError,
+      status: status ?? this.status,
+      statusMessage: clearStatusMessage
+          ? null
+          : statusMessage ?? this.statusMessage,
+      deviceInformation: clearDeviceInformation
+          ? null
+          : deviceInformation ?? this.deviceInformation,
+      isLoadingEndpoints: isLoadingEndpoints ?? this.isLoadingEndpoints,
+    );
+  }
+}
+
+/// Owns NTX-8CV endpoint discovery, identity validation, and connection state.
+///
+/// It is intentionally independent from [DistingCubit]. It opens only the
+/// selected NTX-8CV endpoints and creates a session scoped to their selected
+/// SysEx device ID.
+class Ntx8cvConnectionCubit extends Cubit<Ntx8cvConnectionState> {
+  Ntx8cvConnectionCubit({
+    Ntx8cvMidiConnection? midiConnection,
+    Ntx8cvConnectionStore? store,
+    this.sessionTimeout = const Duration(seconds: 1),
+  }) : _midiConnection = midiConnection ?? NativeNtx8cvMidiConnection(),
+       _store = store ?? SharedPreferencesNtx8cvConnectionStore(),
+       super(const Ntx8cvConnectionState());
+
+  final Ntx8cvMidiConnection _midiConnection;
+  final Ntx8cvConnectionStore _store;
+  final Duration sessionTimeout;
+  StreamSubscription<MidiSetupChange>? _setupSubscription;
+  Ntx8cvMidiTransport? _transport;
+  Ntx8cvSession? _session;
+  MidiDevice? _activeInputDevice;
+  MidiDevice? _activeOutputDevice;
+  String? _desiredInputDeviceName;
+  String? _desiredInputDeviceId;
+  String? _desiredOutputDeviceName;
+  String? _desiredOutputDeviceId;
+  bool _initialized = false;
+
+  /// The session for the currently identity-validated NTX-8CV, if any.
+  ///
+  /// Later settings operations can only use this session while [state] is
+  /// connected, keeping all commands scoped to the selected endpoints and ID.
+  Ntx8cvSession? get session => state.isConnected ? _session : null;
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+    _initialized = true;
+    try {
+      final saved = await _store.load();
+      _desiredInputDeviceName = saved.inputDeviceName;
+      _desiredInputDeviceId = saved.inputDeviceId;
+      _desiredOutputDeviceName = saved.outputDeviceName;
+      _desiredOutputDeviceId = saved.outputDeviceId;
+      emit(
+        state.copyWith(
+          deviceId: saved.deviceId,
+          deviceIdText: '${saved.deviceId}',
+          clearDeviceIdError: true,
+        ),
+      );
+      _setupSubscription = _midiConnection.setupChanges?.listen((_) {
+        unawaited(refreshEndpoints());
+      });
+      await refreshEndpoints();
+    } catch (_) {
+      emit(
+        state.copyWith(
+          status: Ntx8cvConnectionStatus.failed,
+          statusMessage:
+              'Could not load NTX-8CV MIDI endpoints. Refresh and try again.',
+          isLoadingEndpoints: false,
+          clearDeviceInformation: true,
+        ),
+      );
+    }
+  }
+
+  /// Refreshes the available input and output endpoint lists.
+  Future<void> refreshEndpoints() async {
+    try {
+      final devices = await _midiConnection.listDevices();
+      final inputDevices =
+          devices.where((device) => device.inputPorts.isNotEmpty).toList()
+            ..sort(_compareDevices);
+      final outputDevices =
+          devices.where((device) => device.outputPorts.isNotEmpty).toList()
+            ..sort(_compareDevices);
+
+      var inputDevice = _resolveSavedDevice(
+        inputDevices,
+        deviceId: _desiredInputDeviceId,
+        deviceName: _desiredInputDeviceName,
+      );
+      var outputDevice = _resolveSavedDevice(
+        outputDevices,
+        deviceId: _desiredOutputDeviceId,
+        deviceName: _desiredOutputDeviceName,
+      );
+
+      if (inputDevice == null &&
+          outputDevice == null &&
+          _hasNoSavedEndpointPreference) {
+        final automaticInput = _singleNtx8cvEndpoint(inputDevices);
+        final automaticOutput = _singleNtx8cvEndpoint(outputDevices);
+        if (automaticInput != null && automaticOutput != null) {
+          inputDevice = automaticInput;
+          outputDevice = automaticOutput;
+          _rememberInputDevice(inputDevice);
+          _rememberOutputDevice(outputDevice);
+          unawaited(_persistSelection());
+        }
+      }
+
+      final activeTargetIsMissing =
+          _transport != null && (inputDevice == null || outputDevice == null);
+      if (activeTargetIsMissing) {
+        await _closeActiveConnection();
+      }
+
+      emit(
+        state.copyWith(
+          inputDevices: List.unmodifiable(inputDevices),
+          outputDevices: List.unmodifiable(outputDevices),
+          selectedInputDevice: inputDevice,
+          clearSelectedInputDevice: inputDevice == null,
+          selectedOutputDevice: outputDevice,
+          clearSelectedOutputDevice: outputDevice == null,
+          status: activeTargetIsMissing
+              ? Ntx8cvConnectionStatus.disconnected
+              : state.status,
+          statusMessage: activeTargetIsMissing
+              ? 'The selected NTX-8CV was disconnected. Reconnect it to retry.'
+              : null,
+          clearStatusMessage:
+              !activeTargetIsMissing &&
+              state.status != Ntx8cvConnectionStatus.failed,
+          clearDeviceInformation: activeTargetIsMissing,
+          isLoadingEndpoints: false,
+        ),
+      );
+    } catch (_) {
+      emit(
+        state.copyWith(
+          status: Ntx8cvConnectionStatus.failed,
+          statusMessage: 'Could not refresh NTX-8CV MIDI endpoints.',
+          isLoadingEndpoints: false,
+          clearDeviceInformation: true,
+        ),
+      );
+    }
+  }
+
+  Future<void> selectInputDevice(MidiDevice? device) async {
+    if (_sameDevice(state.selectedInputDevice, device)) return;
+    await _disconnectForTargetChange();
+    if (device == null) {
+      _desiredInputDeviceName = null;
+      _desiredInputDeviceId = null;
+    } else {
+      _rememberInputDevice(device);
+    }
+    emit(
+      state.copyWith(
+        selectedInputDevice: device,
+        clearSelectedInputDevice: device == null,
+        status: Ntx8cvConnectionStatus.disconnected,
+        clearStatusMessage: true,
+        clearDeviceInformation: true,
+      ),
+    );
+    await _persistSelection();
+  }
+
+  Future<void> selectOutputDevice(MidiDevice? device) async {
+    if (_sameDevice(state.selectedOutputDevice, device)) return;
+    await _disconnectForTargetChange();
+    if (device == null) {
+      _desiredOutputDeviceName = null;
+      _desiredOutputDeviceId = null;
+    } else {
+      _rememberOutputDevice(device);
+    }
+    emit(
+      state.copyWith(
+        selectedOutputDevice: device,
+        clearSelectedOutputDevice: device == null,
+        status: Ntx8cvConnectionStatus.disconnected,
+        clearStatusMessage: true,
+        clearDeviceInformation: true,
+      ),
+    );
+    await _persistSelection();
+  }
+
+  /// Updates the persistent device ID only for decimal values from 0 through
+  /// 126. Address 127 is never saved because it is transient Any addressing.
+  Future<void> setDeviceIdText(String text) async {
+    final value = int.tryParse(text);
+    if (value == null || value < 0 || value > 126) {
+      emit(
+        state.copyWith(
+          deviceIdText: text,
+          deviceIdError: 'Enter a decimal device ID from 0 to 126.',
+        ),
+      );
+      return;
+    }
+
+    if (value != state.deviceId) {
+      await _disconnectForTargetChange();
+    }
+    emit(
+      state.copyWith(
+        deviceId: value,
+        deviceIdText: text,
+        clearDeviceIdError: true,
+        status: value == state.deviceId
+            ? state.status
+            : Ntx8cvConnectionStatus.disconnected,
+        clearStatusMessage: value != state.deviceId,
+        clearDeviceInformation: value != state.deviceId,
+      ),
+    );
+    await _persistSelection();
+  }
+
+  /// Opens the selected endpoints and accepts a connection only after a
+  /// complete NTX-8CV device-information response validates its identity.
+  Future<void> connect() async {
+    if (!_initialized) await initialize();
+    if (!state.canConnect) return;
+
+    final inputDevice = state.selectedInputDevice!;
+    final outputDevice = state.selectedOutputDevice!;
+    final deviceId = state.deviceId;
+    await _closeActiveConnection();
+    emit(
+      state.copyWith(
+        status: Ntx8cvConnectionStatus.connecting,
+        clearStatusMessage: true,
+        clearDeviceInformation: true,
+      ),
+    );
+
+    try {
+      final transport = await _midiConnection.open(
+        inputDevice: inputDevice,
+        outputDevice: outputDevice,
+      );
+      _transport = transport;
+      _activeInputDevice = inputDevice;
+      _activeOutputDevice = outputDevice;
+      final session = Ntx8cvSession(
+        transport: transport,
+        deviceId: deviceId,
+        timeout: sessionTimeout,
+      );
+      _session = session;
+      final deviceInformation = await session.requestDeviceInformation();
+      if (!identical(_transport, transport)) return;
+      emit(
+        state.copyWith(
+          status: Ntx8cvConnectionStatus.connected,
+          deviceInformation: deviceInformation,
+          clearStatusMessage: true,
+        ),
+      );
+    } catch (error) {
+      final stillConnecting = state.isConnecting;
+      await _closeActiveConnection();
+      if (!isClosed && stillConnecting) {
+        emit(
+          state.copyWith(
+            status: Ntx8cvConnectionStatus.failed,
+            statusMessage: _connectionFailureMessage(error),
+            clearDeviceInformation: true,
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> disconnect() async {
+    await _closeActiveConnection();
+    if (!isClosed) {
+      emit(
+        state.copyWith(
+          status: Ntx8cvConnectionStatus.disconnected,
+          clearStatusMessage: true,
+          clearDeviceInformation: true,
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> close() async {
+    await _setupSubscription?.cancel();
+    await _closeActiveConnection();
+    return super.close();
+  }
+
+  bool get _hasNoSavedEndpointPreference =>
+      _desiredInputDeviceName == null &&
+      _desiredInputDeviceId == null &&
+      _desiredOutputDeviceName == null &&
+      _desiredOutputDeviceId == null;
+
+  Future<void> _disconnectForTargetChange() async {
+    if (_transport != null) await _closeActiveConnection();
+  }
+
+  Future<void> _closeActiveConnection() async {
+    final session = _session;
+    final transport = _transport;
+    final inputDevice = _activeInputDevice;
+    final outputDevice = _activeOutputDevice;
+    _session = null;
+    _transport = null;
+    _activeInputDevice = null;
+    _activeOutputDevice = null;
+
+    await session?.close();
+    if (transport != null && inputDevice != null && outputDevice != null) {
+      try {
+        await _midiConnection.close(
+          transport: transport,
+          inputDevice: inputDevice,
+          outputDevice: outputDevice,
+        );
+      } catch (_) {
+        // A missing USB device may fail to close natively; it is already
+        // disconnected from this add-on's state.
+      }
+    }
+  }
+
+  Future<void> _persistSelection() async {
+    try {
+      await _store.save(
+        Ntx8cvSavedConnection(
+          inputDeviceName: _desiredInputDeviceName,
+          inputDeviceId: _desiredInputDeviceId,
+          outputDeviceName: _desiredOutputDeviceName,
+          outputDeviceId: _desiredOutputDeviceId,
+          deviceId: state.deviceId,
+        ),
+      );
+    } catch (_) {
+      // Persistence is best effort; connection and identity validation remain
+      // local and do not depend on saved endpoint names.
+    }
+  }
+
+  void _rememberInputDevice(MidiDevice device) {
+    _desiredInputDeviceName = device.name;
+    _desiredInputDeviceId = device.id;
+  }
+
+  void _rememberOutputDevice(MidiDevice device) {
+    _desiredOutputDeviceName = device.name;
+    _desiredOutputDeviceId = device.id;
+  }
+
+  static MidiDevice? _resolveSavedDevice(
+    List<MidiDevice> devices, {
+    required String? deviceId,
+    required String? deviceName,
+  }) {
+    if (deviceId != null) {
+      for (final device in devices) {
+        if (device.id == deviceId) return device;
+      }
+    }
+    if (deviceName == null) return null;
+    final namedDevices = devices.where((device) => device.name == deviceName);
+    return namedDevices.length == 1 ? namedDevices.single : null;
+  }
+
+  static MidiDevice? _singleNtx8cvEndpoint(List<MidiDevice> devices) {
+    final matches = devices.where(
+      (device) => device.name.trim().toLowerCase() == 'ntx-8cv',
+    );
+    return matches.length == 1 ? matches.single : null;
+  }
+
+  static bool _sameDevice(MidiDevice? first, MidiDevice? second) =>
+      first?.id == second?.id;
+
+  static int _compareDevices(MidiDevice first, MidiDevice second) {
+    final nameOrder = first.name.toLowerCase().compareTo(
+      second.name.toLowerCase(),
+    );
+    return nameOrder != 0 ? nameOrder : first.id.compareTo(second.id);
+  }
+
+  static String _connectionFailureMessage(Object error) {
+    if (error is Ntx8cvTimeoutException) {
+      return 'The selected endpoint did not return valid NTX-8CV device information. Check the MIDI input, output, and device ID.';
+    }
+    return 'Could not connect to the selected NTX-8CV. Check the MIDI endpoints and try again.';
+  }
+}

--- a/lib/cubit/ntx_8cv_settings_cubit.dart
+++ b/lib/cubit/ntx_8cv_settings_cubit.dart
@@ -125,6 +125,8 @@ class Ntx8cvSettingsState {
     this.mode = const Ntx8cvSettingChange(),
     this.modeCapabilityEvidenced = false,
     this.modeRebootRequired = false,
+    this.isRebooting = false,
+    this.rebootMessage,
   });
 
   final Ntx8cvSettingChange channelGroup;
@@ -138,6 +140,12 @@ class Ntx8cvSettingsState {
 
   /// A confirmed mode change is stored but needs a reboot to take effect.
   final bool modeRebootRequired;
+
+  /// True while the selected device is being rebooted and revalidated.
+  final bool isRebooting;
+
+  /// A failed reboot or post-reboot refresh explanation for the user.
+  final String? rebootMessage;
 
   Ntx8cvChannelGroup? get confirmedChannelGroup =>
       channelGroup.confirmedValue == null
@@ -185,6 +193,15 @@ class Ntx8cvSettingsState {
   bool get hasPendingModeChange => mode.hasPendingChange;
 
   bool get isBusy =>
+      isRebooting ||
+      channelGroup.isLoading ||
+      channelGroup.isWriting ||
+      es5.isLoading ||
+      es5.isWriting ||
+      mode.isLoading ||
+      mode.isWriting;
+
+  bool get hasSettingOperationInProgress =>
       channelGroup.isLoading ||
       channelGroup.isWriting ||
       es5.isLoading ||
@@ -198,6 +215,9 @@ class Ntx8cvSettingsState {
     Ntx8cvSettingChange? mode,
     bool? modeCapabilityEvidenced,
     bool? modeRebootRequired,
+    bool? isRebooting,
+    String? rebootMessage,
+    bool clearRebootMessage = false,
   }) {
     return Ntx8cvSettingsState(
       channelGroup: channelGroup ?? this.channelGroup,
@@ -206,6 +226,10 @@ class Ntx8cvSettingsState {
       modeCapabilityEvidenced:
           modeCapabilityEvidenced ?? this.modeCapabilityEvidenced,
       modeRebootRequired: modeRebootRequired ?? this.modeRebootRequired,
+      isRebooting: isRebooting ?? this.isRebooting,
+      rebootMessage: clearRebootMessage
+          ? null
+          : rebootMessage ?? this.rebootMessage,
     );
   }
 
@@ -257,6 +281,8 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
   final Ntx8cvConnectionCubit _connectionCubit;
   late final StreamSubscription<Ntx8cvConnectionState> _connectionSubscription;
   Ntx8cvSession? _activeSession;
+  Ntx8cvSession? _refreshSession;
+  Future<void>? _refreshFuture;
   String? _targetKey;
 
   /// Changes Channel Group immediately, but commits it to presentation state
@@ -287,6 +313,52 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
   /// Explicitly resends the retained, unconfirmed Mode change to the current
   /// identity-validated NTX-8CV. Matching readback is still required.
   Future<void> retryModeChange() => _retrySetting(Ntx8cvSetting.expansionMode);
+
+  /// Reboots the currently connected NTX-8CV once, then waits for its selected
+  /// endpoint pair to be revalidated and all non-pending settings to refresh.
+  /// No confirmation dialog or automatic resend is involved.
+  Future<void> reboot() async {
+    if (_currentSession == null || state.isBusy) return;
+
+    emit(state.copyWith(isRebooting: true, clearRebootMessage: true));
+    final reconnected = await _connectionCubit.rebootAndReconnect();
+    if (isClosed) return;
+
+    if (!reconnected) {
+      emit(
+        state.copyWith(
+          isRebooting: false,
+          rebootMessage:
+              'Could not complete the NTX-8CV reboot and refresh. Check the '
+              'selected MIDI endpoints and reconnect the device.',
+        ),
+      );
+      return;
+    }
+
+    final session = await _waitForCurrentSession();
+    if (session == null) {
+      emit(
+        state.copyWith(
+          isRebooting: false,
+          rebootMessage:
+              'The NTX-8CV disconnected before its settings could refresh '
+              'after reboot.',
+        ),
+      );
+      return;
+    }
+
+    await _refreshFor(session);
+    if (!_isActiveSession(session)) return;
+    emit(
+      state.copyWith(
+        isRebooting: false,
+        modeRebootRequired: false,
+        clearRebootMessage: true,
+      ),
+    );
+  }
 
   Future<void> _setSetting(Ntx8cvSetting setting, int value) async {
     final change = state.changeFor(setting);
@@ -389,7 +461,7 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
     final session = _connectionCubit.session;
     if (session == null) {
       _activeSession = null;
-      if (!isClosed && state.isBusy) {
+      if (!isClosed && state.hasSettingOperationInProgress) {
         emit(_stateForInterruptedConnection());
       }
       return;
@@ -400,7 +472,7 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
     // A prior probe applies to the old session. Reads below must evidence the
     // mode capability again before this session permits a Mode write or retry.
     emit(state.copyWith(modeCapabilityEvidenced: false));
-    unawaited(_refreshSettings(session));
+    unawaited(_refreshFor(session));
   }
 
   /// Clears confirmations that belong to a changed target while retaining an
@@ -424,6 +496,7 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
       channelGroup: retainedChange(state.channelGroup, 'Channel Group'),
       es5: retainedChange(state.es5, 'ES-5'),
       mode: retainedChange(state.mode, 'Mode'),
+      rebootMessage: state.rebootMessage,
     );
   }
 
@@ -450,7 +523,31 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
       es5: interruptedChange(state.es5, 'ES-5'),
       mode: interruptedChange(state.mode, 'NT expansion mode'),
       modeRebootRequired: state.modeRebootRequired,
+      isRebooting: state.isRebooting,
+      rebootMessage: state.rebootMessage,
     );
+  }
+
+  Future<Ntx8cvSession?> _waitForCurrentSession() async {
+    // Cubit stream listeners receive the revalidated connection state
+    // asynchronously. Give that listener two event turns to bind the new
+    // session and begin its shared refresh rather than starting a duplicate.
+    for (var attempt = 0; attempt < 2; attempt++) {
+      final session = _currentSession;
+      if (session != null) return session;
+      await Future<void>.delayed(Duration.zero);
+    }
+    return _currentSession;
+  }
+
+  Future<void> _refreshFor(Ntx8cvSession session) {
+    if (identical(_refreshSession, session) && _refreshFuture != null) {
+      return _refreshFuture!;
+    }
+    _refreshSession = session;
+    final refresh = _refreshSettings(session);
+    _refreshFuture = refresh;
+    return refresh;
   }
 
   Future<void> _refreshSettings(Ntx8cvSession session) async {

--- a/lib/cubit/ntx_8cv_settings_cubit.dart
+++ b/lib/cubit/ntx_8cv_settings_cubit.dart
@@ -7,49 +7,177 @@ import 'package:nt_helper/domain/ntx_8cv/ntx_8cv_sysex.dart';
 /// The released NTX-8CV setting that enables its ES-5 output use.
 const int kNtx8cvEs5EnabledSettingId = 0x01;
 
-/// Presentation state for the device-confirmed ES-5 setting.
-class Ntx8cvSettingsState {
-  const Ntx8cvSettingsState({
-    this.confirmedEs5Enabled,
-    this.attemptedEs5Enabled,
-    this.isLoadingEs5 = false,
-    this.isWritingEs5 = false,
-    this.es5Message,
+/// The upstream NT expansion-mode setting. It is probed before it is writable.
+const int kNtx8cvExpansionModeSettingId = 0x1B;
+
+/// The three owner-supported NT expansion modes and their protocol values.
+enum Ntx8cvExpansionMode {
+  cv8x8(0, '8x8 CV'),
+  audio1x8_32bit(1, '1x8 32bit Audio'),
+  audio2x8_16bit(2, '2x8 16bit Audio');
+
+  const Ntx8cvExpansionMode(this.value, this.label);
+
+  final int value;
+  final String label;
+
+  static Ntx8cvExpansionMode? fromValue(int value) {
+    for (final mode in values) {
+      if (mode.value == value) return mode;
+    }
+    return null;
+  }
+}
+
+enum Ntx8cvSetting { es5Enabled, expansionMode }
+
+extension on Ntx8cvSetting {
+  int get id => switch (this) {
+    Ntx8cvSetting.es5Enabled => kNtx8cvEs5EnabledSettingId,
+    Ntx8cvSetting.expansionMode => kNtx8cvExpansionModeSettingId,
+  };
+
+  String get label => switch (this) {
+    Ntx8cvSetting.es5Enabled => 'ES-5',
+    Ntx8cvSetting.expansionMode => 'NT expansion mode',
+  };
+}
+
+/// The confirmed and attempted state of one NTX-8CV setting.
+///
+/// An attempted value is deliberately not folded into [confirmedValue]: no
+/// write acknowledgement exists, so only a matching readback can confirm it.
+class Ntx8cvSettingChange {
+  const Ntx8cvSettingChange({
+    this.confirmedValue,
+    this.attemptedValue,
+    this.isLoading = false,
+    this.isWriting = false,
+    this.message,
   });
 
-  /// The value most recently read from the selected NTX-8CV.
-  final bool? confirmedEs5Enabled;
+  final int? confirmedValue;
+  final int? attemptedValue;
+  final bool isLoading;
+  final bool isWriting;
+  final String? message;
 
-  /// A value being written or left unconfirmed after a failed write.
-  final bool? attemptedEs5Enabled;
-  final bool isLoadingEs5;
-  final bool isWritingEs5;
-  final String? es5Message;
+  bool get hasPendingChange => attemptedValue != null;
 
-  bool get hasPendingEs5Change => attemptedEs5Enabled != null;
-
-  Ntx8cvSettingsState copyWith({
-    bool? confirmedEs5Enabled,
-    bool clearConfirmedEs5Enabled = false,
-    bool? attemptedEs5Enabled,
-    bool clearAttemptedEs5Enabled = false,
-    bool? isLoadingEs5,
-    bool? isWritingEs5,
-    String? es5Message,
-    bool clearEs5Message = false,
+  Ntx8cvSettingChange copyWith({
+    int? confirmedValue,
+    bool clearConfirmedValue = false,
+    int? attemptedValue,
+    bool clearAttemptedValue = false,
+    bool? isLoading,
+    bool? isWriting,
+    String? message,
+    bool clearMessage = false,
   }) {
-    return Ntx8cvSettingsState(
-      confirmedEs5Enabled: clearConfirmedEs5Enabled
+    return Ntx8cvSettingChange(
+      confirmedValue: clearConfirmedValue
           ? null
-          : confirmedEs5Enabled ?? this.confirmedEs5Enabled,
-      attemptedEs5Enabled: clearAttemptedEs5Enabled
+          : confirmedValue ?? this.confirmedValue,
+      attemptedValue: clearAttemptedValue
           ? null
-          : attemptedEs5Enabled ?? this.attemptedEs5Enabled,
-      isLoadingEs5: isLoadingEs5 ?? this.isLoadingEs5,
-      isWritingEs5: isWritingEs5 ?? this.isWritingEs5,
-      es5Message: clearEs5Message ? null : es5Message ?? this.es5Message,
+          : attemptedValue ?? this.attemptedValue,
+      isLoading: isLoading ?? this.isLoading,
+      isWriting: isWriting ?? this.isWriting,
+      message: clearMessage ? null : message ?? this.message,
     );
   }
+}
+
+/// Presentation state for the device-confirmed NTX-8CV settings.
+class Ntx8cvSettingsState {
+  const Ntx8cvSettingsState({
+    this.es5 = const Ntx8cvSettingChange(),
+    this.mode = const Ntx8cvSettingChange(),
+    this.modeCapabilityEvidenced = false,
+    this.modeRebootRequired = false,
+  });
+
+  final Ntx8cvSettingChange es5;
+  final Ntx8cvSettingChange mode;
+
+  /// True only after the current session read setting `0x1B` with a value in
+  /// `0..2`. A timeout is absence of evidence, not proof of unsupported
+  /// firmware.
+  final bool modeCapabilityEvidenced;
+
+  /// A confirmed mode change is stored but needs a reboot to take effect.
+  final bool modeRebootRequired;
+
+  bool? get confirmedEs5Enabled => switch (es5.confirmedValue) {
+    0 => false,
+    1 => true,
+    _ => null,
+  };
+
+  bool? get attemptedEs5Enabled => switch (es5.attemptedValue) {
+    0 => false,
+    1 => true,
+    _ => null,
+  };
+
+  bool get isLoadingEs5 => es5.isLoading;
+  bool get isWritingEs5 => es5.isWriting;
+  String? get es5Message => es5.message;
+  bool get hasPendingEs5Change => es5.hasPendingChange;
+
+  Ntx8cvExpansionMode? get confirmedMode => mode.confirmedValue == null
+      ? null
+      : Ntx8cvExpansionMode.fromValue(mode.confirmedValue!);
+
+  Ntx8cvExpansionMode? get attemptedMode => mode.attemptedValue == null
+      ? null
+      : Ntx8cvExpansionMode.fromValue(mode.attemptedValue!);
+
+  bool get isLoadingMode => mode.isLoading;
+  bool get isWritingMode => mode.isWriting;
+  String? get modeMessage => mode.message;
+  bool get hasPendingModeChange => mode.hasPendingChange;
+
+  bool get isBusy =>
+      es5.isLoading || es5.isWriting || mode.isLoading || mode.isWriting;
+
+  Ntx8cvSettingsState copyWith({
+    Ntx8cvSettingChange? es5,
+    Ntx8cvSettingChange? mode,
+    bool? modeCapabilityEvidenced,
+    bool? modeRebootRequired,
+  }) {
+    return Ntx8cvSettingsState(
+      es5: es5 ?? this.es5,
+      mode: mode ?? this.mode,
+      modeCapabilityEvidenced:
+          modeCapabilityEvidenced ?? this.modeCapabilityEvidenced,
+      modeRebootRequired: modeRebootRequired ?? this.modeRebootRequired,
+    );
+  }
+
+  Ntx8cvSettingChange changeFor(Ntx8cvSetting setting) => switch (setting) {
+    Ntx8cvSetting.es5Enabled => es5,
+    Ntx8cvSetting.expansionMode => mode,
+  };
+
+  Ntx8cvSettingsState withChange(
+    Ntx8cvSetting setting,
+    Ntx8cvSettingChange change, {
+    bool? modeCapabilityEvidenced,
+    bool? modeRebootRequired,
+  }) => switch (setting) {
+    Ntx8cvSetting.es5Enabled => copyWith(
+      es5: change,
+      modeCapabilityEvidenced: modeCapabilityEvidenced,
+      modeRebootRequired: modeRebootRequired,
+    ),
+    Ntx8cvSetting.expansionMode => copyWith(
+      mode: change,
+      modeCapabilityEvidenced: modeCapabilityEvidenced,
+      modeRebootRequired: modeRebootRequired,
+    ),
+  };
 }
 
 /// Loads and changes settings for the currently identity-validated NTX-8CV.
@@ -73,65 +201,95 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
   String? _targetKey;
 
   /// Changes ES-5 use immediately, but commits it to presentation state only
-  /// after a read of setting `0x01` returns the attempted value.
-  Future<void> setEs5Enabled(bool enabled) async {
-    final session = _currentSession;
-    if (session == null ||
-        state.confirmedEs5Enabled == null ||
-        state.isLoadingEs5 ||
-        state.isWritingEs5 ||
-        state.hasPendingEs5Change ||
-        state.confirmedEs5Enabled == enabled) {
-      return;
-    }
-    await _writeEs5Enabled(session, enabled);
-  }
+  /// after a same-setting read returns the attempted value.
+  Future<void> setEs5Enabled(bool enabled) =>
+      _setSetting(Ntx8cvSetting.es5Enabled, enabled ? 1 : 0);
+
+  /// Changes the NT expansion mode immediately after a successful capability
+  /// probe. The three [Ntx8cvExpansionMode] values map to protocol `0..2`.
+  Future<void> setExpansionMode(Ntx8cvExpansionMode mode) =>
+      _setSetting(Ntx8cvSetting.expansionMode, mode.value);
 
   /// Explicitly resends the retained, unconfirmed ES-5 change to the current
-  /// identity-validated NTX-8CV. This method never reconnects or retries on
-  /// its own, so a retry always uses the currently selected endpoints and ID.
-  Future<void> retryEs5Change() async {
-    final session = _currentSession;
-    final attemptedValue = state.attemptedEs5Enabled;
-    if (session == null ||
-        attemptedValue == null ||
-        state.isLoadingEs5 ||
-        state.isWritingEs5) {
+  /// identity-validated NTX-8CV. It never reconnects or retries on its own.
+  Future<void> retryEs5Change() => _retrySetting(Ntx8cvSetting.es5Enabled);
+
+  /// Explicitly resends the retained, unconfirmed Mode change to the current
+  /// identity-validated NTX-8CV. Matching readback is still required.
+  Future<void> retryModeChange() => _retrySetting(Ntx8cvSetting.expansionMode);
+
+  Future<void> _setSetting(Ntx8cvSetting setting, int value) async {
+    final change = state.changeFor(setting);
+    if (change.hasPendingChange ||
+        change.confirmedValue == null ||
+        change.confirmedValue == value ||
+        state.isBusy ||
+        (setting == Ntx8cvSetting.expansionMode &&
+            !state.modeCapabilityEvidenced)) {
       return;
     }
-    await _writeEs5Enabled(session, attemptedValue);
+    await _writeSetting(setting, value);
   }
 
-  Future<void> _writeEs5Enabled(Ntx8cvSession session, bool enabled) async {
+  Future<void> _retrySetting(Ntx8cvSetting setting) async {
+    final attemptedValue = state.changeFor(setting).attemptedValue;
+    if (attemptedValue == null ||
+        state.isBusy ||
+        (setting == Ntx8cvSetting.expansionMode &&
+            !state.modeCapabilityEvidenced)) {
+      return;
+    }
+    await _writeSetting(setting, attemptedValue);
+  }
+
+  Future<void> _writeSetting(Ntx8cvSetting setting, int value) async {
+    final session = _currentSession;
+    if (session == null) return;
+
     emit(
-      state.copyWith(
-        attemptedEs5Enabled: enabled,
-        isWritingEs5: true,
-        clearEs5Message: true,
+      state.withChange(
+        setting,
+        state
+            .changeFor(setting)
+            .copyWith(
+              attemptedValue: value,
+              isWriting: true,
+              clearMessage: true,
+            ),
       ),
     );
     try {
-      await session.writeAndConfirmSetting(
-        settingId: kNtx8cvEs5EnabledSettingId,
-        value: enabled ? 1 : 0,
-      );
+      await session.writeAndConfirmSetting(settingId: setting.id, value: value);
       if (!_isActiveSession(session)) return;
       emit(
-        state.copyWith(
-          confirmedEs5Enabled: enabled,
-          clearAttemptedEs5Enabled: true,
-          isWritingEs5: false,
-          clearEs5Message: true,
+        state.withChange(
+          setting,
+          state
+              .changeFor(setting)
+              .copyWith(
+                confirmedValue: value,
+                clearAttemptedValue: true,
+                isWriting: false,
+                clearMessage: true,
+              ),
+          modeRebootRequired: setting == Ntx8cvSetting.expansionMode
+              ? true
+              : null,
         ),
       );
     } catch (_) {
       if (!_isActiveSession(session)) return;
       emit(
-        state.copyWith(
-          isWritingEs5: false,
-          es5Message:
-              'The ES-5 change was not confirmed by device readback. The '
-              'actual device state is uncertain.',
+        state.withChange(
+          setting,
+          state
+              .changeFor(setting)
+              .copyWith(
+                isWriting: false,
+                message:
+                    'The ${setting.label} change was not confirmed by device '
+                    'readback. The actual device state is uncertain.',
+              ),
         ),
       );
     }
@@ -161,69 +319,143 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
     final session = _connectionCubit.session;
     if (session == null) {
       _activeSession = null;
-      if (state.isWritingEs5 && !isClosed) {
-        emit(
-          state.copyWith(
-            isWritingEs5: false,
-            es5Message:
-                'The NTX-8CV disconnected before the ES-5 change could be '
-                'confirmed. The actual device state is uncertain.',
-          ),
-        );
+      if (!isClosed && state.isBusy) {
+        emit(_stateForInterruptedConnection());
       }
       return;
     }
     if (identical(session, _activeSession)) return;
 
     _activeSession = session;
-    if (!state.hasPendingEs5Change) {
-      unawaited(_readEs5Enabled(session));
-    }
+    // A prior probe applies to the old session. Reads below must evidence the
+    // mode capability again before this session permits a Mode write or retry.
+    emit(state.copyWith(modeCapabilityEvidenced: false));
+    unawaited(_refreshSettings(session));
   }
 
-  /// Clears a confirmation that belongs to a different selected target while
-  /// retaining an explicit pending change for a user-directed retry.
+  /// Clears confirmations that belong to a changed target while retaining an
+  /// explicit attempted value for a user-directed retry on the new target.
   Ntx8cvSettingsState _stateForChangedTarget() {
-    final attemptedValue = state.attemptedEs5Enabled;
+    Ntx8cvSettingChange retainedChange(
+      Ntx8cvSettingChange change,
+      String label,
+    ) {
+      if (!change.hasPendingChange) return const Ntx8cvSettingChange();
+      return Ntx8cvSettingChange(
+        attemptedValue: change.attemptedValue,
+        message:
+            'The NTX-8CV target changed before the $label change could be '
+            'confirmed. The actual device state is uncertain. Retry send will '
+            'use the current selected connection and device ID.',
+      );
+    }
+
     return Ntx8cvSettingsState(
-      attemptedEs5Enabled: attemptedValue,
-      es5Message: attemptedValue == null
-          ? null
-          : 'The NTX-8CV target changed before the ES-5 change could be '
-                'confirmed. The actual device state is uncertain. Retry send '
-                'will use the current selected connection and device ID.',
+      es5: retainedChange(state.es5, 'ES-5'),
+      mode: retainedChange(state.mode, 'Mode'),
     );
   }
 
-  Future<void> _readEs5Enabled(Ntx8cvSession session) async {
-    emit(state.copyWith(isLoadingEs5: true, clearEs5Message: true));
-    try {
-      final response = await session.readSetting(
-        settingId: kNtx8cvEs5EnabledSettingId,
+  Ntx8cvSettingsState _stateForInterruptedConnection() {
+    Ntx8cvSettingChange interruptedChange(
+      Ntx8cvSettingChange change,
+      String label,
+    ) {
+      if (!change.isWriting && !change.isLoading) return change;
+      final wasWriting = change.isWriting;
+      return change.copyWith(
+        isLoading: false,
+        isWriting: false,
+        message: wasWriting
+            ? 'The NTX-8CV disconnected before the $label change could be '
+                  'confirmed. The actual device state is uncertain.'
+            : 'The NTX-8CV disconnected before the device-confirmed $label '
+                  'value could be read.',
       );
+    }
+
+    return Ntx8cvSettingsState(
+      es5: interruptedChange(state.es5, 'ES-5'),
+      mode: interruptedChange(state.mode, 'NT expansion mode'),
+      modeRebootRequired: state.modeRebootRequired,
+    );
+  }
+
+  Future<void> _refreshSettings(Ntx8cvSession session) async {
+    // Do not read an ES-5 setting whose attempted value is pending: leaving
+    // that value untouched makes reconnect a recovery step, never an implicit
+    // confirmation or resend. A Mode probe is always safe and is required to
+    // enable a Mode retry for this newly validated session.
+    if (!state.es5.hasPendingChange) {
+      await _readSetting(session, Ntx8cvSetting.es5Enabled);
+    }
+    if (!_isActiveSession(session)) return;
+    await _readSetting(session, Ntx8cvSetting.expansionMode);
+  }
+
+  Future<void> _readSetting(
+    Ntx8cvSession session,
+    Ntx8cvSetting setting,
+  ) async {
+    emit(
+      state.withChange(
+        setting,
+        state.changeFor(setting).copyWith(isLoading: true, clearMessage: true),
+        modeCapabilityEvidenced: setting == Ntx8cvSetting.expansionMode
+            ? false
+            : null,
+      ),
+    );
+    try {
+      final response = await session.readSetting(settingId: setting.id);
       if (!_isActiveSession(session)) return;
-      if (response.value != 0 && response.value != 1) {
-        throw StateError('ES-5 setting has invalid value ${response.value}.');
+      if (!_isValidValue(setting, response.value)) {
+        throw StateError(
+          '${setting.label} setting has invalid value ${response.value}.',
+        );
       }
       emit(
-        state.copyWith(
-          confirmedEs5Enabled: response.value == 1,
-          isLoadingEs5: false,
-          clearEs5Message: true,
+        state.withChange(
+          setting,
+          state
+              .changeFor(setting)
+              .copyWith(
+                confirmedValue: response.value,
+                isLoading: false,
+                clearMessage: true,
+              ),
+          modeCapabilityEvidenced: setting == Ntx8cvSetting.expansionMode
+              ? true
+              : null,
         ),
       );
     } catch (_) {
       if (!_isActiveSession(session)) return;
       emit(
-        state.copyWith(
-          isLoadingEs5: false,
-          es5Message:
-              'Could not read the device-confirmed ES-5 setting. Check the '
-              'NTX-8CV connection and reconnect to try again.',
+        state.withChange(
+          setting,
+          state
+              .changeFor(setting)
+              .copyWith(
+                isLoading: false,
+                message: setting == Ntx8cvSetting.expansionMode
+                    ? 'Mode capability was not evidenced. The NTX-8CV did not '
+                          'return a valid Mode setting value.'
+                    : 'Could not read the device-confirmed ES-5 setting. Check '
+                          'the NTX-8CV connection and reconnect to try again.',
+              ),
+          modeCapabilityEvidenced: setting == Ntx8cvSetting.expansionMode
+              ? false
+              : null,
         ),
       );
     }
   }
+
+  bool _isValidValue(Ntx8cvSetting setting, int value) => switch (setting) {
+    Ntx8cvSetting.es5Enabled => value == 0 || value == 1,
+    Ntx8cvSetting.expansionMode => Ntx8cvExpansionMode.fromValue(value) != null,
+  };
 
   Ntx8cvSession? get _currentSession {
     final session = _connectionCubit.session;

--- a/lib/cubit/ntx_8cv_settings_cubit.dart
+++ b/lib/cubit/ntx_8cv_settings_cubit.dart
@@ -1,0 +1,205 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:nt_helper/cubit/ntx_8cv_connection_cubit.dart';
+import 'package:nt_helper/domain/ntx_8cv/ntx_8cv_sysex.dart';
+
+/// The released NTX-8CV setting that enables its ES-5 output use.
+const int kNtx8cvEs5EnabledSettingId = 0x01;
+
+/// Presentation state for the device-confirmed ES-5 setting.
+class Ntx8cvSettingsState {
+  const Ntx8cvSettingsState({
+    this.confirmedEs5Enabled,
+    this.attemptedEs5Enabled,
+    this.isLoadingEs5 = false,
+    this.isWritingEs5 = false,
+    this.es5Message,
+  });
+
+  /// The value most recently read from the selected NTX-8CV.
+  final bool? confirmedEs5Enabled;
+
+  /// A value being written or left unconfirmed after a failed write.
+  final bool? attemptedEs5Enabled;
+  final bool isLoadingEs5;
+  final bool isWritingEs5;
+  final String? es5Message;
+
+  bool get hasPendingEs5Change => attemptedEs5Enabled != null;
+
+  Ntx8cvSettingsState copyWith({
+    bool? confirmedEs5Enabled,
+    bool clearConfirmedEs5Enabled = false,
+    bool? attemptedEs5Enabled,
+    bool clearAttemptedEs5Enabled = false,
+    bool? isLoadingEs5,
+    bool? isWritingEs5,
+    String? es5Message,
+    bool clearEs5Message = false,
+  }) {
+    return Ntx8cvSettingsState(
+      confirmedEs5Enabled: clearConfirmedEs5Enabled
+          ? null
+          : confirmedEs5Enabled ?? this.confirmedEs5Enabled,
+      attemptedEs5Enabled: clearAttemptedEs5Enabled
+          ? null
+          : attemptedEs5Enabled ?? this.attemptedEs5Enabled,
+      isLoadingEs5: isLoadingEs5 ?? this.isLoadingEs5,
+      isWritingEs5: isWritingEs5 ?? this.isWritingEs5,
+      es5Message: clearEs5Message ? null : es5Message ?? this.es5Message,
+    );
+  }
+}
+
+/// Loads and changes settings for the currently identity-validated NTX-8CV.
+///
+/// This cubit owns device-confirmed setting state, not MIDI endpoints. It
+/// listens to [Ntx8cvConnectionCubit] so it can only issue setting requests
+/// through the session that is currently scoped to the selected device.
+class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
+  Ntx8cvSettingsCubit({required Ntx8cvConnectionCubit connectionCubit})
+    : _connectionCubit = connectionCubit,
+      super(const Ntx8cvSettingsState()) {
+    _connectionSubscription = _connectionCubit.stream.listen(
+      _handleConnectionState,
+    );
+    _handleConnectionState(_connectionCubit.state);
+  }
+
+  final Ntx8cvConnectionCubit _connectionCubit;
+  late final StreamSubscription<Ntx8cvConnectionState> _connectionSubscription;
+  Ntx8cvSession? _activeSession;
+  String? _targetKey;
+
+  /// Changes ES-5 use immediately, but commits it to presentation state only
+  /// after a read of setting `0x01` returns the attempted value.
+  Future<void> setEs5Enabled(bool enabled) async {
+    final session = _currentSession;
+    if (session == null ||
+        state.confirmedEs5Enabled == null ||
+        state.isLoadingEs5 ||
+        state.isWritingEs5 ||
+        state.hasPendingEs5Change ||
+        state.confirmedEs5Enabled == enabled) {
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        attemptedEs5Enabled: enabled,
+        isWritingEs5: true,
+        clearEs5Message: true,
+      ),
+    );
+    try {
+      await session.writeAndConfirmSetting(
+        settingId: kNtx8cvEs5EnabledSettingId,
+        value: enabled ? 1 : 0,
+      );
+      if (!_isActiveSession(session)) return;
+      emit(
+        state.copyWith(
+          confirmedEs5Enabled: enabled,
+          clearAttemptedEs5Enabled: true,
+          isWritingEs5: false,
+          clearEs5Message: true,
+        ),
+      );
+    } catch (_) {
+      if (!_isActiveSession(session)) return;
+      emit(
+        state.copyWith(
+          isWritingEs5: false,
+          es5Message:
+              'The ES-5 change was not confirmed by device readback. The '
+              'actual device state is uncertain.',
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> close() async {
+    await _connectionSubscription.cancel();
+    return super.close();
+  }
+
+  void _handleConnectionState(Ntx8cvConnectionState connectionState) {
+    final targetKey = _connectionTargetKey(connectionState);
+    if (targetKey != null && targetKey != _targetKey) {
+      _targetKey = targetKey;
+      _activeSession = null;
+      if (!isClosed) emit(const Ntx8cvSettingsState());
+    }
+
+    final session = _connectionCubit.session;
+    if (session == null) {
+      _activeSession = null;
+      if (state.isWritingEs5 && !isClosed) {
+        emit(
+          state.copyWith(
+            isWritingEs5: false,
+            es5Message:
+                'The NTX-8CV disconnected before the ES-5 change could be '
+                'confirmed. The actual device state is uncertain.',
+          ),
+        );
+      }
+      return;
+    }
+    if (identical(session, _activeSession)) return;
+
+    _activeSession = session;
+    if (!state.hasPendingEs5Change) {
+      unawaited(_readEs5Enabled(session));
+    }
+  }
+
+  Future<void> _readEs5Enabled(Ntx8cvSession session) async {
+    emit(state.copyWith(isLoadingEs5: true, clearEs5Message: true));
+    try {
+      final response = await session.readSetting(
+        settingId: kNtx8cvEs5EnabledSettingId,
+      );
+      if (!_isActiveSession(session)) return;
+      if (response.value != 0 && response.value != 1) {
+        throw StateError('ES-5 setting has invalid value ${response.value}.');
+      }
+      emit(
+        state.copyWith(
+          confirmedEs5Enabled: response.value == 1,
+          isLoadingEs5: false,
+          clearEs5Message: true,
+        ),
+      );
+    } catch (_) {
+      if (!_isActiveSession(session)) return;
+      emit(
+        state.copyWith(
+          isLoadingEs5: false,
+          es5Message:
+              'Could not read the device-confirmed ES-5 setting. Check the '
+              'NTX-8CV connection and reconnect to try again.',
+        ),
+      );
+    }
+  }
+
+  Ntx8cvSession? get _currentSession {
+    final session = _connectionCubit.session;
+    return identical(session, _activeSession) ? session : null;
+  }
+
+  bool _isActiveSession(Ntx8cvSession session) =>
+      !isClosed &&
+      identical(session, _activeSession) &&
+      identical(session, _connectionCubit.session);
+
+  static String? _connectionTargetKey(Ntx8cvConnectionState state) {
+    final inputId = state.selectedInputDevice?.id;
+    final outputId = state.selectedOutputDevice?.id;
+    if (inputId == null || outputId == null) return null;
+    return '$inputId:$outputId:${state.deviceId}';
+  }
+}

--- a/lib/cubit/ntx_8cv_settings_cubit.dart
+++ b/lib/cubit/ntx_8cv_settings_cubit.dart
@@ -10,6 +10,12 @@ const int kNtx8cvChannelGroupSettingId = 0x00;
 /// The released NTX-8CV setting that enables its ES-5 output use.
 const int kNtx8cvEs5EnabledSettingId = 0x01;
 
+/// The first of the eight released per-audio-channel enable settings.
+///
+/// The Expert Sleepers configuration tool identifies settings `0x04` through
+/// `0x0B` as the enable flags for audio channels 1 through 8, respectively.
+const int kNtx8cvFirstAudioChannelEnabledSettingId = 0x04;
+
 /// The upstream NT expansion-mode setting. It is probed before it is writable.
 const int kNtx8cvExpansionModeSettingId = 0x1B;
 
@@ -30,6 +36,26 @@ enum Ntx8cvExpansionMode {
     }
     return null;
   }
+}
+
+/// The eight individually configurable NTX-8CV audio channels.
+///
+/// These settings are applicable only while the device-confirmed expansion
+/// mode is one of the audio modes. Their setting IDs come directly from the
+/// released NTX-8CV configuration tool's `Enable audio channel` controls.
+enum Ntx8cvAudioChannel {
+  channel1,
+  channel2,
+  channel3,
+  channel4,
+  channel5,
+  channel6,
+  channel7,
+  channel8;
+
+  int get number => index + 1;
+  int get settingId => kNtx8cvFirstAudioChannelEnabledSettingId + index;
+  String get label => 'Audio channel $number';
 }
 
 /// The released Channel Group values, each selecting one eight-channel block.
@@ -123,6 +149,16 @@ class Ntx8cvSettingsState {
     this.channelGroup = const Ntx8cvSettingChange(),
     this.es5 = const Ntx8cvSettingChange(),
     this.mode = const Ntx8cvSettingChange(),
+    this.audioChannels = const [
+      Ntx8cvSettingChange(),
+      Ntx8cvSettingChange(),
+      Ntx8cvSettingChange(),
+      Ntx8cvSettingChange(),
+      Ntx8cvSettingChange(),
+      Ntx8cvSettingChange(),
+      Ntx8cvSettingChange(),
+      Ntx8cvSettingChange(),
+    ],
     this.modeCapabilityEvidenced = false,
     this.modeRebootRequired = false,
     this.isRebooting = false,
@@ -132,6 +168,9 @@ class Ntx8cvSettingsState {
   final Ntx8cvSettingChange channelGroup;
   final Ntx8cvSettingChange es5;
   final Ntx8cvSettingChange mode;
+
+  /// One device-confirmed/pending state for each [Ntx8cvAudioChannel].
+  final List<Ntx8cvSettingChange> audioChannels;
 
   /// True only after the current session read setting `0x1B` with a value in
   /// `0..2`. A timeout is absence of evidence, not proof of unsupported
@@ -192,6 +231,27 @@ class Ntx8cvSettingsState {
   String? get modeMessage => mode.message;
   bool get hasPendingModeChange => mode.hasPendingChange;
 
+  Ntx8cvSettingChange audioChannelChange(Ntx8cvAudioChannel channel) =>
+      audioChannels[channel.index];
+
+  bool? confirmedAudioChannelEnabled(Ntx8cvAudioChannel channel) =>
+      _enabledValue(audioChannelChange(channel).confirmedValue);
+
+  bool? attemptedAudioChannelEnabled(Ntx8cvAudioChannel channel) =>
+      _enabledValue(audioChannelChange(channel).attemptedValue);
+
+  bool isLoadingAudioChannel(Ntx8cvAudioChannel channel) =>
+      audioChannelChange(channel).isLoading;
+
+  bool isWritingAudioChannel(Ntx8cvAudioChannel channel) =>
+      audioChannelChange(channel).isWriting;
+
+  bool hasPendingAudioChannelChange(Ntx8cvAudioChannel channel) =>
+      audioChannelChange(channel).hasPendingChange;
+
+  bool get hasAudioChannelOperationInProgress =>
+      audioChannels.any((change) => change.isLoading || change.isWriting);
+
   bool get isBusy =>
       isRebooting ||
       channelGroup.isLoading ||
@@ -199,7 +259,8 @@ class Ntx8cvSettingsState {
       es5.isLoading ||
       es5.isWriting ||
       mode.isLoading ||
-      mode.isWriting;
+      mode.isWriting ||
+      hasAudioChannelOperationInProgress;
 
   bool get hasSettingOperationInProgress =>
       channelGroup.isLoading ||
@@ -207,12 +268,14 @@ class Ntx8cvSettingsState {
       es5.isLoading ||
       es5.isWriting ||
       mode.isLoading ||
-      mode.isWriting;
+      mode.isWriting ||
+      hasAudioChannelOperationInProgress;
 
   Ntx8cvSettingsState copyWith({
     Ntx8cvSettingChange? channelGroup,
     Ntx8cvSettingChange? es5,
     Ntx8cvSettingChange? mode,
+    List<Ntx8cvSettingChange>? audioChannels,
     bool? modeCapabilityEvidenced,
     bool? modeRebootRequired,
     bool? isRebooting,
@@ -223,6 +286,7 @@ class Ntx8cvSettingsState {
       channelGroup: channelGroup ?? this.channelGroup,
       es5: es5 ?? this.es5,
       mode: mode ?? this.mode,
+      audioChannels: audioChannels ?? this.audioChannels,
       modeCapabilityEvidenced:
           modeCapabilityEvidenced ?? this.modeCapabilityEvidenced,
       modeRebootRequired: modeRebootRequired ?? this.modeRebootRequired,
@@ -238,6 +302,15 @@ class Ntx8cvSettingsState {
     Ntx8cvSetting.es5Enabled => es5,
     Ntx8cvSetting.expansionMode => mode,
   };
+
+  Ntx8cvSettingsState withAudioChannelChange(
+    Ntx8cvAudioChannel channel,
+    Ntx8cvSettingChange change,
+  ) {
+    final updatedChanges = List<Ntx8cvSettingChange>.of(audioChannels)
+      ..[channel.index] = change;
+    return copyWith(audioChannels: List.unmodifiable(updatedChanges));
+  }
 
   Ntx8cvSettingsState withChange(
     Ntx8cvSetting setting,
@@ -260,6 +333,12 @@ class Ntx8cvSettingsState {
       modeCapabilityEvidenced: modeCapabilityEvidenced,
       modeRebootRequired: modeRebootRequired,
     ),
+  };
+
+  static bool? _enabledValue(int? value) => switch (value) {
+    0 => false,
+    1 => true,
+    _ => null,
   };
 }
 
@@ -299,6 +378,26 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
   /// probe. The three [Ntx8cvExpansionMode] values map to protocol `0..2`.
   Future<void> setExpansionMode(Ntx8cvExpansionMode mode) =>
       _setSetting(Ntx8cvSetting.expansionMode, mode.value);
+
+  /// Changes one supported audio channel only after the device-confirmed Mode
+  /// establishes that audio channels apply to this selected NTX-8CV.
+  Future<void> setAudioChannelEnabled(
+    Ntx8cvAudioChannel channel,
+    bool enabled,
+  ) => _setAudioChannel(channel, enabled ? 1 : 0);
+
+  /// Explicitly resends one retained, unconfirmed audio-channel change.
+  /// Reconnecting or refreshing never invokes this automatically.
+  Future<void> retryAudioChannelChange(Ntx8cvAudioChannel channel) =>
+      _retryAudioChannel(channel);
+
+  /// Reads the current device-confirmed settings without sending any writes.
+  /// A retained pending change is deliberately not retried or overwritten.
+  Future<void> refresh() async {
+    final session = _currentSession;
+    if (session == null || state.isBusy) return;
+    await _refreshSettings(session);
+  }
 
   /// Explicitly resends the retained, unconfirmed Channel Group change to the
   /// current identity-validated NTX-8CV. It never reconnects or retries on
@@ -382,6 +481,75 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
       return;
     }
     await _writeSetting(setting, attemptedValue);
+  }
+
+  Future<void> _setAudioChannel(Ntx8cvAudioChannel channel, int value) async {
+    final change = state.audioChannelChange(channel);
+    if (!_audioChannelsApply ||
+        change.hasPendingChange ||
+        change.confirmedValue == null ||
+        change.confirmedValue == value ||
+        state.isBusy) {
+      return;
+    }
+    await _writeAudioChannel(channel, value);
+  }
+
+  Future<void> _retryAudioChannel(Ntx8cvAudioChannel channel) async {
+    final attemptedValue = state.audioChannelChange(channel).attemptedValue;
+    if (!_audioChannelsApply || attemptedValue == null || state.isBusy) return;
+    await _writeAudioChannel(channel, attemptedValue);
+  }
+
+  Future<void> _writeAudioChannel(Ntx8cvAudioChannel channel, int value) async {
+    final session = _currentSession;
+    if (session == null) return;
+
+    emit(
+      state.withAudioChannelChange(
+        channel,
+        state
+            .audioChannelChange(channel)
+            .copyWith(
+              attemptedValue: value,
+              isWriting: true,
+              clearMessage: true,
+            ),
+      ),
+    );
+    try {
+      await session.writeAndConfirmSetting(
+        settingId: channel.settingId,
+        value: value,
+      );
+      if (!_isActiveSession(session)) return;
+      emit(
+        state.withAudioChannelChange(
+          channel,
+          state
+              .audioChannelChange(channel)
+              .copyWith(
+                confirmedValue: value,
+                clearAttemptedValue: true,
+                isWriting: false,
+                clearMessage: true,
+              ),
+        ),
+      );
+    } catch (error) {
+      if (!_isActiveSession(session)) return;
+      emit(
+        state.withAudioChannelChange(
+          channel,
+          state
+              .audioChannelChange(channel)
+              .copyWith(
+                isWriting: false,
+                message: _audioWriteFailureMessage(channel, error),
+              ),
+        ),
+      );
+    }
   }
 
   Future<void> _writeSetting(Ntx8cvSetting setting, int value) async {
@@ -471,7 +639,12 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
     _activeSession = session;
     // A prior probe applies to the old session. Reads below must evidence the
     // mode capability again before this session permits a Mode write or retry.
-    emit(state.copyWith(modeCapabilityEvidenced: false));
+    emit(
+      state.copyWith(
+        modeCapabilityEvidenced: false,
+        audioChannels: _audioChannelsForNewSession(),
+      ),
+    );
     unawaited(_refreshFor(session));
   }
 
@@ -496,6 +669,10 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
       channelGroup: retainedChange(state.channelGroup, 'Channel Group'),
       es5: retainedChange(state.es5, 'ES-5'),
       mode: retainedChange(state.mode, 'Mode'),
+      audioChannels: List.unmodifiable([
+        for (final channel in Ntx8cvAudioChannel.values)
+          retainedChange(state.audioChannelChange(channel), channel.label),
+      ]),
       rebootMessage: state.rebootMessage,
     );
   }
@@ -522,6 +699,10 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
       channelGroup: interruptedChange(state.channelGroup, 'Channel Group'),
       es5: interruptedChange(state.es5, 'ES-5'),
       mode: interruptedChange(state.mode, 'NT expansion mode'),
+      audioChannels: List.unmodifiable([
+        for (final channel in Ntx8cvAudioChannel.values)
+          interruptedChange(state.audioChannelChange(channel), channel.label),
+      ]),
       modeRebootRequired: state.modeRebootRequired,
       isRebooting: state.isRebooting,
       rebootMessage: state.rebootMessage,
@@ -551,18 +732,73 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
   }
 
   Future<void> _refreshSettings(Ntx8cvSession session) async {
-    // Do not read an ES-5 or Channel Group setting whose attempted value is
-    // pending: leaving that value untouched makes reconnect a recovery step,
-    // never an implicit confirmation or resend. A Mode probe is always safe
-    // and is required to enable a Mode retry for this newly validated session.
+    // Do not read an ES-5, audio-channel, or Channel Group setting whose
+    // attempted value is pending: leaving that value untouched makes reconnect
+    // a recovery step, never an implicit confirmation or resend. A Mode probe
+    // is always safe and is required to enable a Mode retry for this newly
+    // validated session.
     if (!state.es5.hasPendingChange) {
       await _readSetting(session, Ntx8cvSetting.es5Enabled);
     }
     if (!_isActiveSession(session)) return;
     await _readSetting(session, Ntx8cvSetting.expansionMode);
     if (!_isActiveSession(session)) return;
+    for (final channel in Ntx8cvAudioChannel.values) {
+      if (!state.hasPendingAudioChannelChange(channel)) {
+        await _readAudioChannel(session, channel);
+      }
+      if (!_isActiveSession(session)) return;
+    }
     if (!state.channelGroup.hasPendingChange) {
       await _readSetting(session, Ntx8cvSetting.channelGroup);
+    }
+  }
+
+  Future<void> _readAudioChannel(
+    Ntx8cvSession session,
+    Ntx8cvAudioChannel channel,
+  ) async {
+    emit(
+      state.withAudioChannelChange(
+        channel,
+        state
+            .audioChannelChange(channel)
+            .copyWith(isLoading: true, clearMessage: true),
+      ),
+    );
+    try {
+      final response = await session.readSetting(settingId: channel.settingId);
+      if (!_isActiveSession(session)) return;
+      if (response.value != 0 && response.value != 1) {
+        throw StateError(
+          '${channel.label} has invalid value ${response.value}.',
+        );
+      }
+      emit(
+        state.withAudioChannelChange(
+          channel,
+          state
+              .audioChannelChange(channel)
+              .copyWith(
+                confirmedValue: response.value,
+                isLoading: false,
+                clearMessage: true,
+              ),
+        ),
+      );
+    } catch (error) {
+      if (!_isActiveSession(session)) return;
+      emit(
+        state.withAudioChannelChange(
+          channel,
+          state
+              .audioChannelChange(channel)
+              .copyWith(
+                isLoading: false,
+                message: _audioReadFailureMessage(channel, error),
+              ),
+        ),
+      );
     }
   }
 
@@ -636,6 +872,45 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
     Ntx8cvSetting.es5Enabled => value == 0 || value == 1,
     Ntx8cvSetting.expansionMode => Ntx8cvExpansionMode.fromValue(value) != null,
   };
+
+  String _audioWriteFailureMessage(Ntx8cvAudioChannel channel, Object error) {
+    final reason = switch (error) {
+      Ntx8cvTimeoutException() => 'timed out waiting for device readback',
+      Ntx8cvMalformedResponseException() =>
+        'received a malformed device response',
+      StateError() => 'received mismatched device readback',
+      _ => 'was not confirmed by device readback',
+    };
+    return 'The ${channel.label} change $reason. The actual device state is '
+        'uncertain.';
+  }
+
+  String _audioReadFailureMessage(Ntx8cvAudioChannel channel, Object error) {
+    final reason = switch (error) {
+      Ntx8cvTimeoutException() => 'timed out',
+      Ntx8cvMalformedResponseException() => 'received a malformed response',
+      _ => 'failed',
+    };
+    return 'Could not read the device-confirmed ${channel.label} setting: '
+        '$reason. Check the NTX-8CV connection and reconnect to try again.';
+  }
+
+  bool get _audioChannelsApply =>
+      !state.modeRebootRequired &&
+      switch (state.confirmedMode) {
+        Ntx8cvExpansionMode.audio1x8_32bit ||
+        Ntx8cvExpansionMode.audio2x8_16bit => true,
+        _ => false,
+      };
+
+  List<Ntx8cvSettingChange> _audioChannelsForNewSession() => List.unmodifiable([
+    for (final channel in Ntx8cvAudioChannel.values)
+      state.hasPendingAudioChannelChange(channel)
+          ? state
+                .audioChannelChange(channel)
+                .copyWith(clearConfirmedValue: true)
+          : const Ntx8cvSettingChange(),
+  ]);
 
   Ntx8cvSession? get _currentSession {
     final session = _connectionCubit.session;

--- a/lib/cubit/ntx_8cv_settings_cubit.dart
+++ b/lib/cubit/ntx_8cv_settings_cubit.dart
@@ -732,11 +732,13 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
   }
 
   Future<void> _refreshSettings(Ntx8cvSession session) async {
-    // Do not read an ES-5, audio-channel, or Channel Group setting whose
-    // attempted value is pending: leaving that value untouched makes reconnect
-    // a recovery step, never an implicit confirmation or resend. A Mode probe
-    // is always safe and is required to enable a Mode retry for this newly
-    // validated session.
+    // Do not read an ES-5 or Channel Group setting whose attempted value is
+    // pending: leaving those values untouched makes reconnect a recovery step,
+    // never an implicit confirmation or resend. Audio-channel reads remain
+    // safe: a matching readback confirms a pending channel change, while a
+    // different readback keeps it pending and updates the displayed hardware
+    // state. A Mode probe is always safe and is required to enable a Mode retry
+    // for this newly validated session.
     if (!state.es5.hasPendingChange) {
       await _readSetting(session, Ntx8cvSetting.es5Enabled);
     }
@@ -744,9 +746,7 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
     await _readSetting(session, Ntx8cvSetting.expansionMode);
     if (!_isActiveSession(session)) return;
     for (final channel in Ntx8cvAudioChannel.values) {
-      if (!state.hasPendingAudioChannelChange(channel)) {
-        await _readAudioChannel(session, channel);
-      }
+      await _readAudioChannel(session, channel);
       if (!_isActiveSession(session)) return;
     }
     if (!state.channelGroup.hasPendingChange) {
@@ -774,16 +774,23 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
           '${channel.label} has invalid value ${response.value}.',
         );
       }
+      final change = state.audioChannelChange(channel);
+      final attemptedValue = change.attemptedValue;
+      final matchesPendingAttempt =
+          attemptedValue == null || attemptedValue == response.value;
       emit(
         state.withAudioChannelChange(
           channel,
-          state
-              .audioChannelChange(channel)
-              .copyWith(
-                confirmedValue: response.value,
-                isLoading: false,
-                clearMessage: true,
-              ),
+          change.copyWith(
+            confirmedValue: response.value,
+            clearAttemptedValue: matchesPendingAttempt,
+            isLoading: false,
+            message: matchesPendingAttempt
+                ? null
+                : 'The ${channel.label} attempted value did not match the '
+                      'device-confirmed readback. Retry send to try again.',
+            clearMessage: matchesPendingAttempt,
+          ),
         ),
       );
     } catch (error) {

--- a/lib/cubit/ntx_8cv_settings_cubit.dart
+++ b/lib/cubit/ntx_8cv_settings_cubit.dart
@@ -84,7 +84,25 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
         state.confirmedEs5Enabled == enabled) {
       return;
     }
+    await _writeEs5Enabled(session, enabled);
+  }
 
+  /// Explicitly resends the retained, unconfirmed ES-5 change to the current
+  /// identity-validated NTX-8CV. This method never reconnects or retries on
+  /// its own, so a retry always uses the currently selected endpoints and ID.
+  Future<void> retryEs5Change() async {
+    final session = _currentSession;
+    final attemptedValue = state.attemptedEs5Enabled;
+    if (session == null ||
+        attemptedValue == null ||
+        state.isLoadingEs5 ||
+        state.isWritingEs5) {
+      return;
+    }
+    await _writeEs5Enabled(session, attemptedValue);
+  }
+
+  Future<void> _writeEs5Enabled(Ntx8cvSession session, bool enabled) async {
     emit(
       state.copyWith(
         attemptedEs5Enabled: enabled,
@@ -128,9 +146,16 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
   void _handleConnectionState(Ntx8cvConnectionState connectionState) {
     final targetKey = _connectionTargetKey(connectionState);
     if (targetKey != null && targetKey != _targetKey) {
+      final hasPreviousTarget = _targetKey != null;
       _targetKey = targetKey;
       _activeSession = null;
-      if (!isClosed) emit(const Ntx8cvSettingsState());
+      if (!isClosed) {
+        emit(
+          hasPreviousTarget
+              ? _stateForChangedTarget()
+              : const Ntx8cvSettingsState(),
+        );
+      }
     }
 
     final session = _connectionCubit.session;
@@ -154,6 +179,20 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
     if (!state.hasPendingEs5Change) {
       unawaited(_readEs5Enabled(session));
     }
+  }
+
+  /// Clears a confirmation that belongs to a different selected target while
+  /// retaining an explicit pending change for a user-directed retry.
+  Ntx8cvSettingsState _stateForChangedTarget() {
+    final attemptedValue = state.attemptedEs5Enabled;
+    return Ntx8cvSettingsState(
+      attemptedEs5Enabled: attemptedValue,
+      es5Message: attemptedValue == null
+          ? null
+          : 'The NTX-8CV target changed before the ES-5 change could be '
+                'confirmed. The actual device state is uncertain. Retry send '
+                'will use the current selected connection and device ID.',
+    );
   }
 
   Future<void> _readEs5Enabled(Ntx8cvSession session) async {

--- a/lib/cubit/ntx_8cv_settings_cubit.dart
+++ b/lib/cubit/ntx_8cv_settings_cubit.dart
@@ -4,6 +4,9 @@ import 'package:bloc/bloc.dart';
 import 'package:nt_helper/cubit/ntx_8cv_connection_cubit.dart';
 import 'package:nt_helper/domain/ntx_8cv/ntx_8cv_sysex.dart';
 
+/// The released NTX-8CV setting that selects its eight-channel block.
+const int kNtx8cvChannelGroupSettingId = 0x00;
+
 /// The released NTX-8CV setting that enables its ES-5 output use.
 const int kNtx8cvEs5EnabledSettingId = 0x01;
 
@@ -29,15 +32,41 @@ enum Ntx8cvExpansionMode {
   }
 }
 
-enum Ntx8cvSetting { es5Enabled, expansionMode }
+/// The released Channel Group values, each selecting one eight-channel block.
+enum Ntx8cvChannelGroup {
+  channels1To8(0, '1–8'),
+  channels9To16(1, '9–16'),
+  channels17To24(2, '17–24'),
+  channels25To32(3, '25–32'),
+  channels33To40(4, '33–40'),
+  channels41To48(5, '41–48'),
+  channels49To56(6, '49–56'),
+  channels57To64(7, '57–64');
+
+  const Ntx8cvChannelGroup(this.value, this.label);
+
+  final int value;
+  final String label;
+
+  static Ntx8cvChannelGroup? fromValue(int value) {
+    for (final group in values) {
+      if (group.value == value) return group;
+    }
+    return null;
+  }
+}
+
+enum Ntx8cvSetting { channelGroup, es5Enabled, expansionMode }
 
 extension on Ntx8cvSetting {
   int get id => switch (this) {
+    Ntx8cvSetting.channelGroup => kNtx8cvChannelGroupSettingId,
     Ntx8cvSetting.es5Enabled => kNtx8cvEs5EnabledSettingId,
     Ntx8cvSetting.expansionMode => kNtx8cvExpansionModeSettingId,
   };
 
   String get label => switch (this) {
+    Ntx8cvSetting.channelGroup => 'Channel Group',
     Ntx8cvSetting.es5Enabled => 'ES-5',
     Ntx8cvSetting.expansionMode => 'NT expansion mode',
   };
@@ -91,12 +120,14 @@ class Ntx8cvSettingChange {
 /// Presentation state for the device-confirmed NTX-8CV settings.
 class Ntx8cvSettingsState {
   const Ntx8cvSettingsState({
+    this.channelGroup = const Ntx8cvSettingChange(),
     this.es5 = const Ntx8cvSettingChange(),
     this.mode = const Ntx8cvSettingChange(),
     this.modeCapabilityEvidenced = false,
     this.modeRebootRequired = false,
   });
 
+  final Ntx8cvSettingChange channelGroup;
   final Ntx8cvSettingChange es5;
   final Ntx8cvSettingChange mode;
 
@@ -107,6 +138,21 @@ class Ntx8cvSettingsState {
 
   /// A confirmed mode change is stored but needs a reboot to take effect.
   final bool modeRebootRequired;
+
+  Ntx8cvChannelGroup? get confirmedChannelGroup =>
+      channelGroup.confirmedValue == null
+      ? null
+      : Ntx8cvChannelGroup.fromValue(channelGroup.confirmedValue!);
+
+  Ntx8cvChannelGroup? get attemptedChannelGroup =>
+      channelGroup.attemptedValue == null
+      ? null
+      : Ntx8cvChannelGroup.fromValue(channelGroup.attemptedValue!);
+
+  bool get isLoadingChannelGroup => channelGroup.isLoading;
+  bool get isWritingChannelGroup => channelGroup.isWriting;
+  String? get channelGroupMessage => channelGroup.message;
+  bool get hasPendingChannelGroupChange => channelGroup.hasPendingChange;
 
   bool? get confirmedEs5Enabled => switch (es5.confirmedValue) {
     0 => false,
@@ -139,15 +185,22 @@ class Ntx8cvSettingsState {
   bool get hasPendingModeChange => mode.hasPendingChange;
 
   bool get isBusy =>
-      es5.isLoading || es5.isWriting || mode.isLoading || mode.isWriting;
+      channelGroup.isLoading ||
+      channelGroup.isWriting ||
+      es5.isLoading ||
+      es5.isWriting ||
+      mode.isLoading ||
+      mode.isWriting;
 
   Ntx8cvSettingsState copyWith({
+    Ntx8cvSettingChange? channelGroup,
     Ntx8cvSettingChange? es5,
     Ntx8cvSettingChange? mode,
     bool? modeCapabilityEvidenced,
     bool? modeRebootRequired,
   }) {
     return Ntx8cvSettingsState(
+      channelGroup: channelGroup ?? this.channelGroup,
       es5: es5 ?? this.es5,
       mode: mode ?? this.mode,
       modeCapabilityEvidenced:
@@ -157,6 +210,7 @@ class Ntx8cvSettingsState {
   }
 
   Ntx8cvSettingChange changeFor(Ntx8cvSetting setting) => switch (setting) {
+    Ntx8cvSetting.channelGroup => channelGroup,
     Ntx8cvSetting.es5Enabled => es5,
     Ntx8cvSetting.expansionMode => mode,
   };
@@ -167,6 +221,11 @@ class Ntx8cvSettingsState {
     bool? modeCapabilityEvidenced,
     bool? modeRebootRequired,
   }) => switch (setting) {
+    Ntx8cvSetting.channelGroup => copyWith(
+      channelGroup: change,
+      modeCapabilityEvidenced: modeCapabilityEvidenced,
+      modeRebootRequired: modeRebootRequired,
+    ),
     Ntx8cvSetting.es5Enabled => copyWith(
       es5: change,
       modeCapabilityEvidenced: modeCapabilityEvidenced,
@@ -200,6 +259,11 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
   Ntx8cvSession? _activeSession;
   String? _targetKey;
 
+  /// Changes Channel Group immediately, but commits it to presentation state
+  /// only after a same-setting read returns the attempted value.
+  Future<void> setChannelGroup(Ntx8cvChannelGroup group) =>
+      _setSetting(Ntx8cvSetting.channelGroup, group.value);
+
   /// Changes ES-5 use immediately, but commits it to presentation state only
   /// after a same-setting read returns the attempted value.
   Future<void> setEs5Enabled(bool enabled) =>
@@ -209,6 +273,12 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
   /// probe. The three [Ntx8cvExpansionMode] values map to protocol `0..2`.
   Future<void> setExpansionMode(Ntx8cvExpansionMode mode) =>
       _setSetting(Ntx8cvSetting.expansionMode, mode.value);
+
+  /// Explicitly resends the retained, unconfirmed Channel Group change to the
+  /// current identity-validated NTX-8CV. It never reconnects or retries on
+  /// its own.
+  Future<void> retryChannelGroupChange() =>
+      _retrySetting(Ntx8cvSetting.channelGroup);
 
   /// Explicitly resends the retained, unconfirmed ES-5 change to the current
   /// identity-validated NTX-8CV. It never reconnects or retries on its own.
@@ -351,6 +421,7 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
     }
 
     return Ntx8cvSettingsState(
+      channelGroup: retainedChange(state.channelGroup, 'Channel Group'),
       es5: retainedChange(state.es5, 'ES-5'),
       mode: retainedChange(state.mode, 'Mode'),
     );
@@ -375,6 +446,7 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
     }
 
     return Ntx8cvSettingsState(
+      channelGroup: interruptedChange(state.channelGroup, 'Channel Group'),
       es5: interruptedChange(state.es5, 'ES-5'),
       mode: interruptedChange(state.mode, 'NT expansion mode'),
       modeRebootRequired: state.modeRebootRequired,
@@ -382,15 +454,19 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
   }
 
   Future<void> _refreshSettings(Ntx8cvSession session) async {
-    // Do not read an ES-5 setting whose attempted value is pending: leaving
-    // that value untouched makes reconnect a recovery step, never an implicit
-    // confirmation or resend. A Mode probe is always safe and is required to
-    // enable a Mode retry for this newly validated session.
+    // Do not read an ES-5 or Channel Group setting whose attempted value is
+    // pending: leaving that value untouched makes reconnect a recovery step,
+    // never an implicit confirmation or resend. A Mode probe is always safe
+    // and is required to enable a Mode retry for this newly validated session.
     if (!state.es5.hasPendingChange) {
       await _readSetting(session, Ntx8cvSetting.es5Enabled);
     }
     if (!_isActiveSession(session)) return;
     await _readSetting(session, Ntx8cvSetting.expansionMode);
+    if (!_isActiveSession(session)) return;
+    if (!state.channelGroup.hasPendingChange) {
+      await _readSetting(session, Ntx8cvSetting.channelGroup);
+    }
   }
 
   Future<void> _readSetting(
@@ -438,11 +514,17 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
               .changeFor(setting)
               .copyWith(
                 isLoading: false,
-                message: setting == Ntx8cvSetting.expansionMode
-                    ? 'Mode capability was not evidenced. The NTX-8CV did not '
-                          'return a valid Mode setting value.'
-                    : 'Could not read the device-confirmed ES-5 setting. Check '
-                          'the NTX-8CV connection and reconnect to try again.',
+                message: switch (setting) {
+                  Ntx8cvSetting.expansionMode =>
+                    'Mode capability was not evidenced. The NTX-8CV did not '
+                        'return a valid Mode setting value.',
+                  Ntx8cvSetting.channelGroup =>
+                    'Could not read the device-confirmed Channel Group setting. '
+                        'Check the NTX-8CV connection and reconnect to try again.',
+                  Ntx8cvSetting.es5Enabled =>
+                    'Could not read the device-confirmed ES-5 setting. Check '
+                        'the NTX-8CV connection and reconnect to try again.',
+                },
               ),
           modeCapabilityEvidenced: setting == Ntx8cvSetting.expansionMode
               ? false
@@ -453,6 +535,7 @@ class Ntx8cvSettingsCubit extends Cubit<Ntx8cvSettingsState> {
   }
 
   bool _isValidValue(Ntx8cvSetting setting, int value) => switch (setting) {
+    Ntx8cvSetting.channelGroup => Ntx8cvChannelGroup.fromValue(value) != null,
     Ntx8cvSetting.es5Enabled => value == 0 || value == 1,
     Ntx8cvSetting.expansionMode => Ntx8cvExpansionMode.fromValue(value) != null,
   };

--- a/lib/domain/ntx_8cv/ntx_8cv_midi_connection.dart
+++ b/lib/domain/ntx_8cv/ntx_8cv_midi_connection.dart
@@ -1,0 +1,255 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_midi_command/flutter_midi_command.dart';
+import 'package:nt_helper/domain/midi_command_factory.dart';
+import 'package:nt_helper/domain/ntx_8cv/ntx_8cv_sysex.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The persisted target selection for the independent NTX-8CV connection.
+class Ntx8cvSavedConnection {
+  const Ntx8cvSavedConnection({
+    this.inputDeviceName,
+    this.inputDeviceId,
+    this.outputDeviceName,
+    this.outputDeviceId,
+    this.deviceId = 0,
+  });
+
+  final String? inputDeviceName;
+  final String? inputDeviceId;
+  final String? outputDeviceName;
+  final String? outputDeviceId;
+  final int deviceId;
+}
+
+/// Persists only the selected NTX-8CV endpoints and its SysEx device ID.
+abstract interface class Ntx8cvConnectionStore {
+  Future<Ntx8cvSavedConnection> load();
+
+  Future<void> save(Ntx8cvSavedConnection selection);
+}
+
+/// Shared-preferences persistence for the NTX-8CV add-on's independent target.
+class SharedPreferencesNtx8cvConnectionStore implements Ntx8cvConnectionStore {
+  static const _inputDeviceNameKey = 'ntx8cvInputMidiDevice';
+  static const _inputDeviceIdKey = 'ntx8cvInputMidiDeviceId';
+  static const _outputDeviceNameKey = 'ntx8cvOutputMidiDevice';
+  static const _outputDeviceIdKey = 'ntx8cvOutputMidiDeviceId';
+  static const _deviceIdKey = 'ntx8cvSysExDeviceId';
+
+  SharedPreferencesNtx8cvConnectionStore({
+    Future<SharedPreferences>? preferences,
+  }) : _preferences = preferences ?? SharedPreferences.getInstance();
+
+  final Future<SharedPreferences> _preferences;
+
+  @override
+  Future<Ntx8cvSavedConnection> load() async {
+    final preferences = await _preferences;
+    final savedDeviceId = preferences.getInt(_deviceIdKey);
+    return Ntx8cvSavedConnection(
+      inputDeviceName: preferences.getString(_inputDeviceNameKey),
+      inputDeviceId: preferences.getString(_inputDeviceIdKey),
+      outputDeviceName: preferences.getString(_outputDeviceNameKey),
+      outputDeviceId: preferences.getString(_outputDeviceIdKey),
+      deviceId:
+          savedDeviceId != null && savedDeviceId >= 0 && savedDeviceId <= 126
+          ? savedDeviceId
+          : 0,
+    );
+  }
+
+  @override
+  Future<void> save(Ntx8cvSavedConnection selection) async {
+    final preferences = await _preferences;
+    if (selection.inputDeviceName == null) {
+      await preferences.remove(_inputDeviceNameKey);
+    } else {
+      await preferences.setString(
+        _inputDeviceNameKey,
+        selection.inputDeviceName!,
+      );
+    }
+    if (selection.inputDeviceId == null) {
+      await preferences.remove(_inputDeviceIdKey);
+    } else {
+      await preferences.setString(_inputDeviceIdKey, selection.inputDeviceId!);
+    }
+    if (selection.outputDeviceName == null) {
+      await preferences.remove(_outputDeviceNameKey);
+    } else {
+      await preferences.setString(
+        _outputDeviceNameKey,
+        selection.outputDeviceName!,
+      );
+    }
+    if (selection.outputDeviceId == null) {
+      await preferences.remove(_outputDeviceIdKey);
+    } else {
+      await preferences.setString(
+        _outputDeviceIdKey,
+        selection.outputDeviceId!,
+      );
+    }
+    await preferences.setInt(_deviceIdKey, selection.deviceId);
+  }
+}
+
+/// Opens and closes one independently selected NTX-8CV MIDI endpoint pair.
+///
+/// It intentionally has no dependency on [DistingCubit] or its connection.
+abstract interface class Ntx8cvMidiConnection {
+  Future<List<MidiDevice>> listDevices();
+
+  Stream<MidiSetupChange>? get setupChanges;
+
+  Future<Ntx8cvMidiTransport> open({
+    required MidiDevice inputDevice,
+    required MidiDevice outputDevice,
+  });
+
+  Future<void> close({
+    required Ntx8cvMidiTransport transport,
+    required MidiDevice inputDevice,
+    required MidiDevice outputDevice,
+  });
+}
+
+/// The production MIDI connection used only by the NTX-8CV add-on.
+class NativeNtx8cvMidiConnection implements Ntx8cvMidiConnection {
+  NativeNtx8cvMidiConnection({MidiCommand? midiCommand})
+    : _midiCommand = midiCommand ?? createNativeMidiCommand();
+
+  final MidiCommand _midiCommand;
+
+  @override
+  Stream<MidiSetupChange>? get setupChanges => _midiCommand.onMidiSetupChanged;
+
+  @override
+  Future<List<MidiDevice>> listDevices() async =>
+      List<MidiDevice>.of(await _midiCommand.devices ?? const []);
+
+  @override
+  Future<Ntx8cvMidiTransport> open({
+    required MidiDevice inputDevice,
+    required MidiDevice outputDevice,
+  }) async {
+    final transport = _Ntx8cvMidiCommandTransport(
+      midiCommand: _midiCommand,
+      inputDevice: inputDevice,
+      outputDevice: outputDevice,
+    );
+    try {
+      await transport.open();
+      return transport;
+    } catch (_) {
+      await transport.close();
+      _midiCommand.disconnectDevice(inputDevice);
+      if (inputDevice.id != outputDevice.id) {
+        _midiCommand.disconnectDevice(outputDevice);
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> close({
+    required Ntx8cvMidiTransport transport,
+    required MidiDevice inputDevice,
+    required MidiDevice outputDevice,
+  }) async {
+    if (transport is _Ntx8cvMidiCommandTransport) {
+      await transport.close();
+    }
+    _midiCommand.disconnectDevice(inputDevice);
+    if (inputDevice.id != outputDevice.id) {
+      _midiCommand.disconnectDevice(outputDevice);
+    }
+  }
+}
+
+/// Bridges the selected native MIDI endpoints to an NTX-8CV SysEx session.
+///
+/// Incoming packets are filtered by the selected input device before complete
+/// SysEx frames are exposed. Outgoing packets always name the selected output
+/// device explicitly, so this transport cannot send to the disting NT target.
+class _Ntx8cvMidiCommandTransport implements Ntx8cvMidiTransport {
+  _Ntx8cvMidiCommandTransport({
+    required MidiCommand midiCommand,
+    required MidiDevice inputDevice,
+    required MidiDevice outputDevice,
+  }) : _midiCommand = midiCommand,
+       _inputDevice = inputDevice,
+       _outputDevice = outputDevice;
+
+  final MidiCommand _midiCommand;
+  final MidiDevice _inputDevice;
+  final MidiDevice _outputDevice;
+  final StreamController<Uint8List> _receivedController =
+      StreamController<Uint8List>.broadcast();
+  StreamSubscription<MidiPacket>? _subscription;
+  final List<int> _sysExBuffer = [];
+  bool _isOpen = false;
+  bool _isClosed = false;
+
+  @override
+  Stream<Uint8List> get receivedPackets => _receivedController.stream;
+
+  Future<void> open() async {
+    final incoming = _midiCommand.onMidiPacketReceived;
+    if (incoming == null) {
+      throw UnsupportedError('MIDI input is unavailable on this platform.');
+    }
+    _subscription = incoming.listen(_handlePacket, onError: _handleError);
+    try {
+      await _midiCommand.connectToDevice(_inputDevice);
+      if (_inputDevice.id != _outputDevice.id) {
+        await _midiCommand.connectToDevice(_outputDevice);
+      }
+      _isOpen = true;
+    } catch (_) {
+      await close();
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> send(Uint8List packet) async {
+    if (!_isOpen || _isClosed) {
+      throw StateError('The NTX-8CV MIDI transport is not open.');
+    }
+    _midiCommand.sendData(packet, deviceId: _outputDevice.id);
+  }
+
+  Future<void> close() async {
+    if (_isClosed) return;
+    _isClosed = true;
+    await _subscription?.cancel();
+    await _receivedController.close();
+  }
+
+  void _handlePacket(MidiPacket packet) {
+    if (_isClosed || packet.device.id != _inputDevice.id) return;
+    for (final byte in packet.data) {
+      if (byte == 0xF0) {
+        _sysExBuffer
+          ..clear()
+          ..add(byte);
+        continue;
+      }
+      if (_sysExBuffer.isEmpty) continue;
+      _sysExBuffer.add(byte);
+      if (byte == 0xF7) {
+        _receivedController.add(Uint8List.fromList(_sysExBuffer));
+        _sysExBuffer.clear();
+      }
+    }
+  }
+
+  void _handleError(Object error, StackTrace stackTrace) {
+    if (!_isClosed) {
+      _receivedController.addError(error, stackTrace);
+    }
+  }
+}

--- a/lib/domain/ntx_8cv/ntx_8cv_sysex.dart
+++ b/lib/domain/ntx_8cv/ntx_8cv_sysex.dart
@@ -1,0 +1,423 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+/// The SysEx manufacturer ID assigned to Expert Sleepers.
+const List<int> kNtx8cvManufacturerId = [0x00, 0x21, 0x27];
+
+/// The product byte that identifies NTX-8CV SysEx, distinct from disting NT.
+const int kNtx8cvProductByte = 0x6A;
+
+/// The transient broadcast address. It must not be persisted as a device ID.
+const int kNtx8cvAnyDeviceId = 0x7F;
+
+const int _sysExStart = 0xF0;
+const int _sysExEnd = 0xF7;
+const int _deviceInformationRequest = 0x22;
+const int _setting = 0x31;
+const int _deviceInformationResponse = 0x32;
+const int _reboot = 0x7F;
+
+/// Encodes and decodes the NTX-8CV's product-specific SysEx frames.
+///
+/// This intentionally does not reuse the disting NT parser: an NTX-8CV frame
+/// carries product byte [kNtx8cvProductByte], not the disting NT's `0x6D`.
+class Ntx8cvSysExCodec {
+  const Ntx8cvSysExCodec();
+
+  Uint8List requestDeviceInformation({required int deviceId}) =>
+      _frame(deviceId, _deviceInformationRequest);
+
+  Uint8List readSetting({required int deviceId, required int settingId}) =>
+      _frame(deviceId, _setting, [settingId]);
+
+  Uint8List writeSetting({
+    required int deviceId,
+    required int settingId,
+    required int value,
+  }) => _frame(deviceId, _deviceInformationResponse, [settingId, value]);
+
+  Uint8List reboot({required int deviceId}) => _frame(deviceId, _reboot);
+
+  /// Decodes a complete, standalone NTX-8CV frame.
+  ///
+  /// `null` means the frame is malformed or belongs to another device family.
+  /// Unknown but well-formed NTX-8CV commands are preserved as
+  /// [Ntx8cvUnknownMessage] so callers can safely ignore them.
+  Ntx8cvIncomingMessage? decode(Uint8List packet) {
+    if (packet.length < 8 ||
+        packet.first != _sysExStart ||
+        packet.last != _sysExEnd) {
+      return null;
+    }
+    if (packet[1] != kNtx8cvManufacturerId[0] ||
+        packet[2] != kNtx8cvManufacturerId[1] ||
+        packet[3] != kNtx8cvManufacturerId[2] ||
+        packet[4] != kNtx8cvProductByte ||
+        !_areDataBytes(packet, 1, packet.length - 1)) {
+      return null;
+    }
+
+    final deviceId = packet[5];
+    final command = packet[6];
+    final payload = Uint8List.fromList(packet.sublist(7, packet.length - 1));
+    final rawBytes = Uint8List.fromList(packet);
+
+    switch (command) {
+      case _setting:
+        if (payload.length != 2) return null;
+        return Ntx8cvSettingValue(
+          deviceId: deviceId,
+          settingId: payload[0],
+          value: payload[1],
+          rawBytes: rawBytes,
+        );
+      case _deviceInformationResponse:
+        // Firmware and serial values are opaque NUL-terminated ASCII fields.
+        // Their number and contents are intentionally not interpreted here.
+        if (payload.isNotEmpty && payload.last != 0) return null;
+        return Ntx8cvDeviceInformation(
+          deviceId: deviceId,
+          textFields: _decodeNulTerminatedFields(payload),
+          rawBytes: rawBytes,
+        );
+      default:
+        return Ntx8cvUnknownMessage(
+          deviceId: deviceId,
+          command: command,
+          payload: payload,
+          rawBytes: rawBytes,
+        );
+    }
+  }
+
+  Uint8List _frame(int deviceId, int command, [List<int> payload = const []]) {
+    _validateDataByte(deviceId, 'deviceId');
+    _validateDataByte(command, 'command');
+    for (final value in payload) {
+      _validateDataByte(value, 'payload value');
+    }
+    return Uint8List.fromList([
+      _sysExStart,
+      ...kNtx8cvManufacturerId,
+      kNtx8cvProductByte,
+      deviceId,
+      command,
+      ...payload,
+      _sysExEnd,
+    ]);
+  }
+
+  static bool _areDataBytes(Uint8List bytes, int start, int endExclusive) {
+    for (var index = start; index < endExclusive; index++) {
+      if (bytes[index] > kNtx8cvAnyDeviceId) return false;
+    }
+    return true;
+  }
+
+  static void _validateDataByte(int value, String name) {
+    if (value < 0 || value > kNtx8cvAnyDeviceId) {
+      throw ArgumentError.value(value, name, 'must be a MIDI 7-bit value');
+    }
+  }
+
+  static List<String> _decodeNulTerminatedFields(Uint8List payload) {
+    if (payload.isEmpty) return const [];
+
+    final fields = <String>[];
+    var fieldStart = 0;
+    for (var index = 0; index < payload.length; index++) {
+      if (payload[index] == 0) {
+        fields.add(String.fromCharCodes(payload.sublist(fieldStart, index)));
+        fieldStart = index + 1;
+      }
+    }
+    return List.unmodifiable(fields);
+  }
+}
+
+/// A complete NTX-8CV message received from the selected MIDI input.
+sealed class Ntx8cvIncomingMessage {
+  const Ntx8cvIncomingMessage({required this.deviceId, required this.rawBytes});
+
+  final int deviceId;
+  final Uint8List rawBytes;
+}
+
+/// Device information returned in response to command `0x22` using `0x32`.
+class Ntx8cvDeviceInformation extends Ntx8cvIncomingMessage {
+  const Ntx8cvDeviceInformation({
+    required super.deviceId,
+    required this.textFields,
+    required super.rawBytes,
+  });
+
+  /// Opaque NUL-terminated text fields reported by the device.
+  final List<String> textFields;
+
+  String? get firmwareText => textFields.isEmpty ? null : textFields.first;
+  String? get serialText => textFields.length < 2 ? null : textFields[1];
+}
+
+/// A response to a setting read (`0x31 <setting-id> <value>`).
+class Ntx8cvSettingValue extends Ntx8cvIncomingMessage {
+  const Ntx8cvSettingValue({
+    required super.deviceId,
+    required this.settingId,
+    required this.value,
+    required super.rawBytes,
+  });
+
+  final int settingId;
+  final int value;
+}
+
+/// A well-formed NTX-8CV message whose command is not yet modeled.
+class Ntx8cvUnknownMessage extends Ntx8cvIncomingMessage {
+  const Ntx8cvUnknownMessage({
+    required super.deviceId,
+    required this.command,
+    required this.payload,
+    required super.rawBytes,
+  });
+
+  final int command;
+  final Uint8List payload;
+}
+
+/// The independent MIDI transport used by an NTX-8CV session.
+///
+/// Feature-layer code supplies a transport bound to its chosen NTX-8CV input
+/// and output endpoints; it never shares the disting NT transport.
+abstract interface class Ntx8cvMidiTransport {
+  Stream<Uint8List> get receivedPackets;
+
+  Future<void> send(Uint8List packet);
+}
+
+/// Reports that a requested NTX-8CV response did not arrive in time.
+class Ntx8cvTimeoutException implements Exception {
+  const Ntx8cvTimeoutException({
+    required this.operation,
+    required this.timeout,
+  });
+
+  final String operation;
+  final Duration timeout;
+
+  @override
+  String toString() =>
+      'Ntx8cvTimeoutException($operation after ${timeout.inMilliseconds}ms)';
+}
+
+/// Reports a receive-stream failure while waiting for an NTX-8CV response.
+class Ntx8cvTransportException implements Exception {
+  const Ntx8cvTransportException(this.cause);
+
+  final Object cause;
+
+  @override
+  String toString() => 'Ntx8cvTransportException($cause)';
+}
+
+/// Serializes NTX-8CV requests and matches responses for one selected device.
+///
+/// The session makes no implicit retries. A setting is only confirmed by
+/// [writeAndConfirmSetting], which reads the setting after the write and waits
+/// for a matching value.
+class Ntx8cvSession {
+  Ntx8cvSession({
+    required Ntx8cvMidiTransport transport,
+    required this.deviceId,
+    Ntx8cvSysExCodec codec = const Ntx8cvSysExCodec(),
+    this.timeout = const Duration(seconds: 1),
+  }) : _transport = transport,
+       _codec = codec {
+    _validateDeviceId(deviceId);
+    if (timeout < Duration.zero) {
+      throw ArgumentError.value(timeout, 'timeout', 'must not be negative');
+    }
+    _subscription = _transport.receivedPackets.listen(
+      _handlePacket,
+      onError: _handleStreamError,
+    );
+  }
+
+  final Ntx8cvMidiTransport _transport;
+  final Ntx8cvSysExCodec _codec;
+  final int deviceId;
+  final Duration timeout;
+  late final StreamSubscription<Uint8List> _subscription;
+  _PendingNtx8cvRequest? _pending;
+  bool _isClosed = false;
+
+  Future<Ntx8cvDeviceInformation> requestDeviceInformation() async {
+    final response = await _sendAndAwait(
+      packet: _codec.requestDeviceInformation(deviceId: deviceId),
+      operation: 'device information',
+      matches: (message) => message is Ntx8cvDeviceInformation,
+    );
+    return response as Ntx8cvDeviceInformation;
+  }
+
+  Future<Ntx8cvSettingValue> readSetting({required int settingId}) async {
+    _validateDataByte(settingId, 'settingId');
+    final response = await _sendAndAwait(
+      packet: _codec.readSetting(deviceId: deviceId, settingId: settingId),
+      operation:
+          'read setting 0x${settingId.toRadixString(16).padLeft(2, '0').toUpperCase()}',
+      matches: (message) =>
+          message is Ntx8cvSettingValue && message.settingId == settingId,
+    );
+    return response as Ntx8cvSettingValue;
+  }
+
+  /// Sends a setting write. The protocol has no write acknowledgement.
+  Future<void> writeSetting({
+    required int settingId,
+    required int value,
+  }) async {
+    _ensureOpen();
+    _validateDataByte(settingId, 'settingId');
+    _validateDataByte(value, 'value');
+    await _transport.send(
+      _codec.writeSetting(
+        deviceId: deviceId,
+        settingId: settingId,
+        value: value,
+      ),
+    );
+  }
+
+  /// Writes [value] then confirms it only with a matching setting readback.
+  Future<Ntx8cvSettingValue> writeAndConfirmSetting({
+    required int settingId,
+    required int value,
+  }) async {
+    await writeSetting(settingId: settingId, value: value);
+    final readback = await readSetting(settingId: settingId);
+    if (readback.value != value) {
+      throw StateError(
+        'NTX-8CV readback for setting 0x${settingId.toRadixString(16)} '
+        'was ${readback.value}, expected $value.',
+      );
+    }
+    return readback;
+  }
+
+  Future<void> reboot() async {
+    _ensureOpen();
+    await _transport.send(_codec.reboot(deviceId: deviceId));
+  }
+
+  Future<void> close() async {
+    if (_isClosed) return;
+    _isClosed = true;
+    final pending = _pending;
+    _pending = null;
+    pending?.cancelTimeout();
+    if (pending != null && !pending.isComplete) {
+      pending.completeError(StateError('The NTX-8CV session was closed.'));
+    }
+    await _subscription.cancel();
+  }
+
+  Future<Ntx8cvIncomingMessage> _sendAndAwait({
+    required Uint8List packet,
+    required String operation,
+    required bool Function(Ntx8cvIncomingMessage message) matches,
+  }) async {
+    _ensureOpen();
+    if (_pending != null) {
+      throw StateError('An NTX-8CV request is already waiting for a response.');
+    }
+
+    final pending = _PendingNtx8cvRequest(
+      operation: operation,
+      matches: matches,
+    );
+    _pending = pending;
+    try {
+      await _transport.send(packet);
+    } catch (_) {
+      if (identical(_pending, pending)) {
+        _pending = null;
+      }
+      pending.cancelTimeout();
+      rethrow;
+    }
+
+    if (!pending.isComplete) {
+      pending.startTimeout(timeout, () {
+        if (!identical(_pending, pending)) return;
+        _pending = null;
+        pending.completeError(
+          Ntx8cvTimeoutException(operation: operation, timeout: timeout),
+        );
+      });
+    }
+    return pending.future;
+  }
+
+  void _handlePacket(Uint8List packet) {
+    final pending = _pending;
+    final message = _codec.decode(packet);
+    if (pending == null || message == null || message.deviceId != deviceId) {
+      return;
+    }
+    if (!pending.matches(message)) return;
+
+    _pending = null;
+    pending.cancelTimeout();
+    pending.complete(message);
+  }
+
+  void _handleStreamError(Object error, StackTrace stackTrace) {
+    final pending = _pending;
+    if (pending == null) return;
+
+    _pending = null;
+    pending.cancelTimeout();
+    pending.completeError(Ntx8cvTransportException(error), stackTrace);
+  }
+
+  void _ensureOpen() {
+    if (_isClosed) {
+      throw StateError('The NTX-8CV session is closed.');
+    }
+  }
+
+  static void _validateDeviceId(int value) =>
+      _validateDataByte(value, 'deviceId');
+
+  static void _validateDataByte(int value, String name) {
+    if (value < 0 || value > kNtx8cvAnyDeviceId) {
+      throw ArgumentError.value(value, name, 'must be a MIDI 7-bit value');
+    }
+  }
+}
+
+class _PendingNtx8cvRequest {
+  _PendingNtx8cvRequest({required this.operation, required this.matches});
+
+  final String operation;
+  final bool Function(Ntx8cvIncomingMessage message) matches;
+  final Completer<Ntx8cvIncomingMessage> _completer = Completer();
+  Timer? _timer;
+
+  bool get isComplete => _completer.isCompleted;
+  Future<Ntx8cvIncomingMessage> get future => _completer.future;
+
+  void startTimeout(Duration timeout, void Function() onTimeout) {
+    _timer = Timer(timeout, onTimeout);
+  }
+
+  void cancelTimeout() => _timer?.cancel();
+
+  void complete(Ntx8cvIncomingMessage message) {
+    if (!_completer.isCompleted) _completer.complete(message);
+  }
+
+  void completeError(Object error, [StackTrace? stackTrace]) {
+    if (!_completer.isCompleted) _completer.completeError(error, stackTrace);
+  }
+}

--- a/lib/domain/ntx_8cv/ntx_8cv_sysex.dart
+++ b/lib/domain/ntx_8cv/ntx_8cv_sysex.dart
@@ -219,6 +219,17 @@ class Ntx8cvTransportException implements Exception {
   String toString() => 'Ntx8cvTransportException($cause)';
 }
 
+/// Reports a malformed response from the selected NTX-8CV while a request was
+/// pending. Frames from another device family or device ID remain ignored.
+class Ntx8cvMalformedResponseException implements Exception {
+  const Ntx8cvMalformedResponseException({required this.operation});
+
+  final String operation;
+
+  @override
+  String toString() => 'Ntx8cvMalformedResponseException($operation)';
+}
+
 /// Serializes NTX-8CV requests and matches responses for one selected device.
 ///
 /// The session makes no implicit retries. A setting is only confirmed by
@@ -360,11 +371,20 @@ class Ntx8cvSession {
 
   void _handlePacket(Uint8List packet) {
     final pending = _pending;
+    if (pending == null) return;
+
     final message = _codec.decode(packet);
-    if (pending == null || message == null || message.deviceId != deviceId) {
+    if (message == null) {
+      if (_isMalformedFrameForSelectedDevice(packet)) {
+        _pending = null;
+        pending.cancelTimeout();
+        pending.completeError(
+          Ntx8cvMalformedResponseException(operation: pending.operation),
+        );
+      }
       return;
     }
-    if (!pending.matches(message)) return;
+    if (message.deviceId != deviceId || !pending.matches(message)) return;
 
     _pending = null;
     pending.cancelTimeout();
@@ -379,6 +399,15 @@ class Ntx8cvSession {
     pending.cancelTimeout();
     pending.completeError(Ntx8cvTransportException(error), stackTrace);
   }
+
+  bool _isMalformedFrameForSelectedDevice(Uint8List packet) =>
+      packet.length >= 6 &&
+      packet[0] == _sysExStart &&
+      packet[1] == kNtx8cvManufacturerId[0] &&
+      packet[2] == kNtx8cvManufacturerId[1] &&
+      packet[3] == kNtx8cvManufacturerId[2] &&
+      packet[4] == kNtx8cvProductByte &&
+      packet[5] == deviceId;
 
   void _ensureOpen() {
     if (_isClosed) {

--- a/lib/ui/ntx_8cv/ntx_8cv_screen.dart
+++ b/lib/ui/ntx_8cv/ntx_8cv_screen.dart
@@ -127,6 +127,10 @@ class _Ntx8cvScreenState extends State<Ntx8cvScreen> {
                                     onEs5Changed: _settingsCubit.setEs5Enabled,
                                     onRetryEs5Change:
                                         _settingsCubit.retryEs5Change,
+                                    onModeChanged:
+                                        _settingsCubit.setExpansionMode,
+                                    onRetryModeChange:
+                                        _settingsCubit.retryModeChange,
                                   ),
                             ),
                       ),
@@ -430,7 +434,7 @@ class _MidiEndpointField extends StatelessWidget {
   }
 }
 
-/// Displays the device-confirmed ES-5 value and any explicit retry action.
+/// Displays device-confirmed settings and explicit recovery actions.
 class Ntx8cvSettingsSection extends StatelessWidget {
   const Ntx8cvSettingsSection({
     super.key,
@@ -438,21 +442,30 @@ class Ntx8cvSettingsSection extends StatelessWidget {
     required this.state,
     required this.onEs5Changed,
     required this.onRetryEs5Change,
+    required this.onModeChanged,
+    required this.onRetryModeChange,
   });
 
   final bool isConnected;
   final Ntx8cvSettingsState state;
   final Future<void> Function(bool) onEs5Changed;
   final Future<void> Function() onRetryEs5Change;
+  final Future<void> Function(Ntx8cvExpansionMode) onModeChanged;
+  final Future<void> Function() onRetryModeChange;
 
   @override
   Widget build(BuildContext context) {
     final canChangeEs5 =
         isConnected &&
         state.confirmedEs5Enabled != null &&
-        !state.isLoadingEs5 &&
-        !state.isWritingEs5 &&
+        !state.isBusy &&
         !state.hasPendingEs5Change;
+    final canChangeMode =
+        isConnected &&
+        state.confirmedMode != null &&
+        state.modeCapabilityEvidenced &&
+        !state.isBusy &&
+        !state.hasPendingModeChange;
 
     return Card(
       child: Padding(
@@ -490,10 +503,49 @@ class Ntx8cvSettingsSection extends StatelessWidget {
               const SizedBox(height: 8),
               OutlinedButton.icon(
                 key: const Key('ntx8cv-retry-es5-change'),
-                onPressed:
-                    isConnected && !state.isLoadingEs5 && !state.isWritingEs5
+                onPressed: isConnected && !state.isBusy
                     ? () {
                         unawaited(onRetryEs5Change());
+                      }
+                    : null,
+                icon: const Icon(Icons.refresh),
+                label: const Text('Retry send'),
+              ),
+            ],
+            const SizedBox(height: 24),
+            DropdownButtonFormField<Ntx8cvExpansionMode>(
+              key: ValueKey('ntx8cv-expansion-mode-${state.confirmedMode}'),
+              initialValue: state.confirmedMode,
+              decoration: InputDecoration(
+                labelText: 'NT expansion mode',
+                helperText: _modeDescription(),
+              ),
+              items: Ntx8cvExpansionMode.values
+                  .map(
+                    (mode) =>
+                        DropdownMenuItem(value: mode, child: Text(mode.label)),
+                  )
+                  .toList(),
+              onChanged: canChangeMode
+                  ? (mode) {
+                      if (mode != null) {
+                        unawaited(onModeChanged(mode));
+                      }
+                    }
+                  : null,
+            ),
+            const SizedBox(height: 8),
+            Semantics(liveRegion: true, child: Text(_modeStatus())),
+            if (state.hasPendingModeChange) ...[
+              const SizedBox(height: 8),
+              OutlinedButton.icon(
+                key: const Key('ntx8cv-retry-mode-change'),
+                onPressed:
+                    isConnected &&
+                        state.modeCapabilityEvidenced &&
+                        !state.isBusy
+                    ? () {
+                        unawaited(onRetryModeChange());
                       }
                     : null,
                 icon: const Icon(Icons.refresh),
@@ -507,33 +559,68 @@ class Ntx8cvSettingsSection extends StatelessWidget {
   }
 
   String _es5Description() {
-    if (!isConnected) {
-      return 'Connect an NTX-8CV to read this setting.';
-    }
+    if (!isConnected) return 'Connect an NTX-8CV to read this setting.';
     if (state.confirmedEs5Enabled == null) {
       return 'Waiting for a device-confirmed value.';
     }
     return 'Changes are sent immediately and confirmed by reading the setting back.';
   }
 
-  String _es5Status() {
-    if (state.isLoadingEs5) return 'Reading ES-5 setting from the NTX-8CV.';
-    if (state.isWritingEs5) {
-      return 'Sending the ES-5 change and waiting for device readback.';
+  String _modeDescription() {
+    if (!isConnected) return 'Connect an NTX-8CV to probe this setting.';
+    if (!state.modeCapabilityEvidenced) {
+      return state.modeMessage ?? 'Mode capability has not been evidenced.';
     }
+    return 'Changes are sent immediately and take effect after reboot.';
+  }
+
+  String _es5Status() {
     if (state.hasPendingEs5Change) {
       final attempted = state.attemptedEs5Enabled! ? 'enabled' : 'disabled';
       final confirmed = state.confirmedEs5Enabled == null
           ? 'No device-confirmed value is available.'
           : 'Last device-confirmed value: '
                 '${state.confirmedEs5Enabled! ? 'enabled' : 'disabled'}.';
-      return 'Attempted ES-5 value: $attempted, not confirmed. $confirmed '
-          '${state.es5Message ?? 'The actual device state is uncertain.'}';
+      final progress = state.isWritingEs5
+          ? 'Sending and waiting for device readback.'
+          : state.es5Message ?? 'The actual device state is uncertain.';
+      return 'Attempted ES-5 value: $attempted, pending/failed and not '
+          'device-confirmed. $confirmed $progress';
     }
+    if (state.isLoadingEs5) return 'Reading ES-5 setting from the NTX-8CV.';
     if (state.confirmedEs5Enabled != null) {
       return 'Device-confirmed ES-5 value: '
           '${state.confirmedEs5Enabled! ? 'enabled' : 'disabled'}.';
     }
     return state.es5Message ?? 'No device-confirmed ES-5 value is available.';
+  }
+
+  String _modeStatus() {
+    if (state.hasPendingModeChange) {
+      final attempted = state.attemptedMode?.label ?? 'an invalid value';
+      final confirmed = state.confirmedMode == null
+          ? 'No device-confirmed value is available.'
+          : 'Last device-confirmed value: ${state.confirmedMode!.label}.';
+      final progress = state.isWritingMode
+          ? 'Sending and waiting for device readback.'
+          : state.modeMessage ?? 'The actual device state is uncertain.';
+      return 'Attempted NT expansion mode: $attempted, pending/failed and not '
+          'device-confirmed. $confirmed $progress';
+    }
+    if (state.isLoadingMode) {
+      return 'Probing NT expansion mode capability from the NTX-8CV.';
+    }
+    if (!state.modeCapabilityEvidenced) {
+      return state.modeMessage ?? 'Mode capability has not been evidenced.';
+    }
+    final confirmed = state.confirmedMode;
+    if (confirmed == null) {
+      return 'No device-confirmed mode value is available.';
+    }
+    final reboot = state.modeRebootRequired
+        ? ' Reboot required: this confirmed Mode change is stored but does '
+              'not take effect until this NTX-8CV is rebooted.'
+        : '';
+    return 'Device-confirmed NT expansion mode: ${confirmed.label}.$reboot';
   }
 }

--- a/lib/ui/ntx_8cv/ntx_8cv_screen.dart
+++ b/lib/ui/ntx_8cv/ntx_8cv_screen.dart
@@ -4,13 +4,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_midi_command/flutter_midi_command.dart';
 import 'package:nt_helper/cubit/ntx_8cv_connection_cubit.dart';
+import 'package:nt_helper/cubit/ntx_8cv_settings_cubit.dart';
 import 'package:nt_helper/utils/responsive.dart';
 
 /// The primary page for configuring a separately connected NTX-8CV.
 class Ntx8cvScreen extends StatefulWidget {
   const Ntx8cvScreen({super.key, this.connectionCubit});
 
-  /// Supplying a cubit is useful for embedding and automated tests.
+  /// Supplying a connection cubit is useful for embedding and automated tests.
   final Ntx8cvConnectionCubit? connectionCubit;
 
   @override
@@ -19,6 +20,7 @@ class Ntx8cvScreen extends StatefulWidget {
 
 class _Ntx8cvScreenState extends State<Ntx8cvScreen> {
   late final Ntx8cvConnectionCubit _connectionCubit;
+  late final Ntx8cvSettingsCubit _settingsCubit;
   late final bool _ownsConnectionCubit;
   final TextEditingController _deviceIdController = TextEditingController(
     text: '0',
@@ -29,12 +31,14 @@ class _Ntx8cvScreenState extends State<Ntx8cvScreen> {
     super.initState();
     _ownsConnectionCubit = widget.connectionCubit == null;
     _connectionCubit = widget.connectionCubit ?? Ntx8cvConnectionCubit();
+    _settingsCubit = Ntx8cvSettingsCubit(connectionCubit: _connectionCubit);
     unawaited(_connectionCubit.initialize());
   }
 
   @override
   void dispose() {
     _deviceIdController.dispose();
+    unawaited(_settingsCubit.close());
     if (_ownsConnectionCubit) {
       unawaited(_connectionCubit.close());
     }
@@ -108,7 +112,22 @@ class _Ntx8cvScreenState extends State<Ntx8cvScreen> {
                         ),
                       ),
                       const SizedBox(height: 16),
-                      const _SettingsSection(),
+                      BlocBuilder<Ntx8cvConnectionCubit, Ntx8cvConnectionState>(
+                        bloc: _connectionCubit,
+                        builder: (context, connectionState) =>
+                            BlocBuilder<
+                              Ntx8cvSettingsCubit,
+                              Ntx8cvSettingsState
+                            >(
+                              bloc: _settingsCubit,
+                              builder: (context, settingsState) =>
+                                  _SettingsSection(
+                                    isConnected: connectionState.isConnected,
+                                    state: settingsState,
+                                    onEs5Changed: _settingsCubit.setEs5Enabled,
+                                  ),
+                            ),
+                      ),
                     ],
                   ),
                 ),
@@ -410,10 +429,25 @@ class _MidiEndpointField extends StatelessWidget {
 }
 
 class _SettingsSection extends StatelessWidget {
-  const _SettingsSection();
+  const _SettingsSection({
+    required this.isConnected,
+    required this.state,
+    required this.onEs5Changed,
+  });
+
+  final bool isConnected;
+  final Ntx8cvSettingsState state;
+  final Future<void> Function(bool) onEs5Changed;
 
   @override
   Widget build(BuildContext context) {
+    final canChangeEs5 =
+        isConnected &&
+        state.confirmedEs5Enabled != null &&
+        !state.isLoadingEs5 &&
+        !state.isWritingEs5 &&
+        !state.hasPendingEs5Change;
+
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -433,9 +467,53 @@ class _SettingsSection extends StatelessWidget {
               'NTX-8CV Channel Group remains separate from the disting NT’s '
               'granular channel-enable controls.',
             ),
+            const SizedBox(height: 16),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Enable ES-5'),
+              subtitle: Text(_es5Description()),
+              value: state.confirmedEs5Enabled ?? false,
+              onChanged: canChangeEs5
+                  ? (enabled) {
+                      unawaited(onEs5Changed(enabled));
+                    }
+                  : null,
+            ),
+            Semantics(liveRegion: true, child: Text(_es5Status())),
           ],
         ),
       ),
     );
+  }
+
+  String _es5Description() {
+    if (!isConnected) {
+      return 'Connect an NTX-8CV to read this setting.';
+    }
+    if (state.confirmedEs5Enabled == null) {
+      return 'Waiting for a device-confirmed value.';
+    }
+    return 'Changes are sent immediately and confirmed by reading the setting back.';
+  }
+
+  String _es5Status() {
+    if (state.isLoadingEs5) return 'Reading ES-5 setting from the NTX-8CV.';
+    if (state.isWritingEs5) {
+      return 'Sending the ES-5 change and waiting for device readback.';
+    }
+    if (state.hasPendingEs5Change) {
+      final attempted = state.attemptedEs5Enabled! ? 'enabled' : 'disabled';
+      final confirmed = state.confirmedEs5Enabled == null
+          ? 'No device-confirmed value is available.'
+          : 'Last device-confirmed value: '
+                '${state.confirmedEs5Enabled! ? 'enabled' : 'disabled'}.';
+      return 'Attempted ES-5 value: $attempted, not confirmed. $confirmed '
+          '${state.es5Message ?? 'The actual device state is uncertain.'}';
+    }
+    if (state.confirmedEs5Enabled != null) {
+      return 'Device-confirmed ES-5 value: '
+          '${state.confirmedEs5Enabled! ? 'enabled' : 'disabled'}.';
+    }
+    return state.es5Message ?? 'No device-confirmed ES-5 value is available.';
   }
 }

--- a/lib/ui/ntx_8cv/ntx_8cv_screen.dart
+++ b/lib/ui/ntx_8cv/ntx_8cv_screen.dart
@@ -531,7 +531,7 @@ class Ntx8cvSettingsSection extends StatelessWidget {
         state.modeCapabilityEvidenced &&
         !state.isBusy &&
         !state.hasPendingModeChange;
-    final canChangeAudioChannels =
+    final canOperateAudioChannels =
         isConnected && _audioChannelsApply && !state.isBusy;
     final canReboot = isConnected && !state.isBusy;
     final audioChannelTiles = [
@@ -545,9 +545,10 @@ class Ntx8cvSettingsSection extends StatelessWidget {
           hasPendingChange: state.hasPendingAudioChannelChange(channel),
           status: _audioChannelStatus(channel),
           enabled:
-              canChangeAudioChannels &&
+              canOperateAudioChannels &&
               state.confirmedAudioChannelEnabled(channel) != null &&
               !state.hasPendingAudioChannelChange(channel),
+          retryEnabled: canOperateAudioChannels,
           onChanged: (enabled) {
             unawaited(onAudioChannelChanged(channel, enabled));
           },
@@ -1027,6 +1028,7 @@ class _AudioChannelTile extends StatelessWidget {
     required this.hasPendingChange,
     required this.status,
     required this.enabled,
+    required this.retryEnabled,
     required this.onChanged,
     required this.onRetry,
   });
@@ -1038,6 +1040,7 @@ class _AudioChannelTile extends StatelessWidget {
   final bool hasPendingChange;
   final String status;
   final bool enabled;
+  final bool retryEnabled;
   final ValueChanged<bool> onChanged;
   final VoidCallback onRetry;
 
@@ -1085,7 +1088,7 @@ class _AudioChannelTile extends StatelessWidget {
                     alignment: Alignment.centerLeft,
                     child: TextButton.icon(
                       key: Key('ntx8cv-retry-audio-channel-${channel.number}'),
-                      onPressed: enabled ? onRetry : null,
+                      onPressed: retryEnabled ? onRetry : null,
                       icon: const Icon(Icons.refresh, size: 16),
                       label: const Text('Retry send'),
                     ),

--- a/lib/ui/ntx_8cv/ntx_8cv_screen.dart
+++ b/lib/ui/ntx_8cv/ntx_8cv_screen.dart
@@ -135,6 +135,7 @@ class _Ntx8cvScreenState extends State<Ntx8cvScreen> {
                                         _settingsCubit.setExpansionMode,
                                     onRetryModeChange:
                                         _settingsCubit.retryModeChange,
+                                    onReboot: _settingsCubit.reboot,
                                   ),
                             ),
                       ),
@@ -450,6 +451,7 @@ class Ntx8cvSettingsSection extends StatelessWidget {
     required this.onRetryEs5Change,
     required this.onModeChanged,
     required this.onRetryModeChange,
+    required this.onReboot,
   });
 
   final bool isConnected;
@@ -460,6 +462,7 @@ class Ntx8cvSettingsSection extends StatelessWidget {
   final Future<void> Function() onRetryEs5Change;
   final Future<void> Function(Ntx8cvExpansionMode) onModeChanged;
   final Future<void> Function() onRetryModeChange;
+  final Future<void> Function() onReboot;
 
   @override
   Widget build(BuildContext context) {
@@ -479,6 +482,7 @@ class Ntx8cvSettingsSection extends StatelessWidget {
         state.modeCapabilityEvidenced &&
         !state.isBusy &&
         !state.hasPendingModeChange;
+    final canReboot = isConnected && !state.isBusy;
 
     return Card(
       child: Padding(
@@ -486,13 +490,49 @@ class Ntx8cvSettingsSection extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Semantics(
-              header: true,
-              child: Text(
-                'Settings',
-                style: Theme.of(context).textTheme.titleLarge,
-              ),
+            Row(
+              children: [
+                Expanded(
+                  child: Semantics(
+                    header: true,
+                    child: Text(
+                      'Settings',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Semantics(
+                  label:
+                      'Reboot only the currently selected, identity-verified '
+                      'NTX-8CV',
+                  child: FilledButton.icon(
+                    key: const Key('ntx8cv-reboot'),
+                    onPressed: canReboot
+                        ? () {
+                            unawaited(onReboot());
+                          }
+                        : null,
+                    icon: const Icon(Icons.restart_alt),
+                    label: Text(
+                      state.isRebooting
+                          ? 'Rebooting NTX-8CV'
+                          : 'Reboot NTX-8CV',
+                    ),
+                  ),
+                ),
+              ],
             ),
+            if (state.rebootMessage != null) ...[
+              const SizedBox(height: 8),
+              Semantics(
+                liveRegion: true,
+                child: Text(
+                  state.rebootMessage!,
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+              ),
+            ],
             const SizedBox(height: 8),
             const Text(
               'Connect an NTX-8CV to read and configure its settings. The '
@@ -525,7 +565,7 @@ class Ntx8cvSettingsSection extends StatelessWidget {
                 label: const Text('Retry send'),
               ),
             ],
-            const SizedBox(height: 24),
+            const SizedBox(height: 16),
             DropdownButtonFormField<Ntx8cvExpansionMode>(
               key: ValueKey('ntx8cv-expansion-mode-${state.confirmedMode}'),
               initialValue: state.confirmedMode,
@@ -565,7 +605,7 @@ class Ntx8cvSettingsSection extends StatelessWidget {
                 label: const Text('Retry send'),
               ),
             ],
-            const SizedBox(height: 24),
+            const SizedBox(height: 16),
             DropdownButtonFormField<Ntx8cvChannelGroup>(
               key: ValueKey(
                 'ntx8cv-channel-group-${state.confirmedChannelGroup}',

--- a/lib/ui/ntx_8cv/ntx_8cv_screen.dart
+++ b/lib/ui/ntx_8cv/ntx_8cv_screen.dart
@@ -1,48 +1,116 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_midi_command/flutter_midi_command.dart';
+import 'package:nt_helper/cubit/ntx_8cv_connection_cubit.dart';
 import 'package:nt_helper/utils/responsive.dart';
 
-/// The entry page for configuring a separately connected NTX-8CV.
-///
-/// Connection behavior and settings reads are added independently of the
-/// disting NT connection. This page deliberately owns no [DistingCubit].
-class Ntx8cvScreen extends StatelessWidget {
-  const Ntx8cvScreen({super.key});
+/// The primary page for configuring a separately connected NTX-8CV.
+class Ntx8cvScreen extends StatefulWidget {
+  const Ntx8cvScreen({super.key, this.connectionCubit});
+
+  /// Supplying a cubit is useful for embedding and automated tests.
+  final Ntx8cvConnectionCubit? connectionCubit;
+
+  @override
+  State<Ntx8cvScreen> createState() => _Ntx8cvScreenState();
+}
+
+class _Ntx8cvScreenState extends State<Ntx8cvScreen> {
+  late final Ntx8cvConnectionCubit _connectionCubit;
+  late final bool _ownsConnectionCubit;
+  final TextEditingController _deviceIdController = TextEditingController(
+    text: '0',
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    _ownsConnectionCubit = widget.connectionCubit == null;
+    _connectionCubit = widget.connectionCubit ?? Ntx8cvConnectionCubit();
+    unawaited(_connectionCubit.initialize());
+  }
+
+  @override
+  void dispose() {
+    _deviceIdController.dispose();
+    if (_ownsConnectionCubit) {
+      unawaited(_connectionCubit.close());
+    }
+    super.dispose();
+  }
+
+  void _syncDeviceIdText(Ntx8cvConnectionState state) {
+    if (_deviceIdController.text == state.deviceIdText) return;
+    _deviceIdController.value = TextEditingValue(
+      text: state.deviceIdText,
+      selection: TextSelection.collapsed(offset: state.deviceIdText.length),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     final isNarrow = Responsive.isMobile(context);
     final theme = Theme.of(context);
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('NTX-8CV')),
-      body: SafeArea(
-        child: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 1100),
-            child: SingleChildScrollView(
-              padding: Responsive.getScreenPadding(context),
-              child: FocusTraversalGroup(
-                policy: OrderedTraversalPolicy(),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Semantics(
-                      header: true,
-                      child: Text(
-                        'NTX-8CV',
-                        style: theme.textTheme.headlineMedium,
+    return BlocListener<Ntx8cvConnectionCubit, Ntx8cvConnectionState>(
+      bloc: _connectionCubit,
+      listener: (_, state) => _syncDeviceIdText(state),
+      child: Scaffold(
+        appBar: AppBar(title: const Text('NTX-8CV')),
+        body: SafeArea(
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 1100),
+              child: SingleChildScrollView(
+                padding: Responsive.getScreenPadding(context),
+                child: FocusTraversalGroup(
+                  policy: OrderedTraversalPolicy(),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Semantics(
+                        header: true,
+                        child: Text(
+                          'NTX-8CV',
+                          style: theme.textTheme.headlineMedium,
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 8),
-                    const Text(
-                      'Connect the NTX-8CV directly. Its USB MIDI connection '
-                      'is separate from your disting NT.',
-                    ),
-                    const SizedBox(height: 24),
-                    _ConnectionSection(isNarrow: isNarrow),
-                    const SizedBox(height: 16),
-                    const _SettingsSection(),
-                  ],
+                      const SizedBox(height: 8),
+                      const Text(
+                        'Connect the NTX-8CV directly. Its USB MIDI connection '
+                        'is separate from your disting NT.',
+                      ),
+                      const SizedBox(height: 24),
+                      BlocBuilder<Ntx8cvConnectionCubit, Ntx8cvConnectionState>(
+                        bloc: _connectionCubit,
+                        builder: (context, state) => _ConnectionSection(
+                          isNarrow: isNarrow,
+                          state: state,
+                          deviceIdController: _deviceIdController,
+                          onRefresh: _connectionCubit.refreshEndpoints,
+                          onInputChanged: (device) {
+                            unawaited(
+                              _connectionCubit.selectInputDevice(device),
+                            );
+                          },
+                          onOutputChanged: (device) {
+                            unawaited(
+                              _connectionCubit.selectOutputDevice(device),
+                            );
+                          },
+                          onDeviceIdChanged: (value) {
+                            unawaited(_connectionCubit.setDeviceIdText(value));
+                          },
+                          onConnect: _connectionCubit.connect,
+                          onDisconnect: _connectionCubit.disconnect,
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      const _SettingsSection(),
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -54,12 +122,40 @@ class Ntx8cvScreen extends StatelessWidget {
 }
 
 class _ConnectionSection extends StatelessWidget {
-  const _ConnectionSection({required this.isNarrow});
+  const _ConnectionSection({
+    required this.isNarrow,
+    required this.state,
+    required this.deviceIdController,
+    required this.onRefresh,
+    required this.onInputChanged,
+    required this.onOutputChanged,
+    required this.onDeviceIdChanged,
+    required this.onConnect,
+    required this.onDisconnect,
+  });
 
   final bool isNarrow;
+  final Ntx8cvConnectionState state;
+  final TextEditingController deviceIdController;
+  final Future<void> Function() onRefresh;
+  final ValueChanged<MidiDevice?> onInputChanged;
+  final ValueChanged<MidiDevice?> onOutputChanged;
+  final ValueChanged<String> onDeviceIdChanged;
+  final Future<void> Function() onConnect;
+  final Future<void> Function() onDisconnect;
 
   @override
   Widget build(BuildContext context) {
+    final controls = _ConnectionControls(
+      state: state,
+      deviceIdController: deviceIdController,
+      onInputChanged: onInputChanged,
+      onOutputChanged: onOutputChanged,
+      onDeviceIdChanged: onDeviceIdChanged,
+      onConnect: onConnect,
+      onDisconnect: onDisconnect,
+    );
+
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -77,12 +173,22 @@ class _ConnectionSection extends StatelessWidget {
                     ),
                   ),
                 ),
+                IconButton(
+                  icon: const Icon(Icons.refresh),
+                  tooltip: 'Refresh NTX-8CV MIDI endpoints',
+                  onPressed: state.isConnecting
+                      ? null
+                      : () {
+                          unawaited(onRefresh());
+                        },
+                ),
+                const SizedBox(width: 4),
                 Semantics(
                   liveRegion: true,
-                  label: 'NTX-8CV connection status: Disconnected',
+                  label: 'NTX-8CV connection status: ${state.statusLabel}',
                   child: Chip(
-                    avatar: Icon(Icons.link_off),
-                    label: Text('Disconnected'),
+                    avatar: Icon(_statusIcon(state.status)),
+                    label: Text(state.statusLabel),
                   ),
                 ),
               ],
@@ -94,18 +200,51 @@ class _ConnectionSection extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             if (isNarrow)
-              const _NarrowConnectionControls()
+              _NarrowConnectionControls(controls: controls)
             else
-              const _WideConnectionControls(),
+              _WideConnectionControls(controls: controls),
+            if (state.statusMessage != null) ...[
+              const SizedBox(height: 12),
+              Semantics(
+                liveRegion: true,
+                child: Text(
+                  state.statusMessage!,
+                  style: TextStyle(
+                    color: state.status == Ntx8cvConnectionStatus.failed
+                        ? Theme.of(context).colorScheme.error
+                        : null,
+                  ),
+                ),
+              ),
+            ],
+            if (state.isConnected) ...[
+              const SizedBox(height: 12),
+              Semantics(
+                liveRegion: true,
+                child: const Text(
+                  'Device information verified from the selected MIDI input.',
+                ),
+              ),
+            ],
           ],
         ),
       ),
     );
   }
+
+  static IconData _statusIcon(Ntx8cvConnectionStatus status) =>
+      switch (status) {
+        Ntx8cvConnectionStatus.disconnected => Icons.link_off,
+        Ntx8cvConnectionStatus.connecting => Icons.sync,
+        Ntx8cvConnectionStatus.connected => Icons.link,
+        Ntx8cvConnectionStatus.failed => Icons.error_outline,
+      };
 }
 
 class _WideConnectionControls extends StatelessWidget {
-  const _WideConnectionControls();
+  const _WideConnectionControls({required this.controls});
+
+  final _ConnectionControls controls;
 
   @override
   Widget build(BuildContext context) {
@@ -113,22 +252,15 @@ class _WideConnectionControls extends StatelessWidget {
       key: const Key('ntx8cv-connection-controls-wide'),
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Expanded(child: _MidiEndpointField(label: 'MIDI input')),
-        SizedBox(width: 12),
-        Expanded(child: _MidiEndpointField(label: 'MIDI output')),
-        SizedBox(width: 12),
-        Expanded(child: _DeviceIdField()),
-        SizedBox(width: 12),
+        Expanded(child: controls.inputField()),
+        const SizedBox(width: 12),
+        Expanded(child: controls.outputField()),
+        const SizedBox(width: 12),
+        Expanded(child: controls.deviceIdField()),
+        const SizedBox(width: 12),
         Padding(
-          padding: EdgeInsets.only(top: 4),
-          child: Tooltip(
-            message: 'Choose an NTX-8CV MIDI input and output to connect.',
-            child: FilledButton.icon(
-              onPressed: null,
-              icon: Icon(Icons.link),
-              label: Text('Connect'),
-            ),
-          ),
+          padding: const EdgeInsets.only(top: 4),
+          child: controls.button(),
         ),
       ],
     );
@@ -136,7 +268,9 @@ class _WideConnectionControls extends StatelessWidget {
 }
 
 class _NarrowConnectionControls extends StatelessWidget {
-  const _NarrowConnectionControls();
+  const _NarrowConnectionControls({required this.controls});
+
+  final _ConnectionControls controls;
 
   @override
   Widget build(BuildContext context) {
@@ -144,56 +278,132 @@ class _NarrowConnectionControls extends StatelessWidget {
       key: const Key('ntx8cv-connection-controls-narrow'),
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _MidiEndpointField(label: 'MIDI input'),
-        SizedBox(height: 12),
-        _MidiEndpointField(label: 'MIDI output'),
-        SizedBox(height: 12),
-        _DeviceIdField(),
-        SizedBox(height: 16),
-        Tooltip(
-          message: 'Choose an NTX-8CV MIDI input and output to connect.',
-          child: FilledButton.icon(
-            onPressed: null,
-            icon: Icon(Icons.link),
-            label: Text('Connect'),
-          ),
-        ),
+        controls.inputField(),
+        const SizedBox(height: 12),
+        controls.outputField(),
+        const SizedBox(height: 12),
+        controls.deviceIdField(),
+        const SizedBox(height: 16),
+        controls.button(),
       ],
     );
   }
 }
 
-class _MidiEndpointField extends StatelessWidget {
-  const _MidiEndpointField({required this.label});
+class _ConnectionControls {
+  const _ConnectionControls({
+    required this.state,
+    required this.deviceIdController,
+    required this.onInputChanged,
+    required this.onOutputChanged,
+    required this.onDeviceIdChanged,
+    required this.onConnect,
+    required this.onDisconnect,
+  });
 
-  final String label;
+  final Ntx8cvConnectionState state;
+  final TextEditingController deviceIdController;
+  final ValueChanged<MidiDevice?> onInputChanged;
+  final ValueChanged<MidiDevice?> onOutputChanged;
+  final ValueChanged<String> onDeviceIdChanged;
+  final Future<void> Function() onConnect;
+  final Future<void> Function() onDisconnect;
 
-  @override
-  Widget build(BuildContext context) {
-    return TextFormField(
-      enabled: false,
-      initialValue: 'No MIDI endpoint selected',
-      decoration: InputDecoration(
-        labelText: label,
-        border: const OutlineInputBorder(),
-      ),
+  Widget inputField() => _MidiEndpointField(
+    key: const Key('ntx8cv-midi-input'),
+    label: 'MIDI input',
+    devices: state.inputDevices,
+    selectedDevice: state.selectedInputDevice,
+    enabled: !state.isConnecting,
+    onChanged: onInputChanged,
+  );
+
+  Widget outputField() => _MidiEndpointField(
+    key: const Key('ntx8cv-midi-output'),
+    label: 'MIDI output',
+    devices: state.outputDevices,
+    selectedDevice: state.selectedOutputDevice,
+    enabled: !state.isConnecting,
+    onChanged: onOutputChanged,
+  );
+
+  Widget deviceIdField() => TextFormField(
+    key: const Key('ntx8cv-device-id'),
+    controller: deviceIdController,
+    enabled: !state.isConnecting,
+    keyboardType: TextInputType.number,
+    onChanged: onDeviceIdChanged,
+    decoration: InputDecoration(
+      labelText: 'SysEx device ID',
+      helperText: '0–126',
+      errorText: state.deviceIdError,
+      border: const OutlineInputBorder(),
+    ),
+  );
+
+  Widget button() {
+    if (state.isConnected) {
+      return FilledButton.icon(
+        onPressed: () {
+          unawaited(onDisconnect());
+        },
+        icon: const Icon(Icons.link_off),
+        label: const Text('Disconnect'),
+      );
+    }
+    return FilledButton.icon(
+      onPressed: state.canConnect
+          ? () {
+              unawaited(onConnect());
+            }
+          : null,
+      icon: Icon(state.isConnecting ? Icons.sync : Icons.link),
+      label: Text(state.isConnecting ? 'Connecting' : 'Connect'),
     );
   }
 }
 
-class _DeviceIdField extends StatelessWidget {
-  const _DeviceIdField();
+class _MidiEndpointField extends StatelessWidget {
+  const _MidiEndpointField({
+    super.key,
+    required this.label,
+    required this.devices,
+    required this.selectedDevice,
+    required this.enabled,
+    required this.onChanged,
+  });
+
+  final String label;
+  final List<MidiDevice> devices;
+  final MidiDevice? selectedDevice;
+  final bool enabled;
+  final ValueChanged<MidiDevice?> onChanged;
 
   @override
   Widget build(BuildContext context) {
-    return TextFormField(
-      enabled: false,
-      initialValue: '0',
-      keyboardType: TextInputType.number,
-      decoration: const InputDecoration(
-        labelText: 'SysEx device ID',
-        helperText: '0–126',
-        border: OutlineInputBorder(),
+    MidiDevice? selectedValue;
+    for (final device in devices) {
+      if (device.id == selectedDevice?.id) {
+        selectedValue = device;
+        break;
+      }
+    }
+    return KeyedSubtree(
+      key: ValueKey('$label:${selectedValue?.id}'),
+      child: DropdownButtonFormField<MidiDevice>(
+        key: ValueKey('$label-dropdown'),
+        initialValue: selectedValue,
+        isExpanded: true,
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(),
+        ),
+        hint: const Text('No MIDI endpoint selected'),
+        items: [
+          for (final device in devices)
+            DropdownMenuItem(value: device, child: Text(device.name)),
+        ],
+        onChanged: enabled ? onChanged : null,
       ),
     );
   }

--- a/lib/ui/ntx_8cv/ntx_8cv_screen.dart
+++ b/lib/ui/ntx_8cv/ntx_8cv_screen.dart
@@ -121,10 +121,12 @@ class _Ntx8cvScreenState extends State<Ntx8cvScreen> {
                             >(
                               bloc: _settingsCubit,
                               builder: (context, settingsState) =>
-                                  _SettingsSection(
+                                  Ntx8cvSettingsSection(
                                     isConnected: connectionState.isConnected,
                                     state: settingsState,
                                     onEs5Changed: _settingsCubit.setEs5Enabled,
+                                    onRetryEs5Change:
+                                        _settingsCubit.retryEs5Change,
                                   ),
                             ),
                       ),
@@ -428,16 +430,20 @@ class _MidiEndpointField extends StatelessWidget {
   }
 }
 
-class _SettingsSection extends StatelessWidget {
-  const _SettingsSection({
+/// Displays the device-confirmed ES-5 value and any explicit retry action.
+class Ntx8cvSettingsSection extends StatelessWidget {
+  const Ntx8cvSettingsSection({
+    super.key,
     required this.isConnected,
     required this.state,
     required this.onEs5Changed,
+    required this.onRetryEs5Change,
   });
 
   final bool isConnected;
   final Ntx8cvSettingsState state;
   final Future<void> Function(bool) onEs5Changed;
+  final Future<void> Function() onRetryEs5Change;
 
   @override
   Widget build(BuildContext context) {
@@ -480,6 +486,20 @@ class _SettingsSection extends StatelessWidget {
                   : null,
             ),
             Semantics(liveRegion: true, child: Text(_es5Status())),
+            if (state.hasPendingEs5Change) ...[
+              const SizedBox(height: 8),
+              OutlinedButton.icon(
+                key: const Key('ntx8cv-retry-es5-change'),
+                onPressed:
+                    isConnected && !state.isLoadingEs5 && !state.isWritingEs5
+                    ? () {
+                        unawaited(onRetryEs5Change());
+                      }
+                    : null,
+                icon: const Icon(Icons.refresh),
+                label: const Text('Retry send'),
+              ),
+            ],
           ],
         ),
       ),

--- a/lib/ui/ntx_8cv/ntx_8cv_screen.dart
+++ b/lib/ui/ntx_8cv/ntx_8cv_screen.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:nt_helper/utils/responsive.dart';
+
+/// The entry page for configuring a separately connected NTX-8CV.
+///
+/// Connection behavior and settings reads are added independently of the
+/// disting NT connection. This page deliberately owns no [DistingCubit].
+class Ntx8cvScreen extends StatelessWidget {
+  const Ntx8cvScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final isNarrow = Responsive.isMobile(context);
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('NTX-8CV')),
+      body: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 1100),
+            child: SingleChildScrollView(
+              padding: Responsive.getScreenPadding(context),
+              child: FocusTraversalGroup(
+                policy: OrderedTraversalPolicy(),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Semantics(
+                      header: true,
+                      child: Text(
+                        'NTX-8CV',
+                        style: theme.textTheme.headlineMedium,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    const Text(
+                      'Connect the NTX-8CV directly. Its USB MIDI connection '
+                      'is separate from your disting NT.',
+                    ),
+                    const SizedBox(height: 24),
+                    _ConnectionSection(isNarrow: isNarrow),
+                    const SizedBox(height: 16),
+                    const _SettingsSection(),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ConnectionSection extends StatelessWidget {
+  const _ConnectionSection({required this.isNarrow});
+
+  final bool isNarrow;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Semantics(
+                    header: true,
+                    child: Text(
+                      'Connection',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                  ),
+                ),
+                Semantics(
+                  liveRegion: true,
+                  label: 'NTX-8CV connection status: Disconnected',
+                  child: Chip(
+                    avatar: Icon(Icons.link_off),
+                    label: Text('Disconnected'),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Choose the NTX-8CV MIDI input and output, then connect to '
+              'verify the device before changing its settings.',
+            ),
+            const SizedBox(height: 16),
+            if (isNarrow)
+              const _NarrowConnectionControls()
+            else
+              const _WideConnectionControls(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WideConnectionControls extends StatelessWidget {
+  const _WideConnectionControls();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      key: const Key('ntx8cv-connection-controls-wide'),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(child: _MidiEndpointField(label: 'MIDI input')),
+        SizedBox(width: 12),
+        Expanded(child: _MidiEndpointField(label: 'MIDI output')),
+        SizedBox(width: 12),
+        Expanded(child: _DeviceIdField()),
+        SizedBox(width: 12),
+        Padding(
+          padding: EdgeInsets.only(top: 4),
+          child: Tooltip(
+            message: 'Choose an NTX-8CV MIDI input and output to connect.',
+            child: FilledButton.icon(
+              onPressed: null,
+              icon: Icon(Icons.link),
+              label: Text('Connect'),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _NarrowConnectionControls extends StatelessWidget {
+  const _NarrowConnectionControls();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      key: const Key('ntx8cv-connection-controls-narrow'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _MidiEndpointField(label: 'MIDI input'),
+        SizedBox(height: 12),
+        _MidiEndpointField(label: 'MIDI output'),
+        SizedBox(height: 12),
+        _DeviceIdField(),
+        SizedBox(height: 16),
+        Tooltip(
+          message: 'Choose an NTX-8CV MIDI input and output to connect.',
+          child: FilledButton.icon(
+            onPressed: null,
+            icon: Icon(Icons.link),
+            label: Text('Connect'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _MidiEndpointField extends StatelessWidget {
+  const _MidiEndpointField({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      enabled: false,
+      initialValue: 'No MIDI endpoint selected',
+      decoration: InputDecoration(
+        labelText: label,
+        border: const OutlineInputBorder(),
+      ),
+    );
+  }
+}
+
+class _DeviceIdField extends StatelessWidget {
+  const _DeviceIdField();
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      enabled: false,
+      initialValue: '0',
+      keyboardType: TextInputType.number,
+      decoration: const InputDecoration(
+        labelText: 'SysEx device ID',
+        helperText: '0–126',
+        border: OutlineInputBorder(),
+      ),
+    );
+  }
+}
+
+class _SettingsSection extends StatelessWidget {
+  const _SettingsSection();
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Semantics(
+              header: true,
+              child: Text(
+                'Settings',
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Connect an NTX-8CV to read and configure its settings. The '
+              'NTX-8CV Channel Group remains separate from the disting NT’s '
+              'granular channel-enable controls.',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/ntx_8cv/ntx_8cv_screen.dart
+++ b/lib/ui/ntx_8cv/ntx_8cv_screen.dart
@@ -7,6 +7,9 @@ import 'package:nt_helper/cubit/ntx_8cv_connection_cubit.dart';
 import 'package:nt_helper/cubit/ntx_8cv_settings_cubit.dart';
 import 'package:nt_helper/utils/responsive.dart';
 
+Future<void> _ignoreAudioChannelChange(Ntx8cvAudioChannel _, bool _) async {}
+Future<void> _ignoreAudioChannelRetry(Ntx8cvAudioChannel _) async {}
+
 /// The primary page for configuring a separately connected NTX-8CV.
 class Ntx8cvScreen extends StatefulWidget {
   const Ntx8cvScreen({super.key, this.connectionCubit});
@@ -53,6 +56,11 @@ class _Ntx8cvScreenState extends State<Ntx8cvScreen> {
     );
   }
 
+  Future<void> _refresh() async {
+    await _connectionCubit.refreshEndpoints();
+    await _settingsCubit.refresh();
+  }
+
   @override
   Widget build(BuildContext context) {
     final isNarrow = Responsive.isMobile(context);
@@ -93,7 +101,7 @@ class _Ntx8cvScreenState extends State<Ntx8cvScreen> {
                           isNarrow: isNarrow,
                           state: state,
                           deviceIdController: _deviceIdController,
-                          onRefresh: _connectionCubit.refreshEndpoints,
+                          onRefresh: _refresh,
                           onInputChanged: (device) {
                             unawaited(
                               _connectionCubit.selectInputDevice(device),
@@ -123,6 +131,7 @@ class _Ntx8cvScreenState extends State<Ntx8cvScreen> {
                               builder: (context, settingsState) =>
                                   Ntx8cvSettingsSection(
                                     isConnected: connectionState.isConnected,
+                                    isNarrow: isNarrow,
                                     state: settingsState,
                                     onChannelGroupChanged:
                                         _settingsCubit.setChannelGroup,
@@ -135,6 +144,10 @@ class _Ntx8cvScreenState extends State<Ntx8cvScreen> {
                                         _settingsCubit.setExpansionMode,
                                     onRetryModeChange:
                                         _settingsCubit.retryModeChange,
+                                    onAudioChannelChanged:
+                                        _settingsCubit.setAudioChannelEnabled,
+                                    onRetryAudioChannelChange:
+                                        _settingsCubit.retryAudioChannelChange,
                                     onReboot: _settingsCubit.reboot,
                                   ),
                             ),
@@ -213,12 +226,18 @@ class _ConnectionSection extends StatelessWidget {
                         },
                 ),
                 const SizedBox(width: 4),
-                Semantics(
-                  liveRegion: true,
-                  label: 'NTX-8CV connection status: ${state.statusLabel}',
-                  child: Chip(
-                    avatar: Icon(_statusIcon(state.status)),
-                    label: Text(state.statusLabel),
+                SizedBox(
+                  width: 144,
+                  child: Semantics(
+                    liveRegion: true,
+                    label: 'NTX-8CV connection status: ${state.statusLabel}',
+                    child: Align(
+                      alignment: Alignment.centerRight,
+                      child: Chip(
+                        avatar: Icon(_statusIcon(state.status)),
+                        label: Text(state.statusLabel),
+                      ),
+                    ),
                   ),
                 ),
               ],
@@ -233,29 +252,8 @@ class _ConnectionSection extends StatelessWidget {
               _NarrowConnectionControls(controls: controls)
             else
               _WideConnectionControls(controls: controls),
-            if (state.statusMessage != null) ...[
-              const SizedBox(height: 12),
-              Semantics(
-                liveRegion: true,
-                child: Text(
-                  state.statusMessage!,
-                  style: TextStyle(
-                    color: state.status == Ntx8cvConnectionStatus.failed
-                        ? Theme.of(context).colorScheme.error
-                        : null,
-                  ),
-                ),
-              ),
-            ],
-            if (state.isConnected) ...[
-              const SizedBox(height: 12),
-              Semantics(
-                liveRegion: true,
-                child: const Text(
-                  'Device information verified from the selected MIDI input.',
-                ),
-              ),
-            ],
+            const SizedBox(height: 12),
+            _ConnectionFeedbackRegion(isNarrow: isNarrow, state: state),
           ],
         ),
       ),
@@ -269,6 +267,51 @@ class _ConnectionSection extends StatelessWidget {
         Ntx8cvConnectionStatus.connected => Icons.link,
         Ntx8cvConnectionStatus.failed => Icons.error_outline,
       };
+}
+
+/// A fixed-height connection feedback area keeps endpoint controls from
+/// shifting as lifecycle messages appear, disappear, or change length.
+class _ConnectionFeedbackRegion extends StatelessWidget {
+  const _ConnectionFeedbackRegion({
+    required this.isNarrow,
+    required this.state,
+  });
+
+  final bool isNarrow;
+  final Ntx8cvConnectionState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final message =
+        state.statusMessage ??
+        (state.isLoadingEndpoints
+            ? 'Refreshing NTX-8CV MIDI endpoints.'
+            : state.isConnected
+            ? 'Device information verified from the selected MIDI input.'
+            : 'Select the NTX-8CV MIDI endpoints, then connect to verify it.');
+    final isError = state.status == Ntx8cvConnectionStatus.failed;
+    return SizedBox(
+      height: isNarrow ? 72 : 56,
+      child: Align(
+        alignment: Alignment.topLeft,
+        child: Semantics(
+          liveRegion: true,
+          label: message,
+          child: ExcludeSemantics(
+            child: SingleChildScrollView(
+              primary: false,
+              child: Text(
+                message,
+                style: TextStyle(
+                  color: isError ? Theme.of(context).colorScheme.error : null,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class _WideConnectionControls extends StatelessWidget {
@@ -290,7 +333,7 @@ class _WideConnectionControls extends StatelessWidget {
         const SizedBox(width: 12),
         Padding(
           padding: const EdgeInsets.only(top: 4),
-          child: controls.button(),
+          child: SizedBox(width: 144, child: controls.button()),
         ),
       ],
     );
@@ -444,6 +487,7 @@ class Ntx8cvSettingsSection extends StatelessWidget {
   const Ntx8cvSettingsSection({
     super.key,
     required this.isConnected,
+    this.isNarrow = false,
     required this.state,
     required this.onChannelGroupChanged,
     required this.onRetryChannelGroupChange,
@@ -451,10 +495,13 @@ class Ntx8cvSettingsSection extends StatelessWidget {
     required this.onRetryEs5Change,
     required this.onModeChanged,
     required this.onRetryModeChange,
+    this.onAudioChannelChanged = _ignoreAudioChannelChange,
+    this.onRetryAudioChannelChange = _ignoreAudioChannelRetry,
     required this.onReboot,
   });
 
   final bool isConnected;
+  final bool isNarrow;
   final Ntx8cvSettingsState state;
   final Future<void> Function(Ntx8cvChannelGroup) onChannelGroupChanged;
   final Future<void> Function() onRetryChannelGroupChange;
@@ -462,6 +509,8 @@ class Ntx8cvSettingsSection extends StatelessWidget {
   final Future<void> Function() onRetryEs5Change;
   final Future<void> Function(Ntx8cvExpansionMode) onModeChanged;
   final Future<void> Function() onRetryModeChange;
+  final Future<void> Function(Ntx8cvAudioChannel, bool) onAudioChannelChanged;
+  final Future<void> Function(Ntx8cvAudioChannel) onRetryAudioChannelChange;
   final Future<void> Function() onReboot;
 
   @override
@@ -482,7 +531,31 @@ class Ntx8cvSettingsSection extends StatelessWidget {
         state.modeCapabilityEvidenced &&
         !state.isBusy &&
         !state.hasPendingModeChange;
+    final canChangeAudioChannels =
+        isConnected && _audioChannelsApply && !state.isBusy;
     final canReboot = isConnected && !state.isBusy;
+    final audioChannelTiles = [
+      for (final channel in Ntx8cvAudioChannel.values)
+        _AudioChannelTile(
+          key: Key('ntx8cv-audio-channel-${channel.number}'),
+          isNarrow: isNarrow,
+          channel: channel,
+          confirmedEnabled: state.confirmedAudioChannelEnabled(channel),
+          isWriting: state.isWritingAudioChannel(channel),
+          hasPendingChange: state.hasPendingAudioChannelChange(channel),
+          status: _audioChannelStatus(channel),
+          enabled:
+              canChangeAudioChannels &&
+              state.confirmedAudioChannelEnabled(channel) != null &&
+              !state.hasPendingAudioChannelChange(channel),
+          onChanged: (enabled) {
+            unawaited(onAudioChannelChanged(channel, enabled));
+          },
+          onRetry: () {
+            unawaited(onRetryAudioChannelChange(channel));
+          },
+        ),
+    ];
 
     return Card(
       child: Padding(
@@ -513,37 +586,45 @@ class Ntx8cvSettingsSection extends StatelessWidget {
                             unawaited(onReboot());
                           }
                         : null,
-                    icon: const Icon(Icons.restart_alt),
-                    label: Text(
-                      state.isRebooting
-                          ? 'Rebooting NTX-8CV'
-                          : 'Reboot NTX-8CV',
-                    ),
+                    icon: state.isRebooting
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.restart_alt),
+                    label: const Text('Reboot NTX-8CV'),
                   ),
                 ),
               ],
             ),
-            if (state.rebootMessage != null) ...[
-              const SizedBox(height: 8),
-              Semantics(
-                liveRegion: true,
-                child: Text(
-                  state.rebootMessage!,
-                  style: TextStyle(color: Theme.of(context).colorScheme.error),
-                ),
-              ),
-            ],
             const SizedBox(height: 8),
+            _ReservedSettingsStatusRegion(
+              isNarrow: isNarrow,
+              message:
+                  state.rebootMessage ??
+                  (state.isRebooting
+                      ? 'Rebooting the selected NTX-8CV and reacquiring its settings.'
+                      : ''),
+              isError: state.rebootMessage != null,
+            ),
             const Text(
-              'Connect an NTX-8CV to read and configure its settings. The '
-              'NTX-8CV Channel Group remains separate from the disting NT’s '
-              'granular channel-enable controls.',
+              'Connect an NTX-8CV to read and configure its settings. Channel '
+              'Group is separate from individual NTX-8CV audio-channel '
+              'enablement and does not alter disting NT algorithm routing.',
             ),
             const SizedBox(height: 16),
             SwitchListTile(
               contentPadding: EdgeInsets.zero,
               title: const Text('Enable ES-5'),
-              subtitle: Text(_es5Description()),
+              subtitle: SizedBox(
+                height: 36,
+                child: Text(
+                  _es5Description(),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
               value: state.confirmedEs5Enabled ?? false,
               onChanged: canChangeEs5
                   ? (enabled) {
@@ -551,27 +632,23 @@ class Ntx8cvSettingsSection extends StatelessWidget {
                     }
                   : null,
             ),
-            Semantics(liveRegion: true, child: Text(_es5Status())),
-            if (state.hasPendingEs5Change) ...[
-              const SizedBox(height: 8),
-              OutlinedButton.icon(
-                key: const Key('ntx8cv-retry-es5-change'),
-                onPressed: isConnected && !state.isBusy
-                    ? () {
-                        unawaited(onRetryEs5Change());
-                      }
-                    : null,
-                icon: const Icon(Icons.refresh),
-                label: const Text('Retry send'),
-              ),
-            ],
+            _ReservedSettingsStatusRegion(
+              isNarrow: isNarrow,
+              message: _es5Status(),
+            ),
+            _RecoveryActionSlot(
+              visible: state.hasPendingEs5Change,
+              actionKey: const Key('ntx8cv-retry-es5-change'),
+              enabled: isConnected && !state.isBusy,
+              onPressed: onRetryEs5Change,
+            ),
             const SizedBox(height: 16),
             DropdownButtonFormField<Ntx8cvExpansionMode>(
               key: ValueKey('ntx8cv-expansion-mode-${state.confirmedMode}'),
               initialValue: state.confirmedMode,
-              decoration: InputDecoration(
+              decoration: const InputDecoration(
                 labelText: 'NT expansion mode',
-                helperText: _modeDescription(),
+                border: OutlineInputBorder(),
               ),
               items: Ntx8cvExpansionMode.values
                   .map(
@@ -587,33 +664,62 @@ class Ntx8cvSettingsSection extends StatelessWidget {
                     }
                   : null,
             ),
-            const SizedBox(height: 8),
-            Semantics(liveRegion: true, child: Text(_modeStatus())),
-            if (state.hasPendingModeChange) ...[
-              const SizedBox(height: 8),
-              OutlinedButton.icon(
-                key: const Key('ntx8cv-retry-mode-change'),
-                onPressed:
-                    isConnected &&
-                        state.modeCapabilityEvidenced &&
-                        !state.isBusy
-                    ? () {
-                        unawaited(onRetryModeChange());
-                      }
-                    : null,
-                icon: const Icon(Icons.refresh),
-                label: const Text('Retry send'),
+            _ReservedSettingsDescriptionRegion(
+              isNarrow: isNarrow,
+              message: _modeDescription(),
+            ),
+            _ReservedSettingsStatusRegion(
+              isNarrow: isNarrow,
+              message: _modeStatus(),
+            ),
+            _RecoveryActionSlot(
+              visible: state.hasPendingModeChange,
+              actionKey: const Key('ntx8cv-retry-mode-change'),
+              enabled:
+                  isConnected && state.modeCapabilityEvidenced && !state.isBusy,
+              onPressed: onRetryModeChange,
+            ),
+            const SizedBox(height: 16),
+            Semantics(
+              header: true,
+              child: Text(
+                'Audio channel enablement',
+                style: Theme.of(context).textTheme.titleMedium,
               ),
-            ],
+            ),
+            const SizedBox(height: 8),
+            SizedBox(
+              height: isNarrow ? 56 : 40,
+              child: Text(
+                _audioChannelsDescription(),
+                maxLines: isNarrow ? 3 : 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            if (isNarrow)
+              ...audioChannelTiles
+            else
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Column(children: audioChannelTiles.take(4).toList()),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(children: audioChannelTiles.skip(4).toList()),
+                  ),
+                ],
+              ),
             const SizedBox(height: 16),
             DropdownButtonFormField<Ntx8cvChannelGroup>(
               key: ValueKey(
                 'ntx8cv-channel-group-${state.confirmedChannelGroup}',
               ),
               initialValue: state.confirmedChannelGroup,
-              decoration: InputDecoration(
+              decoration: const InputDecoration(
                 labelText: 'Channel Group',
-                helperText: _channelGroupDescription(),
+                border: OutlineInputBorder(),
               ),
               items: Ntx8cvChannelGroup.values
                   .map(
@@ -631,25 +737,78 @@ class Ntx8cvSettingsSection extends StatelessWidget {
                     }
                   : null,
             ),
-            const SizedBox(height: 8),
-            Semantics(liveRegion: true, child: Text(_channelGroupStatus())),
-            if (state.hasPendingChannelGroupChange) ...[
-              const SizedBox(height: 8),
-              OutlinedButton.icon(
-                key: const Key('ntx8cv-retry-channel-group-change'),
-                onPressed: isConnected && !state.isBusy
-                    ? () {
-                        unawaited(onRetryChannelGroupChange());
-                      }
-                    : null,
-                icon: const Icon(Icons.refresh),
-                label: const Text('Retry send'),
-              ),
-            ],
+            _ReservedSettingsDescriptionRegion(
+              isNarrow: isNarrow,
+              message: _channelGroupDescription(),
+            ),
+            _ReservedSettingsStatusRegion(
+              isNarrow: isNarrow,
+              message: _channelGroupStatus(),
+            ),
+            _RecoveryActionSlot(
+              visible: state.hasPendingChannelGroupChange,
+              actionKey: const Key('ntx8cv-retry-channel-group-change'),
+              enabled: isConnected && !state.isBusy,
+              onPressed: onRetryChannelGroupChange,
+            ),
           ],
         ),
       ),
     );
+  }
+
+  bool get _audioChannelsApply =>
+      !state.modeRebootRequired &&
+      switch (state.confirmedMode) {
+        Ntx8cvExpansionMode.audio1x8_32bit ||
+        Ntx8cvExpansionMode.audio2x8_16bit => true,
+        _ => false,
+      };
+
+  String _audioChannelsDescription() {
+    if (!isConnected) {
+      return 'Connect an NTX-8CV to read its audio-channel enable settings.';
+    }
+    if (!state.modeCapabilityEvidenced) {
+      return 'Audio-channel controls remain unavailable until Mode is evidenced.';
+    }
+    if (state.modeRebootRequired) {
+      return 'Audio-channel changes are unavailable until the confirmed Mode change is applied by rebooting the NTX-8CV.';
+    }
+    if (!_audioChannelsApply) {
+      return 'Audio channels are not applicable while the device-confirmed Mode is 8x8 CV.';
+    }
+    return 'Each channel is read from the selected NTX-8CV and changes require matching readback.';
+  }
+
+  String _audioChannelStatus(Ntx8cvAudioChannel channel) {
+    final change = state.audioChannelChange(channel);
+    if (!isConnected) {
+      return 'Connect to read the device-confirmed state.';
+    }
+    if (state.modeRebootRequired) {
+      return 'Unavailable until the confirmed Mode change is applied by rebooting the NTX-8CV.';
+    }
+    if (!_audioChannelsApply) {
+      return 'Unavailable: this channel applies only in an audio expansion mode.';
+    }
+    if (change.hasPendingChange) {
+      final attempted = state.attemptedAudioChannelEnabled(channel);
+      final confirmed = state.confirmedAudioChannelEnabled(channel);
+      final progress = change.isWriting
+          ? 'Sending and waiting for device readback.'
+          : change.message ?? 'The actual device state is uncertain.';
+      return 'Attempted ${attempted == true ? 'enabled' : 'disabled'}, '
+          'pending/failed and not device-confirmed. '
+          '${confirmed == null ? 'No device-confirmed value is available.' : 'Last device-confirmed value: ${confirmed ? 'enabled' : 'disabled'}.'} '
+          '$progress';
+    }
+    if (change.isLoading) return 'Reading this channel from the NTX-8CV.';
+    final confirmed = state.confirmedAudioChannelEnabled(channel);
+    if (confirmed != null) {
+      return 'Device-confirmed: ${confirmed ? 'enabled' : 'disabled'}.';
+    }
+    return change.message ?? 'No device-confirmed value is available.';
   }
 
   String _channelGroupDescription() {
@@ -657,10 +816,9 @@ class Ntx8cvSettingsSection extends StatelessWidget {
     if (state.confirmedChannelGroup == null) {
       return 'Waiting for a device-confirmed value.';
     }
-    return 'Selects this NTX-8CV’s eight-channel block. This does not replace '
-        'the disting NT’s granular channel-enable controls; configure both '
-        'when needed. Changes are sent immediately and confirmed by reading '
-        'the setting back.';
+    return 'Selects this NTX-8CV’s eight-channel block. It does not enable '
+        'individual audio channels or alter disting NT algorithm routing. '
+        'Changes are sent immediately and confirmed by reading the setting back.';
   }
 
   String _es5Description() {
@@ -753,5 +911,189 @@ class Ntx8cvSettingsSection extends StatelessWidget {
               'not take effect until this NTX-8CV is rebooted.'
         : '';
     return 'Device-confirmed NT expansion mode: ${confirmed.label}.$reboot';
+  }
+}
+
+/// Keeps explanatory text from changing a dropdown's rendered height.
+class _ReservedSettingsDescriptionRegion extends StatelessWidget {
+  const _ReservedSettingsDescriptionRegion({
+    required this.isNarrow,
+    required this.message,
+  });
+
+  final bool isNarrow;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: isNarrow ? 56 : 40,
+      child: Text(
+        message,
+        maxLines: isNarrow ? 3 : 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+}
+
+/// Reserves enough vertical room for all lifecycle and recovery text without
+/// allowing a transient message to move adjacent settings controls.
+class _ReservedSettingsStatusRegion extends StatelessWidget {
+  const _ReservedSettingsStatusRegion({
+    required this.isNarrow,
+    required this.message,
+    this.isError = false,
+  });
+
+  final bool isNarrow;
+  final String message;
+  final bool isError;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: isNarrow ? 72 : 56,
+      child: message.isEmpty
+          ? const SizedBox.shrink()
+          : Align(
+              alignment: Alignment.topLeft,
+              child: Semantics(
+                liveRegion: true,
+                label: message,
+                child: ExcludeSemantics(
+                  child: SingleChildScrollView(
+                    primary: false,
+                    child: Text(
+                      message,
+                      style: TextStyle(
+                        color: isError
+                            ? Theme.of(context).colorScheme.error
+                            : null,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+    );
+  }
+}
+
+/// Keeps recovery actions from changing the settings card's geometry.
+class _RecoveryActionSlot extends StatelessWidget {
+  const _RecoveryActionSlot({
+    required this.visible,
+    required this.actionKey,
+    required this.enabled,
+    required this.onPressed,
+  });
+
+  final bool visible;
+  final Key actionKey;
+  final bool enabled;
+  final Future<void> Function() onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 40,
+      child: visible
+          ? Align(
+              alignment: Alignment.centerLeft,
+              child: OutlinedButton.icon(
+                key: actionKey,
+                onPressed: enabled
+                    ? () {
+                        unawaited(onPressed());
+                      }
+                    : null,
+                icon: const Icon(Icons.refresh),
+                label: const Text('Retry send'),
+              ),
+            )
+          : const SizedBox.shrink(),
+    );
+  }
+}
+
+class _AudioChannelTile extends StatelessWidget {
+  const _AudioChannelTile({
+    super.key,
+    required this.isNarrow,
+    required this.channel,
+    required this.confirmedEnabled,
+    required this.isWriting,
+    required this.hasPendingChange,
+    required this.status,
+    required this.enabled,
+    required this.onChanged,
+    required this.onRetry,
+  });
+
+  final bool isNarrow;
+  final Ntx8cvAudioChannel channel;
+  final bool? confirmedEnabled;
+  final bool isWriting;
+  final bool hasPendingChange;
+  final String status;
+  final bool enabled;
+  final ValueChanged<bool> onChanged;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: isNarrow ? 132 : 116,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Semantics(
+            container: true,
+            label: '${channel.label}. $status',
+            child: SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              title: Text(channel.label),
+              subtitle: SizedBox(
+                height: 36,
+                child: ExcludeSemantics(
+                  child: Tooltip(
+                    message: status,
+                    child: Text(
+                      status,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ),
+              ),
+              value: confirmedEnabled ?? false,
+              onChanged: enabled ? onChanged : null,
+              secondary: isWriting
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : null,
+            ),
+          ),
+          SizedBox(
+            height: 32,
+            child: hasPendingChange
+                ? Align(
+                    alignment: Alignment.centerLeft,
+                    child: TextButton.icon(
+                      key: Key('ntx8cv-retry-audio-channel-${channel.number}'),
+                      onPressed: enabled ? onRetry : null,
+                      icon: const Icon(Icons.refresh, size: 16),
+                      label: const Text('Retry send'),
+                    ),
+                  )
+                : const SizedBox.shrink(),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/ui/ntx_8cv/ntx_8cv_screen.dart
+++ b/lib/ui/ntx_8cv/ntx_8cv_screen.dart
@@ -124,6 +124,10 @@ class _Ntx8cvScreenState extends State<Ntx8cvScreen> {
                                   Ntx8cvSettingsSection(
                                     isConnected: connectionState.isConnected,
                                     state: settingsState,
+                                    onChannelGroupChanged:
+                                        _settingsCubit.setChannelGroup,
+                                    onRetryChannelGroupChange:
+                                        _settingsCubit.retryChannelGroupChange,
                                     onEs5Changed: _settingsCubit.setEs5Enabled,
                                     onRetryEs5Change:
                                         _settingsCubit.retryEs5Change,
@@ -440,6 +444,8 @@ class Ntx8cvSettingsSection extends StatelessWidget {
     super.key,
     required this.isConnected,
     required this.state,
+    required this.onChannelGroupChanged,
+    required this.onRetryChannelGroupChange,
     required this.onEs5Changed,
     required this.onRetryEs5Change,
     required this.onModeChanged,
@@ -448,6 +454,8 @@ class Ntx8cvSettingsSection extends StatelessWidget {
 
   final bool isConnected;
   final Ntx8cvSettingsState state;
+  final Future<void> Function(Ntx8cvChannelGroup) onChannelGroupChanged;
+  final Future<void> Function() onRetryChannelGroupChange;
   final Future<void> Function(bool) onEs5Changed;
   final Future<void> Function() onRetryEs5Change;
   final Future<void> Function(Ntx8cvExpansionMode) onModeChanged;
@@ -455,6 +463,11 @@ class Ntx8cvSettingsSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final canChangeChannelGroup =
+        isConnected &&
+        state.confirmedChannelGroup != null &&
+        !state.isBusy &&
+        !state.hasPendingChannelGroupChange;
     final canChangeEs5 =
         isConnected &&
         state.confirmedEs5Enabled != null &&
@@ -552,10 +565,62 @@ class Ntx8cvSettingsSection extends StatelessWidget {
                 label: const Text('Retry send'),
               ),
             ],
+            const SizedBox(height: 24),
+            DropdownButtonFormField<Ntx8cvChannelGroup>(
+              key: ValueKey(
+                'ntx8cv-channel-group-${state.confirmedChannelGroup}',
+              ),
+              initialValue: state.confirmedChannelGroup,
+              decoration: InputDecoration(
+                labelText: 'Channel Group',
+                helperText: _channelGroupDescription(),
+              ),
+              items: Ntx8cvChannelGroup.values
+                  .map(
+                    (group) => DropdownMenuItem(
+                      value: group,
+                      child: Text(group.label),
+                    ),
+                  )
+                  .toList(),
+              onChanged: canChangeChannelGroup
+                  ? (group) {
+                      if (group != null) {
+                        unawaited(onChannelGroupChanged(group));
+                      }
+                    }
+                  : null,
+            ),
+            const SizedBox(height: 8),
+            Semantics(liveRegion: true, child: Text(_channelGroupStatus())),
+            if (state.hasPendingChannelGroupChange) ...[
+              const SizedBox(height: 8),
+              OutlinedButton.icon(
+                key: const Key('ntx8cv-retry-channel-group-change'),
+                onPressed: isConnected && !state.isBusy
+                    ? () {
+                        unawaited(onRetryChannelGroupChange());
+                      }
+                    : null,
+                icon: const Icon(Icons.refresh),
+                label: const Text('Retry send'),
+              ),
+            ],
           ],
         ),
       ),
     );
+  }
+
+  String _channelGroupDescription() {
+    if (!isConnected) return 'Connect an NTX-8CV to read this setting.';
+    if (state.confirmedChannelGroup == null) {
+      return 'Waiting for a device-confirmed value.';
+    }
+    return 'Selects this NTX-8CV’s eight-channel block. This does not replace '
+        'the disting NT’s granular channel-enable controls; configure both '
+        'when needed. Changes are sent immediately and confirmed by reading '
+        'the setting back.';
   }
 
   String _es5Description() {
@@ -572,6 +637,32 @@ class Ntx8cvSettingsSection extends StatelessWidget {
       return state.modeMessage ?? 'Mode capability has not been evidenced.';
     }
     return 'Changes are sent immediately and take effect after reboot.';
+  }
+
+  String _channelGroupStatus() {
+    if (state.hasPendingChannelGroupChange) {
+      final attempted =
+          state.attemptedChannelGroup?.label ?? 'an invalid value';
+      final confirmed = state.confirmedChannelGroup == null
+          ? 'No device-confirmed value is available.'
+          : 'Last device-confirmed value: '
+                '${state.confirmedChannelGroup!.label}.';
+      final progress = state.isWritingChannelGroup
+          ? 'Sending and waiting for device readback.'
+          : state.channelGroupMessage ??
+                'The actual device state is uncertain.';
+      return 'Attempted Channel Group: $attempted, pending/failed and not '
+          'device-confirmed. $confirmed $progress';
+    }
+    if (state.isLoadingChannelGroup) {
+      return 'Reading Channel Group from the NTX-8CV.';
+    }
+    if (state.confirmedChannelGroup != null) {
+      return 'Device-confirmed Channel Group: '
+          '${state.confirmedChannelGroup!.label}.';
+    }
+    return state.channelGroupMessage ??
+        'No device-confirmed Channel Group value is available.';
   }
 
   String _es5Status() {

--- a/lib/ui/synchronized_screen.dart
+++ b/lib/ui/synchronized_screen.dart
@@ -48,6 +48,7 @@ import 'package:nt_helper/ui/metadata_sync/metadata_sync_page.dart';
 import 'package:nt_helper/ui/midi_listener/midi_listener_cubit.dart';
 import 'package:nt_helper/ui/poly_multisample/poly_samples_screen.dart';
 import 'package:nt_helper/ui/plugin_gallery_screen.dart';
+import 'package:nt_helper/ui/ntx_8cv/ntx_8cv_screen.dart';
 import 'package:nt_helper/ui/template_manager/current_preset_template_source.dart';
 import 'package:nt_helper/ui/template_manager/template_manager_screen.dart';
 import 'package:nt_helper/ui/widgets/shortcut_help_overlay.dart';
@@ -2193,6 +2194,11 @@ class _SynchronizedScreenState extends State<SynchronizedScreen>
   Widget _buildOverflowMenu(DistingCubit cubit) {
     return PopupMenuButton<String>(
       icon: const Icon(Icons.more_vert, semanticLabel: 'More options'),
+      onSelected: (value) {
+        if (value == 'addons') {
+          _showAddonsSubmenu(context);
+        }
+      },
       itemBuilder: (popupCtx) {
         // Get offline status here for menu items that need it
         final isOffline = switch (cubit.state) {
@@ -2412,6 +2418,13 @@ class _SynchronizedScreenState extends State<SynchronizedScreen>
                 ],
               ),
             ),
+          PopupMenuItem(
+            value: 'addons',
+            child: const Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [Text('Add-ons'), Icon(Icons.extension_rounded)],
+            ),
+          ),
           // Switch Devices: Only disabled by loading (Fix context usage)
           PopupMenuItem(
             value: 'Switch Devices',
@@ -2869,6 +2882,36 @@ class _SynchronizedScreenState extends State<SynchronizedScreen>
           _ => const Center(child: Text("Loading slots...")),
         };
       },
+    );
+  }
+
+  void _showAddonsSubmenu(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => SimpleDialog(
+        title: const Row(
+          children: [
+            Icon(Icons.extension_rounded),
+            SizedBox(width: 8),
+            Text('Add-ons'),
+          ],
+        ),
+        children: [
+          SimpleDialogOption(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              Navigator.of(
+                context,
+              ).push(MaterialPageRoute(builder: (_) => const Ntx8cvScreen()));
+            },
+            child: const ListTile(
+              leading: Icon(Icons.tune_rounded),
+              title: Text('NTX-8CV'),
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -524,7 +524,7 @@ packages:
     source: hosted
     version: "1.0.2"
   flutter_midi_command_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: flutter_midi_command_platform_interface
       sha256: "1e3a50a11a742245178f97d7ba524b94994fb7e960797132cbfc517f6d35020d"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -104,6 +104,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_midi_command_platform_interface: ^1.0.2
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/cubit/ntx_8cv_connection_cubit_test.dart
+++ b/test/cubit/ntx_8cv_connection_cubit_test.dart
@@ -1,0 +1,293 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_midi_command/flutter_midi_command.dart';
+import 'package:flutter_midi_command_platform_interface/midi_port.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/cubit/ntx_8cv_connection_cubit.dart';
+import 'package:nt_helper/domain/ntx_8cv/ntx_8cv_midi_connection.dart';
+import 'package:nt_helper/domain/ntx_8cv/ntx_8cv_sysex.dart';
+
+import '../fixtures/ntx_8cv_sysex_fixtures.dart';
+
+void main() {
+  group('Ntx8cvConnectionCubit', () {
+    late _FakeNtx8cvMidiConnection midiConnection;
+    late _MemoryNtx8cvConnectionStore store;
+    late Ntx8cvConnectionCubit cubit;
+
+    setUp(() {
+      midiConnection = _FakeNtx8cvMidiConnection();
+      store = _MemoryNtx8cvConnectionStore();
+      cubit = Ntx8cvConnectionCubit(
+        midiConnection: midiConnection,
+        store: store,
+        sessionTimeout: const Duration(milliseconds: 10),
+      );
+    });
+
+    tearDown(() async {
+      await cubit.close();
+      await midiConnection.dispose();
+    });
+
+    test('preselects one unambiguous NTX-8CV input and output pair', () async {
+      final ntx8cv = _midiDevice(
+        id: 'ntx8cv',
+        name: 'ntx-8cv',
+        input: true,
+        output: true,
+      );
+      midiConnection.devices = [
+        _midiDevice(
+          id: 'disting',
+          name: 'Disting NT',
+          input: true,
+          output: true,
+        ),
+        ntx8cv,
+      ];
+
+      await cubit.initialize();
+
+      expect(cubit.state.deviceId, 0);
+      expect(cubit.state.selectedInputDevice?.id, 'ntx8cv');
+      expect(cubit.state.selectedOutputDevice?.id, 'ntx8cv');
+      expect(cubit.state.status, Ntx8cvConnectionStatus.disconnected);
+    });
+
+    test(
+      'keeps manual endpoint selection and a persistent ID from 0 through 126',
+      () async {
+        final input = _midiDevice(
+          id: 'input',
+          name: 'Manual input',
+          input: true,
+        );
+        final output = _midiDevice(
+          id: 'output',
+          name: 'Manual output',
+          output: true,
+        );
+        midiConnection.devices = [input, output];
+
+        await cubit.initialize();
+        await cubit.selectInputDevice(input);
+        await cubit.selectOutputDevice(output);
+        await cubit.setDeviceIdText('126');
+
+        expect(cubit.state.selectedInputDevice?.id, 'input');
+        expect(cubit.state.selectedOutputDevice?.id, 'output');
+        expect(cubit.state.deviceId, 126);
+        expect(store.saved.inputDeviceId, 'input');
+        expect(store.saved.outputDeviceId, 'output');
+        expect(store.saved.deviceId, 126);
+
+        await cubit.setDeviceIdText('127');
+
+        expect(cubit.state.deviceId, 126);
+        expect(cubit.state.deviceIdError, isNotNull);
+        expect(store.saved.deviceId, 126);
+      },
+    );
+
+    test(
+      'connects only the selected endpoints after device information validates',
+      () async {
+        final ntx8cv = _midiDevice(
+          id: 'ntx8cv',
+          name: 'NTX-8CV',
+          input: true,
+          output: true,
+        );
+        midiConnection.devices = [
+          _midiDevice(
+            id: 'disting',
+            name: 'Disting NT',
+            input: true,
+            output: true,
+          ),
+          ntx8cv,
+        ];
+        midiConnection.transport.onSend = (_) {
+          midiConnection.transport.receive(
+            Ntx8cvSysExFixtures.deviceInformationResponse,
+          );
+        };
+        await cubit.initialize();
+
+        await cubit.connect();
+
+        expect(cubit.state.status, Ntx8cvConnectionStatus.connected);
+        expect(cubit.session, isNotNull);
+        expect(midiConnection.openedPairs, hasLength(1));
+        expect(midiConnection.openedPairs.single.inputDevice.id, 'ntx8cv');
+        expect(midiConnection.openedPairs.single.outputDevice.id, 'ntx8cv');
+        expect(
+          midiConnection.transport.sent.single,
+          orderedEquals(Ntx8cvSysExFixtures.deviceInformationRequest),
+        );
+      },
+    );
+
+    test(
+      'does not accept a mismatched device-information response as connected',
+      () async {
+        midiConnection.devices = [
+          _midiDevice(id: 'ntx8cv', name: 'NTX-8CV', input: true, output: true),
+        ];
+        midiConnection.transport.onSend = (_) {
+          midiConnection.transport.receive(
+            Uint8List.fromList([
+              0xF0,
+              0x00,
+              0x21,
+              0x27,
+              0x6A,
+              0x01,
+              0x32,
+              0x00,
+              0xF7,
+            ]),
+          );
+        };
+        await cubit.initialize();
+
+        await cubit.connect();
+
+        expect(cubit.state.status, Ntx8cvConnectionStatus.failed);
+        expect(cubit.session, isNull);
+        expect(cubit.state.statusMessage, contains('did not return valid'));
+      },
+    );
+
+    test(
+      'disconnects on endpoint loss, reselects on return, and never reconnects automatically',
+      () async {
+        final ntx8cv = _midiDevice(
+          id: 'ntx8cv',
+          name: 'NTX-8CV',
+          input: true,
+          output: true,
+        );
+        midiConnection.devices = [ntx8cv];
+        midiConnection.transport.onSend = (_) {
+          midiConnection.transport.receive(
+            Ntx8cvSysExFixtures.deviceInformationResponse,
+          );
+        };
+        await cubit.initialize();
+        await cubit.connect();
+        expect(cubit.state.status, Ntx8cvConnectionStatus.connected);
+
+        midiConnection.devices = [];
+        midiConnection.notifySetupChange(MidiSetupChange.deviceDisappeared);
+        await _flushEvents();
+
+        expect(cubit.state.status, Ntx8cvConnectionStatus.disconnected);
+        expect(cubit.state.selectedInputDevice, isNull);
+        expect(cubit.state.selectedOutputDevice, isNull);
+        expect(midiConnection.openedPairs, hasLength(1));
+
+        midiConnection.devices = [ntx8cv];
+        midiConnection.notifySetupChange(MidiSetupChange.deviceAppeared);
+        await _flushEvents();
+
+        expect(cubit.state.selectedInputDevice?.id, 'ntx8cv');
+        expect(cubit.state.selectedOutputDevice?.id, 'ntx8cv');
+        expect(midiConnection.openedPairs, hasLength(1));
+      },
+    );
+  });
+}
+
+Future<void> _flushEvents() async {
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+}
+
+MidiDevice _midiDevice({
+  required String id,
+  required String name,
+  bool input = false,
+  bool output = false,
+}) {
+  final device = MidiDevice(id, name, MidiDeviceType.serial, false);
+  if (input) device.inputPorts = [MidiPort(1, MidiPortType.IN)];
+  if (output) device.outputPorts = [MidiPort(2, MidiPortType.OUT)];
+  return device;
+}
+
+class _MemoryNtx8cvConnectionStore implements Ntx8cvConnectionStore {
+  Ntx8cvSavedConnection saved = const Ntx8cvSavedConnection();
+
+  @override
+  Future<Ntx8cvSavedConnection> load() async => saved;
+
+  @override
+  Future<void> save(Ntx8cvSavedConnection selection) async {
+    saved = selection;
+  }
+}
+
+class _FakeNtx8cvMidiConnection implements Ntx8cvMidiConnection {
+  List<MidiDevice> devices = [];
+  final _setupChanges = StreamController<MidiSetupChange>.broadcast();
+  final _FakeNtx8cvMidiTransport transport = _FakeNtx8cvMidiTransport();
+  final List<_OpenedPair> openedPairs = [];
+
+  @override
+  Stream<MidiSetupChange> get setupChanges => _setupChanges.stream;
+
+  @override
+  Future<List<MidiDevice>> listDevices() async => List.of(devices);
+
+  @override
+  Future<Ntx8cvMidiTransport> open({
+    required MidiDevice inputDevice,
+    required MidiDevice outputDevice,
+  }) async {
+    openedPairs.add(_OpenedPair(inputDevice, outputDevice));
+    return transport;
+  }
+
+  @override
+  Future<void> close({
+    required Ntx8cvMidiTransport transport,
+    required MidiDevice inputDevice,
+    required MidiDevice outputDevice,
+  }) async {}
+
+  void notifySetupChange(MidiSetupChange change) => _setupChanges.add(change);
+
+  Future<void> dispose() async {
+    await transport.close();
+    await _setupChanges.close();
+  }
+}
+
+class _OpenedPair {
+  const _OpenedPair(this.inputDevice, this.outputDevice);
+
+  final MidiDevice inputDevice;
+  final MidiDevice outputDevice;
+}
+
+class _FakeNtx8cvMidiTransport implements Ntx8cvMidiTransport {
+  final _received = StreamController<Uint8List>.broadcast(sync: true);
+  final List<Uint8List> sent = [];
+  void Function(Uint8List packet)? onSend;
+
+  @override
+  Stream<Uint8List> get receivedPackets => _received.stream;
+
+  @override
+  Future<void> send(Uint8List packet) async {
+    sent.add(packet);
+    onSend?.call(packet);
+  }
+
+  void receive(Uint8List packet) => _received.add(packet);
+
+  Future<void> close() => _received.close();
+}

--- a/test/cubit/ntx_8cv_settings_cubit_test.dart
+++ b/test/cubit/ntx_8cv_settings_cubit_test.dart
@@ -36,62 +36,21 @@ void main() {
       await midiConnection.dispose();
     });
 
-    test('reads the device-confirmed ES-5 value after connecting', () async {
+    test('reads ES-5 and probes Mode after connecting', () async {
       midiConnection.transport.onSend = (packet) {
-        if (packet[6] == 0x22) {
-          midiConnection.transport.receive(
-            Ntx8cvSysExFixtures.deviceInformationResponse,
-          );
-        } else if (packet[6] == 0x31 && packet[7] == 0x01) {
-          midiConnection.transport.receive(
-            Ntx8cvSysExFixtures.es5DisabledResponse,
-          );
-        }
+        _respondWithSettings(midiConnection.transport, packet);
       };
       await connectionCubit.initialize();
-
       await connectionCubit.connect();
       await _flushEvents();
 
       expect(settingsCubit.state.confirmedEs5Enabled, isFalse);
-      expect(settingsCubit.state.hasPendingEs5Change, isFalse);
-      expect(midiConnection.transport.sent, hasLength(2));
       expect(
-        midiConnection.transport.sent[0],
-        orderedEquals(Ntx8cvSysExFixtures.deviceInformationRequest),
+        settingsCubit.state.confirmedMode,
+        Ntx8cvExpansionMode.audio2x8_16bit,
       );
-      expect(
-        midiConnection.transport.sent[1],
-        orderedEquals(Ntx8cvSysExFixtures.readEs5EnabledSetting),
-      );
-    });
-
-    test('changes ES-5 only after a matching same-setting readback', () async {
-      midiConnection.transport.onSend = (packet) {
-        if (packet[6] == 0x22) {
-          midiConnection.transport.receive(
-            Ntx8cvSysExFixtures.deviceInformationResponse,
-          );
-        } else if (packet[6] == 0x31 && packet[7] == 0x01) {
-          final hasWrittenEs5 = midiConnection.transport.sent.any(
-            (sent) => sent[6] == 0x32 && sent[7] == 0x01,
-          );
-          midiConnection.transport.receive(
-            hasWrittenEs5
-                ? Ntx8cvSysExFixtures.es5EnabledResponse
-                : Ntx8cvSysExFixtures.es5DisabledResponse,
-          );
-        }
-      };
-      await connectionCubit.initialize();
-      await connectionCubit.connect();
-      await _flushEvents();
-
-      await settingsCubit.setEs5Enabled(true);
-
-      expect(settingsCubit.state.confirmedEs5Enabled, isTrue);
-      expect(settingsCubit.state.hasPendingEs5Change, isFalse);
-      expect(midiConnection.transport.sent, hasLength(4));
+      expect(settingsCubit.state.modeCapabilityEvidenced, isTrue);
+      expect(midiConnection.transport.sent, hasLength(3));
       expect(
         midiConnection.transport.sent[0],
         orderedEquals(Ntx8cvSysExFixtures.deviceInformationRequest),
@@ -102,37 +61,50 @@ void main() {
       );
       expect(
         midiConnection.transport.sent[2],
+        orderedEquals(Ntx8cvSysExFixtures.readModeSetting),
+      );
+    });
+
+    test('changes ES-5 only after matching same-setting readback', () async {
+      midiConnection.transport.onSend = (packet) {
+        final hasWrittenEs5 = midiConnection.transport.sent.any(
+          (sent) => sent[6] == 0x32 && sent[7] == 0x01,
+        );
+        _respondWithSettings(
+          midiConnection.transport,
+          packet,
+          es5Value: hasWrittenEs5 ? 1 : 0,
+        );
+      };
+      await connectionCubit.initialize();
+      await connectionCubit.connect();
+      await _flushEvents();
+
+      await settingsCubit.setEs5Enabled(true);
+
+      expect(settingsCubit.state.confirmedEs5Enabled, isTrue);
+      expect(settingsCubit.state.hasPendingEs5Change, isFalse);
+      expect(midiConnection.transport.sent, hasLength(5));
+      expect(
+        midiConnection.transport.sent[3],
         orderedEquals(Ntx8cvSysExFixtures.writeEs5EnabledSetting),
       );
       expect(
-        midiConnection.transport.sent[3],
+        midiConnection.transport.sent[4],
         orderedEquals(Ntx8cvSysExFixtures.readEs5EnabledSetting),
       );
     });
 
     test(
-      'retains a mismatched ES-5 change across reconnect and retries it only explicitly',
+      'retains a mismatched ES-5 change across reconnect and retries only explicitly',
       () async {
         var returnEnabledValue = false;
         midiConnection.transport.onSend = (packet) {
-          final deviceId = packet[5];
-          if (packet[6] == 0x22) {
-            midiConnection.transport.receive(
-              _withDeviceId(
-                Ntx8cvSysExFixtures.deviceInformationResponse,
-                deviceId,
-              ),
-            );
-          } else if (packet[6] == 0x31 && packet[7] == 0x01) {
-            midiConnection.transport.receive(
-              _withDeviceId(
-                returnEnabledValue
-                    ? Ntx8cvSysExFixtures.es5EnabledResponse
-                    : Ntx8cvSysExFixtures.es5DisabledResponse,
-                deviceId,
-              ),
-            );
-          }
+          _respondWithSettings(
+            midiConnection.transport,
+            packet,
+            es5Value: returnEnabledValue ? 1 : 0,
+          );
         };
         await connectionCubit.initialize();
         await connectionCubit.connect();
@@ -157,30 +129,35 @@ void main() {
         await _flushEvents();
 
         expect(settingsCubit.state.hasPendingEs5Change, isTrue);
+        // Reconnect validates identity and probes Mode, but never resends ES-5.
         expect(
           midiConnection.transport.sent,
-          hasLength(sendsBeforeReconnect + 1),
+          hasLength(sendsBeforeReconnect + 2),
         );
+        expect(midiConnection.transport.sent[sendsBeforeReconnect][5], 2);
+        expect(midiConnection.transport.sent[sendsBeforeReconnect][6], 0x22);
         expect(midiConnection.transport.sent.last[5], 2);
-        expect(midiConnection.transport.sent.last[6], 0x22);
+        expect(midiConnection.transport.sent.last[6], 0x31);
+        expect(midiConnection.transport.sent.last[7], 0x1B);
 
         returnEnabledValue = true;
         await settingsCubit.retryEs5Change();
 
         expect(settingsCubit.state.confirmedEs5Enabled, isTrue);
         expect(settingsCubit.state.hasPendingEs5Change, isFalse);
+        expect(settingsCubit.state.modeRebootRequired, isFalse);
         expect(
           midiConnection.transport.sent,
-          hasLength(sendsBeforeReconnect + 3),
-        );
-        expect(midiConnection.transport.sent[sendsBeforeReconnect + 1][5], 2);
-        expect(
-          midiConnection.transport.sent[sendsBeforeReconnect + 1][6],
-          0x32,
+          hasLength(sendsBeforeReconnect + 4),
         );
         expect(midiConnection.transport.sent[sendsBeforeReconnect + 2][5], 2);
         expect(
           midiConnection.transport.sent[sendsBeforeReconnect + 2][6],
+          0x32,
+        );
+        expect(midiConnection.transport.sent[sendsBeforeReconnect + 3][5], 2);
+        expect(
+          midiConnection.transport.sent[sendsBeforeReconnect + 3][6],
           0x31,
         );
       },
@@ -191,19 +168,14 @@ void main() {
       () async {
         var hasStartedWrite = false;
         midiConnection.transport.onSend = (packet) {
-          if (packet[6] == 0x22) {
-            midiConnection.transport.receive(
-              Ntx8cvSysExFixtures.deviceInformationResponse,
-            );
-          } else if (packet[6] == 0x32 && packet[7] == 0x01) {
+          if (packet[6] == 0x32 && packet[7] == 0x01) {
             hasStartedWrite = true;
-          } else if (packet[6] == 0x31 &&
-              packet[7] == 0x01 &&
-              !hasStartedWrite) {
-            midiConnection.transport.receive(
-              Ntx8cvSysExFixtures.es5DisabledResponse,
-            );
+            return;
           }
+          if (packet[6] == 0x31 && packet[7] == 0x01 && hasStartedWrite) {
+            return;
+          }
+          _respondWithSettings(midiConnection.transport, packet);
         };
         await connectionCubit.initialize();
         await connectionCubit.connect();
@@ -224,19 +196,14 @@ void main() {
       () async {
         var hasStartedWrite = false;
         midiConnection.transport.onSend = (packet) {
-          if (packet[6] == 0x22) {
-            midiConnection.transport.receive(
-              Ntx8cvSysExFixtures.deviceInformationResponse,
-            );
-          } else if (packet[6] == 0x32 && packet[7] == 0x01) {
+          if (packet[6] == 0x32 && packet[7] == 0x01) {
             hasStartedWrite = true;
-          } else if (packet[6] == 0x31 &&
-              packet[7] == 0x01 &&
-              !hasStartedWrite) {
-            midiConnection.transport.receive(
-              Ntx8cvSysExFixtures.es5DisabledResponse,
-            );
+            return;
           }
+          if (packet[6] == 0x31 && packet[7] == 0x01 && hasStartedWrite) {
+            return;
+          }
+          _respondWithSettings(midiConnection.transport, packet);
         };
         await connectionCubit.initialize();
         await connectionCubit.connect();
@@ -257,13 +224,158 @@ void main() {
         expect(settingsCubit.state.es5Message, contains('uncertain'));
       },
     );
+
+    test(
+      'keeps Mode disabled when its capability probe is not evidenced',
+      () async {
+        midiConnection.transport.onSend = (packet) {
+          _respondWithSettings(midiConnection.transport, packet, modeValue: 3);
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        expect(settingsCubit.state.modeCapabilityEvidenced, isFalse);
+        expect(settingsCubit.state.confirmedMode, isNull);
+        expect(settingsCubit.state.modeMessage, contains('not evidenced'));
+
+        final sendsBeforeModeChange = midiConnection.transport.sent.length;
+        await settingsCubit.setExpansionMode(Ntx8cvExpansionMode.cv8x8);
+        expect(midiConnection.transport.sent, hasLength(sendsBeforeModeChange));
+      },
+    );
+
+    test(
+      'reports a timed-out Mode probe as capability not evidenced',
+      () async {
+        midiConnection.transport.onSend = (packet) {
+          if (packet[6] == 0x22 || (packet[6] == 0x31 && packet[7] == 0x01)) {
+            _respondWithSettings(midiConnection.transport, packet);
+          }
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+
+        expect(settingsCubit.state.modeCapabilityEvidenced, isFalse);
+        expect(settingsCubit.state.isLoadingMode, isFalse);
+        expect(settingsCubit.state.modeMessage, contains('not evidenced'));
+      },
+    );
+
+    test(
+      'confirms a retried Mode change only after matching readback and requires reboot',
+      () async {
+        var returnedModeValue = 2;
+        midiConnection.transport.onSend = (packet) {
+          _respondWithSettings(
+            midiConnection.transport,
+            packet,
+            modeValue: returnedModeValue,
+          );
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        await settingsCubit.setExpansionMode(Ntx8cvExpansionMode.cv8x8);
+
+        expect(
+          settingsCubit.state.confirmedMode,
+          Ntx8cvExpansionMode.audio2x8_16bit,
+        );
+        expect(settingsCubit.state.attemptedMode, Ntx8cvExpansionMode.cv8x8);
+        expect(settingsCubit.state.modeRebootRequired, isFalse);
+        expect(settingsCubit.state.modeMessage, contains('not confirmed'));
+        expect(settingsCubit.state.modeMessage, contains('uncertain'));
+
+        await connectionCubit.disconnect();
+        final sendsBeforeReconnect = midiConnection.transport.sent.length;
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        expect(settingsCubit.state.hasPendingModeChange, isTrue);
+        // Reconnect reads ES-5 and Mode but does not write a pending Mode.
+        expect(
+          midiConnection.transport.sent,
+          hasLength(sendsBeforeReconnect + 3),
+        );
+        expect(
+          midiConnection.transport.sent.where((packet) => packet[6] == 0x32),
+          hasLength(1),
+        );
+
+        returnedModeValue = 0;
+        await settingsCubit.retryModeChange();
+
+        expect(settingsCubit.state.confirmedMode, Ntx8cvExpansionMode.cv8x8);
+        expect(settingsCubit.state.hasPendingModeChange, isFalse);
+        expect(settingsCubit.state.modeRebootRequired, isTrue);
+        expect(settingsCubit.state.confirmedEs5Enabled, isFalse);
+        expect(
+          midiConnection.transport.sent[midiConnection.transport.sent.length -
+              2],
+          orderedEquals(_writeSetting(0x1B, 0)),
+        );
+        expect(
+          midiConnection.transport.sent.last,
+          orderedEquals(Ntx8cvSysExFixtures.readModeSetting),
+        );
+      },
+    );
   });
+}
+
+void _respondWithSettings(
+  _FakeNtx8cvMidiTransport transport,
+  Uint8List packet, {
+  int es5Value = 0,
+  int modeValue = 2,
+}) {
+  final deviceId = packet[5];
+  if (packet[6] == 0x22) {
+    transport.receive(
+      _withDeviceId(Ntx8cvSysExFixtures.deviceInformationResponse, deviceId),
+    );
+  } else if (packet[6] == 0x31 && packet[7] == 0x01) {
+    transport.receive(_settingResponse(0x01, es5Value, deviceId));
+  } else if (packet[6] == 0x31 && packet[7] == 0x1B) {
+    transport.receive(_settingResponse(0x1B, modeValue, deviceId));
+  }
 }
 
 Future<void> _flushEvents() async {
   await Future<void>.delayed(Duration.zero);
   await Future<void>.delayed(Duration.zero);
 }
+
+Uint8List _writeSetting(int settingId, int value, [int deviceId = 0]) =>
+    Uint8List.fromList([
+      0xF0,
+      0x00,
+      0x21,
+      0x27,
+      0x6A,
+      deviceId,
+      0x32,
+      settingId,
+      value,
+      0xF7,
+    ]);
+
+Uint8List _settingResponse(int settingId, int value, [int deviceId = 0]) =>
+    Uint8List.fromList([
+      0xF0,
+      0x00,
+      0x21,
+      0x27,
+      0x6A,
+      deviceId,
+      0x31,
+      settingId,
+      value,
+      0xF7,
+    ]);
 
 Uint8List _withDeviceId(Uint8List packet, int deviceId) {
   final copy = Uint8List.fromList(packet);

--- a/test/cubit/ntx_8cv_settings_cubit_test.dart
+++ b/test/cubit/ntx_8cv_settings_cubit_test.dart
@@ -263,6 +263,59 @@ void main() {
       },
     );
 
+    test('confirms every supported Mode without changing ES-5', () async {
+      var deviceMode = Ntx8cvExpansionMode.cv8x8.value;
+      midiConnection.transport.onSend = (packet) {
+        if (packet[6] == 0x32 && packet[7] == 0x1B) {
+          deviceMode = packet[8];
+        }
+        _respondWithSettings(
+          midiConnection.transport,
+          packet,
+          es5Value: 1,
+          modeValue: deviceMode,
+        );
+      };
+      await connectionCubit.initialize();
+      await connectionCubit.connect();
+      await _flushEvents();
+
+      expect(
+        Ntx8cvExpansionMode.values.map((mode) => mode.label),
+        orderedEquals(['8x8 CV', '1x8 32bit Audio', '2x8 16bit Audio']),
+      );
+      expect(
+        Ntx8cvExpansionMode.values.map((mode) => mode.value),
+        orderedEquals([0, 1, 2]),
+      );
+
+      for (final mode in [
+        Ntx8cvExpansionMode.audio1x8_32bit,
+        Ntx8cvExpansionMode.audio2x8_16bit,
+        Ntx8cvExpansionMode.cv8x8,
+      ]) {
+        await settingsCubit.setExpansionMode(mode);
+
+        expect(settingsCubit.state.confirmedMode, mode);
+        expect(settingsCubit.state.hasPendingModeChange, isFalse);
+        expect(settingsCubit.state.modeRebootRequired, isTrue);
+        expect(settingsCubit.state.confirmedEs5Enabled, isTrue);
+        expect(settingsCubit.state.hasPendingEs5Change, isFalse);
+      }
+
+      final settingWrites = midiConnection.transport.sent
+          .where((packet) => packet[6] == 0x32)
+          .toList();
+      expect(
+        settingWrites.map((packet) => packet[7]),
+        orderedEquals([0x1B, 0x1B, 0x1B]),
+      );
+      expect(
+        settingWrites.map((packet) => packet[8]),
+        orderedEquals([1, 2, 0]),
+      );
+    });
+
     test(
       'confirms a retried Mode change only after matching readback and requires reboot',
       () async {

--- a/test/cubit/ntx_8cv_settings_cubit_test.dart
+++ b/test/cubit/ntx_8cv_settings_cubit_test.dart
@@ -38,7 +38,7 @@ void main() {
     });
 
     test(
-      'reads Channel Group, ES-5, and probes Mode after connecting',
+      'reads Channel Group, ES-5, Mode, and every audio-channel setting after connecting',
       () async {
         midiConnection.transport.onSend = (packet) {
           _respondWithSettings(midiConnection.transport, packet);
@@ -53,7 +53,7 @@ void main() {
           Ntx8cvExpansionMode.audio2x8_16bit,
         );
         expect(settingsCubit.state.modeCapabilityEvidenced, isTrue);
-        expect(midiConnection.transport.sent, hasLength(4));
+        expect(midiConnection.transport.sent, hasLength(12));
         expect(
           midiConnection.transport.sent[0],
           orderedEquals(Ntx8cvSysExFixtures.deviceInformationRequest),
@@ -68,6 +68,16 @@ void main() {
         );
         expect(
           midiConnection.transport.sent[3],
+          orderedEquals(Ntx8cvSysExFixtures.readAudioChannel1EnabledSetting),
+        );
+        expect(
+          midiConnection.transport.sent
+              .sublist(3, 11)
+              .map((packet) => packet[7]),
+          orderedEquals([0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B]),
+        );
+        expect(
+          midiConnection.transport.sent[11],
           orderedEquals(Ntx8cvSysExFixtures.readChannelGroupSetting),
         );
         expect(
@@ -129,7 +139,13 @@ void main() {
           orderedEquals(Ntx8cvSysExFixtures.readModeSetting),
         );
         expect(
-          midiConnection.transport.sent[sendsBeforeReboot + 4],
+          midiConnection.transport.sent
+              .sublist(sendsBeforeReboot + 4, sendsBeforeReboot + 12)
+              .map((packet) => packet[7]),
+          orderedEquals([0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B]),
+        );
+        expect(
+          midiConnection.transport.sent[sendsBeforeReboot + 12],
           orderedEquals(Ntx8cvSysExFixtures.readChannelGroupSetting),
         );
         expect(settingsCubit.state.confirmedEs5Enabled, isTrue);
@@ -144,6 +160,286 @@ void main() {
         expect(settingsCubit.state.modeCapabilityEvidenced, isTrue);
         expect(settingsCubit.state.modeRebootRequired, isFalse);
         expect(settingsCubit.state.isRebooting, isFalse);
+      },
+    );
+
+    test(
+      'confirms individual audio channels only after same-setting readback',
+      () async {
+        final audioChannelValues = [1, 0, 1, 0, 1, 0, 1, 0];
+        midiConnection.transport.onSend = (packet) {
+          if (packet[6] == 0x32 && packet[7] == 0x05) {
+            audioChannelValues[1] = packet[8];
+          }
+          _respondWithSettings(
+            midiConnection.transport,
+            packet,
+            audioChannelValues: audioChannelValues,
+          );
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        expect(
+          settingsCubit.state.confirmedAudioChannelEnabled(
+            Ntx8cvAudioChannel.channel1,
+          ),
+          isTrue,
+        );
+        expect(
+          settingsCubit.state.confirmedAudioChannelEnabled(
+            Ntx8cvAudioChannel.channel2,
+          ),
+          isFalse,
+        );
+
+        await settingsCubit.setAudioChannelEnabled(
+          Ntx8cvAudioChannel.channel2,
+          true,
+        );
+
+        expect(
+          settingsCubit.state.confirmedAudioChannelEnabled(
+            Ntx8cvAudioChannel.channel2,
+          ),
+          isTrue,
+        );
+        expect(
+          settingsCubit.state.hasPendingAudioChannelChange(
+            Ntx8cvAudioChannel.channel2,
+          ),
+          isFalse,
+        );
+        expect(
+          midiConnection.transport.sent[midiConnection.transport.sent.length -
+              2],
+          orderedEquals(_writeSetting(0x05, 1)),
+        );
+        expect(
+          midiConnection.transport.sent.last,
+          orderedEquals(_readSetting(0x05)),
+        );
+      },
+    );
+
+    test(
+      'keeps a mismatched audio-channel change pending and uncertain',
+      () async {
+        midiConnection.transport.onSend = (packet) {
+          _respondWithSettings(midiConnection.transport, packet);
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        await settingsCubit.setAudioChannelEnabled(
+          Ntx8cvAudioChannel.channel1,
+          false,
+        );
+
+        expect(
+          settingsCubit.state.confirmedAudioChannelEnabled(
+            Ntx8cvAudioChannel.channel1,
+          ),
+          isTrue,
+        );
+        expect(
+          settingsCubit.state.attemptedAudioChannelEnabled(
+            Ntx8cvAudioChannel.channel1,
+          ),
+          isFalse,
+        );
+        expect(
+          settingsCubit.state.hasPendingAudioChannelChange(
+            Ntx8cvAudioChannel.channel1,
+          ),
+          isTrue,
+        );
+        expect(
+          settingsCubit.state
+              .audioChannelChange(Ntx8cvAudioChannel.channel1)
+              .message,
+          contains('uncertain'),
+        );
+      },
+    );
+
+    test(
+      'refresh and reconnect repopulate audio channels without resending',
+      () async {
+        var audioChannelValues = [1, 0, 1, 0, 1, 0, 1, 0];
+        midiConnection.transport.onSend = (packet) {
+          _respondWithSettings(
+            midiConnection.transport,
+            packet,
+            audioChannelValues: audioChannelValues,
+          );
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        audioChannelValues = [0, 1, 0, 1, 0, 1, 0, 1];
+        final sendsBeforeRefresh = midiConnection.transport.sent.length;
+        await settingsCubit.refresh();
+
+        expect(
+          settingsCubit.state.confirmedAudioChannelEnabled(
+            Ntx8cvAudioChannel.channel1,
+          ),
+          isFalse,
+        );
+        expect(
+          settingsCubit.state.confirmedAudioChannelEnabled(
+            Ntx8cvAudioChannel.channel2,
+          ),
+          isTrue,
+        );
+        expect(
+          midiConnection.transport.sent
+              .skip(sendsBeforeRefresh)
+              .every((packet) => packet[6] != 0x32),
+          isTrue,
+        );
+
+        await connectionCubit.disconnect();
+        final sendsBeforeReconnect = midiConnection.transport.sent.length;
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        expect(
+          settingsCubit.state.confirmedAudioChannelEnabled(
+            Ntx8cvAudioChannel.channel1,
+          ),
+          isFalse,
+        );
+        expect(
+          midiConnection.transport.sent
+              .skip(sendsBeforeReconnect)
+              .where((packet) => packet[6] == 0x32),
+          isEmpty,
+        );
+        expect(
+          midiConnection.transport.sent
+              .skip(sendsBeforeReconnect)
+              .where((packet) => packet[6] == 0x31)
+              .map((packet) => packet[7]),
+          containsAllInOrder([0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B]),
+        );
+      },
+    );
+
+    test(
+      'keeps a timed-out audio-channel change pending and uncertain',
+      () async {
+        var writeStarted = false;
+        midiConnection.transport.onSend = (packet) {
+          if (packet[6] == 0x32 && packet[7] == 0x04) {
+            writeStarted = true;
+            return;
+          }
+          if (writeStarted && packet[6] == 0x31 && packet[7] == 0x04) {
+            return;
+          }
+          _respondWithSettings(midiConnection.transport, packet);
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        await settingsCubit.setAudioChannelEnabled(
+          Ntx8cvAudioChannel.channel1,
+          false,
+        );
+
+        final change = settingsCubit.state.audioChannelChange(
+          Ntx8cvAudioChannel.channel1,
+        );
+        expect(change.attemptedValue, 0);
+        expect(change.isWriting, isFalse);
+        expect(change.message, contains('timed out'));
+        expect(change.message, contains('uncertain'));
+      },
+    );
+
+    test('labels a malformed audio-channel readback as uncertain', () async {
+      var writeStarted = false;
+      midiConnection.transport.onSend = (packet) {
+        if (packet[6] == 0x32 && packet[7] == 0x04) {
+          writeStarted = true;
+          return;
+        }
+        if (writeStarted && packet[6] == 0x31 && packet[7] == 0x04) {
+          scheduleMicrotask(() {
+            midiConnection.transport.receive(
+              Uint8List.fromList([
+                0xF0,
+                0x00,
+                0x21,
+                0x27,
+                0x6A,
+                packet[5],
+                0x31,
+                0x04,
+                0xF7,
+              ]),
+            );
+          });
+          return;
+        }
+        _respondWithSettings(midiConnection.transport, packet);
+      };
+      await connectionCubit.initialize();
+      await connectionCubit.connect();
+      await _flushEvents();
+
+      await settingsCubit.setAudioChannelEnabled(
+        Ntx8cvAudioChannel.channel1,
+        false,
+      );
+
+      final change = settingsCubit.state.audioChannelChange(
+        Ntx8cvAudioChannel.channel1,
+      );
+      expect(change.attemptedValue, 0);
+      expect(change.message, contains('malformed'));
+      expect(change.message, contains('uncertain'));
+    });
+
+    test(
+      'does not offer audio-channel writes until a confirmed audio Mode is rebooted',
+      () async {
+        var modeValue = Ntx8cvExpansionMode.cv8x8.value;
+        midiConnection.transport.onSend = (packet) {
+          if (packet[6] == 0x32 && packet[7] == 0x1B) {
+            modeValue = packet[8];
+          }
+          _respondWithSettings(
+            midiConnection.transport,
+            packet,
+            modeValue: modeValue,
+          );
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        await settingsCubit.setExpansionMode(
+          Ntx8cvExpansionMode.audio1x8_32bit,
+        );
+        expect(settingsCubit.state.modeRebootRequired, isTrue);
+
+        final sendsBeforeAudioChange = midiConnection.transport.sent.length;
+        await settingsCubit.setAudioChannelEnabled(
+          Ntx8cvAudioChannel.channel1,
+          false,
+        );
+
+        expect(
+          midiConnection.transport.sent,
+          hasLength(sendsBeforeAudioChange),
+        );
       },
     );
 
@@ -166,13 +462,13 @@ void main() {
 
       expect(settingsCubit.state.confirmedEs5Enabled, isTrue);
       expect(settingsCubit.state.hasPendingEs5Change, isFalse);
-      expect(midiConnection.transport.sent, hasLength(6));
+      expect(midiConnection.transport.sent, hasLength(14));
       expect(
-        midiConnection.transport.sent[4],
+        midiConnection.transport.sent[12],
         orderedEquals(Ntx8cvSysExFixtures.writeEs5EnabledSetting),
       );
       expect(
-        midiConnection.transport.sent[5],
+        midiConnection.transport.sent[13],
         orderedEquals(Ntx8cvSysExFixtures.readEs5EnabledSetting),
       );
     });
@@ -205,11 +501,11 @@ void main() {
         expect(settingsCubit.state.hasPendingChannelGroupChange, isTrue);
         expect(settingsCubit.state.channelGroupMessage, contains('uncertain'));
         expect(
-          midiConnection.transport.sent[4],
+          midiConnection.transport.sent[12],
           orderedEquals(Ntx8cvSysExFixtures.writeChannelGroupSetting),
         );
         expect(
-          midiConnection.transport.sent[5],
+          midiConnection.transport.sent[13],
           orderedEquals(Ntx8cvSysExFixtures.readChannelGroupSetting),
         );
 
@@ -259,11 +555,11 @@ void main() {
         await _flushEvents();
 
         expect(settingsCubit.state.hasPendingEs5Change, isTrue);
-        // Reconnect validates identity and refreshes Mode and Channel Group,
-        // but never resends ES-5.
+        // Reconnect validates identity and reads Mode, all audio channels,
+        // and Channel Group, but never resends the pending ES-5 change.
         expect(
           midiConnection.transport.sent,
-          hasLength(sendsBeforeReconnect + 3),
+          hasLength(sendsBeforeReconnect + 11),
         );
         expect(midiConnection.transport.sent[sendsBeforeReconnect][5], 2);
         expect(midiConnection.transport.sent[sendsBeforeReconnect][6], 0x22);
@@ -279,6 +575,12 @@ void main() {
         expect(midiConnection.transport.sent.last[5], 2);
         expect(midiConnection.transport.sent.last[6], 0x31);
         expect(midiConnection.transport.sent.last[7], 0x00);
+        expect(
+          midiConnection.transport.sent
+              .sublist(sendsBeforeReconnect + 2, sendsBeforeReconnect + 10)
+              .map((packet) => packet[7]),
+          orderedEquals([0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B]),
+        );
 
         returnEnabledValue = true;
         await settingsCubit.retryEs5Change();
@@ -288,16 +590,16 @@ void main() {
         expect(settingsCubit.state.modeRebootRequired, isFalse);
         expect(
           midiConnection.transport.sent,
-          hasLength(sendsBeforeReconnect + 5),
+          hasLength(sendsBeforeReconnect + 13),
         );
-        expect(midiConnection.transport.sent[sendsBeforeReconnect + 3][5], 2);
+        expect(midiConnection.transport.sent[sendsBeforeReconnect + 11][5], 2);
         expect(
-          midiConnection.transport.sent[sendsBeforeReconnect + 3][6],
+          midiConnection.transport.sent[sendsBeforeReconnect + 11][6],
           0x32,
         );
-        expect(midiConnection.transport.sent[sendsBeforeReconnect + 4][5], 2);
+        expect(midiConnection.transport.sent[sendsBeforeReconnect + 12][5], 2);
         expect(
-          midiConnection.transport.sent[sendsBeforeReconnect + 4][6],
+          midiConnection.transport.sent[sendsBeforeReconnect + 12][6],
           0x31,
         );
       },
@@ -488,10 +790,11 @@ void main() {
         await _flushEvents();
 
         expect(settingsCubit.state.hasPendingModeChange, isTrue);
-        // Reconnect reads ES-5 and Mode but does not write a pending Mode.
+        // Reconnect reads ES-5, Mode, all audio channels, and Channel Group
+        // but does not write a pending Mode.
         expect(
           midiConnection.transport.sent,
-          hasLength(sendsBeforeReconnect + 4),
+          hasLength(sendsBeforeReconnect + 12),
         );
         expect(
           midiConnection.transport.sent.where((packet) => packet[6] == 0x32),
@@ -525,6 +828,7 @@ void _respondWithSettings(
   int channelGroupValue = 0,
   int es5Value = 0,
   int modeValue = 2,
+  List<int> audioChannelValues = const [1, 0, 1, 0, 1, 0, 1, 0],
 }) {
   final deviceId = packet[5];
   if (packet[6] == 0x22) {
@@ -535,6 +839,14 @@ void _respondWithSettings(
     transport.receive(_settingResponse(0x00, channelGroupValue, deviceId));
   } else if (packet[6] == 0x31 && packet[7] == 0x01) {
     transport.receive(_settingResponse(0x01, es5Value, deviceId));
+  } else if (packet[6] == 0x31 && packet[7] >= 0x04 && packet[7] <= 0x0B) {
+    transport.receive(
+      _settingResponse(
+        packet[7],
+        audioChannelValues[packet[7] - 0x04],
+        deviceId,
+      ),
+    );
   } else if (packet[6] == 0x31 && packet[7] == 0x1B) {
     transport.receive(_settingResponse(0x1B, modeValue, deviceId));
   }
@@ -544,6 +856,10 @@ Future<void> _flushEvents() async {
   await Future<void>.delayed(Duration.zero);
   await Future<void>.delayed(Duration.zero);
 }
+
+Uint8List _readSetting(int settingId, [int deviceId = 0]) => Uint8List.fromList(
+  [0xF0, 0x00, 0x21, 0x27, 0x6A, deviceId, 0x31, settingId, 0xF7],
+);
 
 Uint8List _writeSetting(int settingId, int value, [int deviceId = 0]) =>
     Uint8List.fromList([

--- a/test/cubit/ntx_8cv_settings_cubit_test.dart
+++ b/test/cubit/ntx_8cv_settings_cubit_test.dart
@@ -111,16 +111,26 @@ void main() {
     });
 
     test(
-      'does not confirm ES-5 when same-setting readback mismatches',
+      'retains a mismatched ES-5 change across reconnect and retries it only explicitly',
       () async {
+        var returnEnabledValue = false;
         midiConnection.transport.onSend = (packet) {
+          final deviceId = packet[5];
           if (packet[6] == 0x22) {
             midiConnection.transport.receive(
-              Ntx8cvSysExFixtures.deviceInformationResponse,
+              _withDeviceId(
+                Ntx8cvSysExFixtures.deviceInformationResponse,
+                deviceId,
+              ),
             );
           } else if (packet[6] == 0x31 && packet[7] == 0x01) {
             midiConnection.transport.receive(
-              Ntx8cvSysExFixtures.es5DisabledResponse,
+              _withDeviceId(
+                returnEnabledValue
+                    ? Ntx8cvSysExFixtures.es5EnabledResponse
+                    : Ntx8cvSysExFixtures.es5DisabledResponse,
+                deviceId,
+              ),
             );
           }
         };
@@ -135,6 +145,116 @@ void main() {
         expect(settingsCubit.state.hasPendingEs5Change, isTrue);
         expect(settingsCubit.state.es5Message, contains('not confirmed'));
         expect(settingsCubit.state.es5Message, contains('uncertain'));
+
+        await connectionCubit.disconnect();
+        await connectionCubit.setDeviceIdText('2');
+        expect(settingsCubit.state.confirmedEs5Enabled, isNull);
+        expect(settingsCubit.state.attemptedEs5Enabled, isTrue);
+        expect(settingsCubit.state.es5Message, contains('target changed'));
+
+        final sendsBeforeReconnect = midiConnection.transport.sent.length;
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        expect(settingsCubit.state.hasPendingEs5Change, isTrue);
+        expect(
+          midiConnection.transport.sent,
+          hasLength(sendsBeforeReconnect + 1),
+        );
+        expect(midiConnection.transport.sent.last[5], 2);
+        expect(midiConnection.transport.sent.last[6], 0x22);
+
+        returnEnabledValue = true;
+        await settingsCubit.retryEs5Change();
+
+        expect(settingsCubit.state.confirmedEs5Enabled, isTrue);
+        expect(settingsCubit.state.hasPendingEs5Change, isFalse);
+        expect(
+          midiConnection.transport.sent,
+          hasLength(sendsBeforeReconnect + 3),
+        );
+        expect(midiConnection.transport.sent[sendsBeforeReconnect + 1][5], 2);
+        expect(
+          midiConnection.transport.sent[sendsBeforeReconnect + 1][6],
+          0x32,
+        );
+        expect(midiConnection.transport.sent[sendsBeforeReconnect + 2][5], 2);
+        expect(
+          midiConnection.transport.sent[sendsBeforeReconnect + 2][6],
+          0x31,
+        );
+      },
+    );
+
+    test(
+      'keeps a timed-out ES-5 write pending and labels it uncertain',
+      () async {
+        var hasStartedWrite = false;
+        midiConnection.transport.onSend = (packet) {
+          if (packet[6] == 0x22) {
+            midiConnection.transport.receive(
+              Ntx8cvSysExFixtures.deviceInformationResponse,
+            );
+          } else if (packet[6] == 0x32 && packet[7] == 0x01) {
+            hasStartedWrite = true;
+          } else if (packet[6] == 0x31 &&
+              packet[7] == 0x01 &&
+              !hasStartedWrite) {
+            midiConnection.transport.receive(
+              Ntx8cvSysExFixtures.es5DisabledResponse,
+            );
+          }
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        await settingsCubit.setEs5Enabled(true);
+
+        expect(settingsCubit.state.confirmedEs5Enabled, isFalse);
+        expect(settingsCubit.state.attemptedEs5Enabled, isTrue);
+        expect(settingsCubit.state.isWritingEs5, isFalse);
+        expect(settingsCubit.state.es5Message, contains('not confirmed'));
+        expect(settingsCubit.state.es5Message, contains('uncertain'));
+      },
+    );
+
+    test(
+      'keeps an interrupted ES-5 write pending and labels it uncertain',
+      () async {
+        var hasStartedWrite = false;
+        midiConnection.transport.onSend = (packet) {
+          if (packet[6] == 0x22) {
+            midiConnection.transport.receive(
+              Ntx8cvSysExFixtures.deviceInformationResponse,
+            );
+          } else if (packet[6] == 0x32 && packet[7] == 0x01) {
+            hasStartedWrite = true;
+          } else if (packet[6] == 0x31 &&
+              packet[7] == 0x01 &&
+              !hasStartedWrite) {
+            midiConnection.transport.receive(
+              Ntx8cvSysExFixtures.es5DisabledResponse,
+            );
+          }
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        final write = settingsCubit.setEs5Enabled(true);
+        await _flushEvents();
+        expect(settingsCubit.state.isWritingEs5, isTrue);
+        expect(settingsCubit.state.attemptedEs5Enabled, isTrue);
+
+        await connectionCubit.disconnect();
+        await write;
+
+        expect(settingsCubit.state.confirmedEs5Enabled, isFalse);
+        expect(settingsCubit.state.attemptedEs5Enabled, isTrue);
+        expect(settingsCubit.state.isWritingEs5, isFalse);
+        expect(settingsCubit.state.es5Message, contains('disconnected'));
+        expect(settingsCubit.state.es5Message, contains('uncertain'));
       },
     );
   });
@@ -143,6 +263,12 @@ void main() {
 Future<void> _flushEvents() async {
   await Future<void>.delayed(Duration.zero);
   await Future<void>.delayed(Duration.zero);
+}
+
+Uint8List _withDeviceId(Uint8List packet, int deviceId) {
+  final copy = Uint8List.fromList(packet);
+  copy[5] = deviceId;
+  return copy;
 }
 
 MidiDevice _midiDevice({

--- a/test/cubit/ntx_8cv_settings_cubit_test.dart
+++ b/test/cubit/ntx_8cv_settings_cubit_test.dart
@@ -26,6 +26,7 @@ void main() {
         midiConnection: midiConnection,
         store: _MemoryNtx8cvConnectionStore(),
         sessionTimeout: const Duration(milliseconds: 10),
+        rebootReconnectDelay: Duration.zero,
       );
       settingsCubit = Ntx8cvSettingsCubit(connectionCubit: connectionCubit);
     });
@@ -73,6 +74,76 @@ void main() {
           settingsCubit.state.confirmedChannelGroup,
           Ntx8cvChannelGroup.channels1To8,
         );
+      },
+    );
+
+    test(
+      'reboots only the selected NTX-8CV then revalidates and refreshes settings',
+      () async {
+        var channelGroupValue = Ntx8cvChannelGroup.channels1To8.value;
+        var es5Value = 0;
+        var modeValue = Ntx8cvExpansionMode.cv8x8.value;
+        midiConnection.transport.onSend = (packet) {
+          if (packet[6] == 0x32 && packet[7] == 0x1B) {
+            modeValue = packet[8];
+          }
+          _respondWithSettings(
+            midiConnection.transport,
+            packet,
+            channelGroupValue: channelGroupValue,
+            es5Value: es5Value,
+            modeValue: modeValue,
+          );
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        await settingsCubit.setExpansionMode(
+          Ntx8cvExpansionMode.audio1x8_32bit,
+        );
+        expect(settingsCubit.state.modeRebootRequired, isTrue);
+
+        channelGroupValue = Ntx8cvChannelGroup.channels57To64.value;
+        es5Value = 1;
+        final sendsBeforeReboot = midiConnection.transport.sent.length;
+
+        await settingsCubit.reboot();
+
+        expect(midiConnection.openCount, 2);
+        expect(midiConnection.closeCount, 1);
+        expect(
+          midiConnection.transport.sent[sendsBeforeReboot],
+          orderedEquals(Ntx8cvSysExFixtures.reboot),
+        );
+        expect(
+          midiConnection.transport.sent[sendsBeforeReboot + 1],
+          orderedEquals(Ntx8cvSysExFixtures.deviceInformationRequest),
+        );
+        expect(
+          midiConnection.transport.sent[sendsBeforeReboot + 2],
+          orderedEquals(Ntx8cvSysExFixtures.readEs5EnabledSetting),
+        );
+        expect(
+          midiConnection.transport.sent[sendsBeforeReboot + 3],
+          orderedEquals(Ntx8cvSysExFixtures.readModeSetting),
+        );
+        expect(
+          midiConnection.transport.sent[sendsBeforeReboot + 4],
+          orderedEquals(Ntx8cvSysExFixtures.readChannelGroupSetting),
+        );
+        expect(settingsCubit.state.confirmedEs5Enabled, isTrue);
+        expect(
+          settingsCubit.state.confirmedMode,
+          Ntx8cvExpansionMode.audio1x8_32bit,
+        );
+        expect(
+          settingsCubit.state.confirmedChannelGroup,
+          Ntx8cvChannelGroup.channels57To64,
+        );
+        expect(settingsCubit.state.modeCapabilityEvidenced, isTrue);
+        expect(settingsCubit.state.modeRebootRequired, isFalse);
+        expect(settingsCubit.state.isRebooting, isFalse);
       },
     );
 
@@ -531,6 +602,8 @@ class _MemoryNtx8cvConnectionStore implements Ntx8cvConnectionStore {
 class _FakeNtx8cvMidiConnection implements Ntx8cvMidiConnection {
   List<MidiDevice> devices = [];
   final _FakeNtx8cvMidiTransport transport = _FakeNtx8cvMidiTransport();
+  int openCount = 0;
+  int closeCount = 0;
 
   @override
   Stream<MidiSetupChange>? get setupChanges => null;
@@ -542,14 +615,19 @@ class _FakeNtx8cvMidiConnection implements Ntx8cvMidiConnection {
   Future<Ntx8cvMidiTransport> open({
     required MidiDevice inputDevice,
     required MidiDevice outputDevice,
-  }) async => transport;
+  }) async {
+    openCount += 1;
+    return transport;
+  }
 
   @override
   Future<void> close({
     required Ntx8cvMidiTransport transport,
     required MidiDevice inputDevice,
     required MidiDevice outputDevice,
-  }) async {}
+  }) async {
+    closeCount += 1;
+  }
 
   Future<void> dispose() => transport.close();
 }

--- a/test/cubit/ntx_8cv_settings_cubit_test.dart
+++ b/test/cubit/ntx_8cv_settings_cubit_test.dart
@@ -331,6 +331,122 @@ void main() {
     );
 
     test(
+      'manual refresh reads a pending audio channel without resending and confirms a matching readback',
+      () async {
+        var audioChannelValues = [1, 0, 1, 0, 1, 0, 1, 0];
+        midiConnection.transport.onSend = (packet) {
+          _respondWithSettings(
+            midiConnection.transport,
+            packet,
+            audioChannelValues: audioChannelValues,
+          );
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        await settingsCubit.setAudioChannelEnabled(
+          Ntx8cvAudioChannel.channel1,
+          false,
+        );
+        expect(
+          settingsCubit.state.hasPendingAudioChannelChange(
+            Ntx8cvAudioChannel.channel1,
+          ),
+          isTrue,
+        );
+
+        audioChannelValues[0] = 0;
+        final sendsBeforeRefresh = midiConnection.transport.sent.length;
+        await settingsCubit.refresh();
+
+        expect(
+          settingsCubit.state.confirmedAudioChannelEnabled(
+            Ntx8cvAudioChannel.channel1,
+          ),
+          isFalse,
+        );
+        expect(
+          settingsCubit.state.hasPendingAudioChannelChange(
+            Ntx8cvAudioChannel.channel1,
+          ),
+          isFalse,
+        );
+        expect(
+          midiConnection.transport.sent
+              .skip(sendsBeforeRefresh)
+              .where((packet) => packet[6] == 0x32),
+          isEmpty,
+        );
+        expect(
+          midiConnection.transport.sent
+              .skip(sendsBeforeRefresh)
+              .where((packet) => packet[6] == 0x31 && packet[7] == 0x04),
+          hasLength(1),
+        );
+      },
+    );
+
+    test(
+      'reconnect refreshes a pending audio channel without resending',
+      () async {
+        var audioChannelValues = [1, 0, 1, 0, 1, 0, 1, 0];
+        midiConnection.transport.onSend = (packet) {
+          _respondWithSettings(
+            midiConnection.transport,
+            packet,
+            audioChannelValues: audioChannelValues,
+          );
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        await settingsCubit.setAudioChannelEnabled(
+          Ntx8cvAudioChannel.channel1,
+          false,
+        );
+        expect(
+          settingsCubit.state.hasPendingAudioChannelChange(
+            Ntx8cvAudioChannel.channel1,
+          ),
+          isTrue,
+        );
+
+        audioChannelValues[0] = 0;
+        await connectionCubit.disconnect();
+        final sendsBeforeReconnect = midiConnection.transport.sent.length;
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        expect(
+          settingsCubit.state.confirmedAudioChannelEnabled(
+            Ntx8cvAudioChannel.channel1,
+          ),
+          isFalse,
+        );
+        expect(
+          settingsCubit.state.hasPendingAudioChannelChange(
+            Ntx8cvAudioChannel.channel1,
+          ),
+          isFalse,
+        );
+        expect(
+          midiConnection.transport.sent
+              .skip(sendsBeforeReconnect)
+              .where((packet) => packet[6] == 0x32),
+          isEmpty,
+        );
+        expect(
+          midiConnection.transport.sent
+              .skip(sendsBeforeReconnect)
+              .where((packet) => packet[6] == 0x31 && packet[7] == 0x04),
+          hasLength(1),
+        );
+      },
+    );
+
+    test(
       'keeps a timed-out audio-channel change pending and uncertain',
       () async {
         var writeStarted = false;

--- a/test/cubit/ntx_8cv_settings_cubit_test.dart
+++ b/test/cubit/ntx_8cv_settings_cubit_test.dart
@@ -36,34 +36,45 @@ void main() {
       await midiConnection.dispose();
     });
 
-    test('reads ES-5 and probes Mode after connecting', () async {
-      midiConnection.transport.onSend = (packet) {
-        _respondWithSettings(midiConnection.transport, packet);
-      };
-      await connectionCubit.initialize();
-      await connectionCubit.connect();
-      await _flushEvents();
+    test(
+      'reads Channel Group, ES-5, and probes Mode after connecting',
+      () async {
+        midiConnection.transport.onSend = (packet) {
+          _respondWithSettings(midiConnection.transport, packet);
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
 
-      expect(settingsCubit.state.confirmedEs5Enabled, isFalse);
-      expect(
-        settingsCubit.state.confirmedMode,
-        Ntx8cvExpansionMode.audio2x8_16bit,
-      );
-      expect(settingsCubit.state.modeCapabilityEvidenced, isTrue);
-      expect(midiConnection.transport.sent, hasLength(3));
-      expect(
-        midiConnection.transport.sent[0],
-        orderedEquals(Ntx8cvSysExFixtures.deviceInformationRequest),
-      );
-      expect(
-        midiConnection.transport.sent[1],
-        orderedEquals(Ntx8cvSysExFixtures.readEs5EnabledSetting),
-      );
-      expect(
-        midiConnection.transport.sent[2],
-        orderedEquals(Ntx8cvSysExFixtures.readModeSetting),
-      );
-    });
+        expect(settingsCubit.state.confirmedEs5Enabled, isFalse);
+        expect(
+          settingsCubit.state.confirmedMode,
+          Ntx8cvExpansionMode.audio2x8_16bit,
+        );
+        expect(settingsCubit.state.modeCapabilityEvidenced, isTrue);
+        expect(midiConnection.transport.sent, hasLength(4));
+        expect(
+          midiConnection.transport.sent[0],
+          orderedEquals(Ntx8cvSysExFixtures.deviceInformationRequest),
+        );
+        expect(
+          midiConnection.transport.sent[1],
+          orderedEquals(Ntx8cvSysExFixtures.readEs5EnabledSetting),
+        );
+        expect(
+          midiConnection.transport.sent[2],
+          orderedEquals(Ntx8cvSysExFixtures.readModeSetting),
+        );
+        expect(
+          midiConnection.transport.sent[3],
+          orderedEquals(Ntx8cvSysExFixtures.readChannelGroupSetting),
+        );
+        expect(
+          settingsCubit.state.confirmedChannelGroup,
+          Ntx8cvChannelGroup.channels1To8,
+        );
+      },
+    );
 
     test('changes ES-5 only after matching same-setting readback', () async {
       midiConnection.transport.onSend = (packet) {
@@ -84,16 +95,64 @@ void main() {
 
       expect(settingsCubit.state.confirmedEs5Enabled, isTrue);
       expect(settingsCubit.state.hasPendingEs5Change, isFalse);
-      expect(midiConnection.transport.sent, hasLength(5));
+      expect(midiConnection.transport.sent, hasLength(6));
       expect(
-        midiConnection.transport.sent[3],
+        midiConnection.transport.sent[4],
         orderedEquals(Ntx8cvSysExFixtures.writeEs5EnabledSetting),
       );
       expect(
-        midiConnection.transport.sent[4],
+        midiConnection.transport.sent[5],
         orderedEquals(Ntx8cvSysExFixtures.readEs5EnabledSetting),
       );
     });
+
+    test(
+      'confirms a Channel Group only after matching readback and manual retry',
+      () async {
+        var reportedChannelGroup = Ntx8cvChannelGroup.channels1To8.value;
+        midiConnection.transport.onSend = (packet) {
+          _respondWithSettings(
+            midiConnection.transport,
+            packet,
+            channelGroupValue: reportedChannelGroup,
+          );
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        await settingsCubit.setChannelGroup(Ntx8cvChannelGroup.channels57To64);
+
+        expect(
+          settingsCubit.state.confirmedChannelGroup,
+          Ntx8cvChannelGroup.channels1To8,
+        );
+        expect(
+          settingsCubit.state.attemptedChannelGroup,
+          Ntx8cvChannelGroup.channels57To64,
+        );
+        expect(settingsCubit.state.hasPendingChannelGroupChange, isTrue);
+        expect(settingsCubit.state.channelGroupMessage, contains('uncertain'));
+        expect(
+          midiConnection.transport.sent[4],
+          orderedEquals(Ntx8cvSysExFixtures.writeChannelGroupSetting),
+        );
+        expect(
+          midiConnection.transport.sent[5],
+          orderedEquals(Ntx8cvSysExFixtures.readChannelGroupSetting),
+        );
+
+        reportedChannelGroup = Ntx8cvChannelGroup.channels57To64.value;
+        await settingsCubit.retryChannelGroupChange();
+
+        expect(
+          settingsCubit.state.confirmedChannelGroup,
+          Ntx8cvChannelGroup.channels57To64,
+        );
+        expect(settingsCubit.state.hasPendingChannelGroupChange, isFalse);
+        expect(settingsCubit.state.modeRebootRequired, isFalse);
+      },
+    );
 
     test(
       'retains a mismatched ES-5 change across reconnect and retries only explicitly',
@@ -129,16 +188,26 @@ void main() {
         await _flushEvents();
 
         expect(settingsCubit.state.hasPendingEs5Change, isTrue);
-        // Reconnect validates identity and probes Mode, but never resends ES-5.
+        // Reconnect validates identity and refreshes Mode and Channel Group,
+        // but never resends ES-5.
         expect(
           midiConnection.transport.sent,
-          hasLength(sendsBeforeReconnect + 2),
+          hasLength(sendsBeforeReconnect + 3),
         );
         expect(midiConnection.transport.sent[sendsBeforeReconnect][5], 2);
         expect(midiConnection.transport.sent[sendsBeforeReconnect][6], 0x22);
+        expect(midiConnection.transport.sent[sendsBeforeReconnect + 1][5], 2);
+        expect(
+          midiConnection.transport.sent[sendsBeforeReconnect + 1][6],
+          0x31,
+        );
+        expect(
+          midiConnection.transport.sent[sendsBeforeReconnect + 1][7],
+          0x1B,
+        );
         expect(midiConnection.transport.sent.last[5], 2);
         expect(midiConnection.transport.sent.last[6], 0x31);
-        expect(midiConnection.transport.sent.last[7], 0x1B);
+        expect(midiConnection.transport.sent.last[7], 0x00);
 
         returnEnabledValue = true;
         await settingsCubit.retryEs5Change();
@@ -148,16 +217,16 @@ void main() {
         expect(settingsCubit.state.modeRebootRequired, isFalse);
         expect(
           midiConnection.transport.sent,
-          hasLength(sendsBeforeReconnect + 4),
-        );
-        expect(midiConnection.transport.sent[sendsBeforeReconnect + 2][5], 2);
-        expect(
-          midiConnection.transport.sent[sendsBeforeReconnect + 2][6],
-          0x32,
+          hasLength(sendsBeforeReconnect + 5),
         );
         expect(midiConnection.transport.sent[sendsBeforeReconnect + 3][5], 2);
         expect(
           midiConnection.transport.sent[sendsBeforeReconnect + 3][6],
+          0x32,
+        );
+        expect(midiConnection.transport.sent[sendsBeforeReconnect + 4][5], 2);
+        expect(
+          midiConnection.transport.sent[sendsBeforeReconnect + 4][6],
           0x31,
         );
       },
@@ -351,7 +420,7 @@ void main() {
         // Reconnect reads ES-5 and Mode but does not write a pending Mode.
         expect(
           midiConnection.transport.sent,
-          hasLength(sendsBeforeReconnect + 3),
+          hasLength(sendsBeforeReconnect + 4),
         );
         expect(
           midiConnection.transport.sent.where((packet) => packet[6] == 0x32),
@@ -382,6 +451,7 @@ void main() {
 void _respondWithSettings(
   _FakeNtx8cvMidiTransport transport,
   Uint8List packet, {
+  int channelGroupValue = 0,
   int es5Value = 0,
   int modeValue = 2,
 }) {
@@ -390,6 +460,8 @@ void _respondWithSettings(
     transport.receive(
       _withDeviceId(Ntx8cvSysExFixtures.deviceInformationResponse, deviceId),
     );
+  } else if (packet[6] == 0x31 && packet[7] == 0x00) {
+    transport.receive(_settingResponse(0x00, channelGroupValue, deviceId));
   } else if (packet[6] == 0x31 && packet[7] == 0x01) {
     transport.receive(_settingResponse(0x01, es5Value, deviceId));
   } else if (packet[6] == 0x31 && packet[7] == 0x1B) {

--- a/test/cubit/ntx_8cv_settings_cubit_test.dart
+++ b/test/cubit/ntx_8cv_settings_cubit_test.dart
@@ -1,0 +1,211 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_midi_command/flutter_midi_command.dart';
+import 'package:flutter_midi_command_platform_interface/midi_port.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/cubit/ntx_8cv_connection_cubit.dart';
+import 'package:nt_helper/cubit/ntx_8cv_settings_cubit.dart';
+import 'package:nt_helper/domain/ntx_8cv/ntx_8cv_midi_connection.dart';
+import 'package:nt_helper/domain/ntx_8cv/ntx_8cv_sysex.dart';
+
+import '../fixtures/ntx_8cv_sysex_fixtures.dart';
+
+void main() {
+  group('Ntx8cvSettingsCubit', () {
+    late _FakeNtx8cvMidiConnection midiConnection;
+    late Ntx8cvConnectionCubit connectionCubit;
+    late Ntx8cvSettingsCubit settingsCubit;
+
+    setUp(() {
+      midiConnection = _FakeNtx8cvMidiConnection();
+      midiConnection.devices = [
+        _midiDevice(id: 'ntx8cv', name: 'NTX-8CV', input: true, output: true),
+      ];
+      connectionCubit = Ntx8cvConnectionCubit(
+        midiConnection: midiConnection,
+        store: _MemoryNtx8cvConnectionStore(),
+        sessionTimeout: const Duration(milliseconds: 10),
+      );
+      settingsCubit = Ntx8cvSettingsCubit(connectionCubit: connectionCubit);
+    });
+
+    tearDown(() async {
+      await settingsCubit.close();
+      await connectionCubit.close();
+      await midiConnection.dispose();
+    });
+
+    test('reads the device-confirmed ES-5 value after connecting', () async {
+      midiConnection.transport.onSend = (packet) {
+        if (packet[6] == 0x22) {
+          midiConnection.transport.receive(
+            Ntx8cvSysExFixtures.deviceInformationResponse,
+          );
+        } else if (packet[6] == 0x31 && packet[7] == 0x01) {
+          midiConnection.transport.receive(
+            Ntx8cvSysExFixtures.es5DisabledResponse,
+          );
+        }
+      };
+      await connectionCubit.initialize();
+
+      await connectionCubit.connect();
+      await _flushEvents();
+
+      expect(settingsCubit.state.confirmedEs5Enabled, isFalse);
+      expect(settingsCubit.state.hasPendingEs5Change, isFalse);
+      expect(midiConnection.transport.sent, hasLength(2));
+      expect(
+        midiConnection.transport.sent[0],
+        orderedEquals(Ntx8cvSysExFixtures.deviceInformationRequest),
+      );
+      expect(
+        midiConnection.transport.sent[1],
+        orderedEquals(Ntx8cvSysExFixtures.readEs5EnabledSetting),
+      );
+    });
+
+    test('changes ES-5 only after a matching same-setting readback', () async {
+      midiConnection.transport.onSend = (packet) {
+        if (packet[6] == 0x22) {
+          midiConnection.transport.receive(
+            Ntx8cvSysExFixtures.deviceInformationResponse,
+          );
+        } else if (packet[6] == 0x31 && packet[7] == 0x01) {
+          final hasWrittenEs5 = midiConnection.transport.sent.any(
+            (sent) => sent[6] == 0x32 && sent[7] == 0x01,
+          );
+          midiConnection.transport.receive(
+            hasWrittenEs5
+                ? Ntx8cvSysExFixtures.es5EnabledResponse
+                : Ntx8cvSysExFixtures.es5DisabledResponse,
+          );
+        }
+      };
+      await connectionCubit.initialize();
+      await connectionCubit.connect();
+      await _flushEvents();
+
+      await settingsCubit.setEs5Enabled(true);
+
+      expect(settingsCubit.state.confirmedEs5Enabled, isTrue);
+      expect(settingsCubit.state.hasPendingEs5Change, isFalse);
+      expect(midiConnection.transport.sent, hasLength(4));
+      expect(
+        midiConnection.transport.sent[0],
+        orderedEquals(Ntx8cvSysExFixtures.deviceInformationRequest),
+      );
+      expect(
+        midiConnection.transport.sent[1],
+        orderedEquals(Ntx8cvSysExFixtures.readEs5EnabledSetting),
+      );
+      expect(
+        midiConnection.transport.sent[2],
+        orderedEquals(Ntx8cvSysExFixtures.writeEs5EnabledSetting),
+      );
+      expect(
+        midiConnection.transport.sent[3],
+        orderedEquals(Ntx8cvSysExFixtures.readEs5EnabledSetting),
+      );
+    });
+
+    test(
+      'does not confirm ES-5 when same-setting readback mismatches',
+      () async {
+        midiConnection.transport.onSend = (packet) {
+          if (packet[6] == 0x22) {
+            midiConnection.transport.receive(
+              Ntx8cvSysExFixtures.deviceInformationResponse,
+            );
+          } else if (packet[6] == 0x31 && packet[7] == 0x01) {
+            midiConnection.transport.receive(
+              Ntx8cvSysExFixtures.es5DisabledResponse,
+            );
+          }
+        };
+        await connectionCubit.initialize();
+        await connectionCubit.connect();
+        await _flushEvents();
+
+        await settingsCubit.setEs5Enabled(true);
+
+        expect(settingsCubit.state.confirmedEs5Enabled, isFalse);
+        expect(settingsCubit.state.attemptedEs5Enabled, isTrue);
+        expect(settingsCubit.state.hasPendingEs5Change, isTrue);
+        expect(settingsCubit.state.es5Message, contains('not confirmed'));
+        expect(settingsCubit.state.es5Message, contains('uncertain'));
+      },
+    );
+  });
+}
+
+Future<void> _flushEvents() async {
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+}
+
+MidiDevice _midiDevice({
+  required String id,
+  required String name,
+  bool input = false,
+  bool output = false,
+}) {
+  final device = MidiDevice(id, name, MidiDeviceType.serial, false);
+  if (input) device.inputPorts = [MidiPort(1, MidiPortType.IN)];
+  if (output) device.outputPorts = [MidiPort(2, MidiPortType.OUT)];
+  return device;
+}
+
+class _MemoryNtx8cvConnectionStore implements Ntx8cvConnectionStore {
+  @override
+  Future<Ntx8cvSavedConnection> load() async => const Ntx8cvSavedConnection();
+
+  @override
+  Future<void> save(Ntx8cvSavedConnection selection) async {}
+}
+
+class _FakeNtx8cvMidiConnection implements Ntx8cvMidiConnection {
+  List<MidiDevice> devices = [];
+  final _FakeNtx8cvMidiTransport transport = _FakeNtx8cvMidiTransport();
+
+  @override
+  Stream<MidiSetupChange>? get setupChanges => null;
+
+  @override
+  Future<List<MidiDevice>> listDevices() async => List.of(devices);
+
+  @override
+  Future<Ntx8cvMidiTransport> open({
+    required MidiDevice inputDevice,
+    required MidiDevice outputDevice,
+  }) async => transport;
+
+  @override
+  Future<void> close({
+    required Ntx8cvMidiTransport transport,
+    required MidiDevice inputDevice,
+    required MidiDevice outputDevice,
+  }) async {}
+
+  Future<void> dispose() => transport.close();
+}
+
+class _FakeNtx8cvMidiTransport implements Ntx8cvMidiTransport {
+  final _received = StreamController<Uint8List>.broadcast(sync: true);
+  final List<Uint8List> sent = [];
+  void Function(Uint8List packet)? onSend;
+
+  @override
+  Stream<Uint8List> get receivedPackets => _received.stream;
+
+  @override
+  Future<void> send(Uint8List packet) async {
+    sent.add(packet);
+    onSend?.call(packet);
+  }
+
+  void receive(Uint8List packet) => _received.add(packet);
+
+  Future<void> close() => _received.close();
+}

--- a/test/domain/ntx_8cv/ntx_8cv_sysex_test.dart
+++ b/test/domain/ntx_8cv/ntx_8cv_sysex_test.dart
@@ -1,0 +1,255 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/domain/ntx_8cv/ntx_8cv_sysex.dart';
+
+import '../../fixtures/ntx_8cv_sysex_fixtures.dart';
+
+void main() {
+  const codec = Ntx8cvSysExCodec();
+
+  group('NTX-8CV documented packet fixtures', () {
+    test(
+      'encodes device information, setting read/write, and reboot frames',
+      () {
+        expect(
+          codec.requestDeviceInformation(deviceId: 0),
+          orderedEquals(Ntx8cvSysExFixtures.deviceInformationRequest),
+        );
+        expect(
+          codec.readSetting(deviceId: 0, settingId: 0x1B),
+          orderedEquals(Ntx8cvSysExFixtures.readModeSetting),
+        );
+        expect(
+          codec.writeSetting(deviceId: 0, settingId: 0x1B, value: 2),
+          orderedEquals(Ntx8cvSysExFixtures.writeModeSetting),
+        );
+        expect(
+          codec.reboot(deviceId: 0),
+          orderedEquals(Ntx8cvSysExFixtures.reboot),
+        );
+      },
+    );
+
+    test('decodes a complete device-information response', () {
+      final decoded = codec.decode(
+        Ntx8cvSysExFixtures.deviceInformationResponse,
+      );
+
+      expect(decoded, isA<Ntx8cvDeviceInformation>());
+      final information = decoded! as Ntx8cvDeviceInformation;
+      expect(information.deviceId, 0);
+      expect(information.firmwareText, 'fixture-firmware');
+      expect(information.serialText, 'fixture-serial');
+      expect(information.textFields, ['fixture-firmware', 'fixture-serial']);
+    });
+
+    test('decodes a complete setting response', () {
+      final decoded = codec.decode(Ntx8cvSysExFixtures.modeSettingResponse);
+
+      expect(decoded, isA<Ntx8cvSettingValue>());
+      final setting = decoded! as Ntx8cvSettingValue;
+      expect(setting.deviceId, 0);
+      expect(setting.settingId, 0x1B);
+      expect(setting.value, 2);
+    });
+
+    test('rejects malformed, wrong-product, and incomplete responses', () {
+      expect(codec.decode(Ntx8cvSysExFixtures.malformedWrongProduct), isNull);
+      expect(
+        codec.decode(Ntx8cvSysExFixtures.malformedSettingResponse),
+        isNull,
+      );
+      expect(
+        codec.decode(Ntx8cvSysExFixtures.malformedInformationResponse),
+        isNull,
+      );
+      expect(
+        codec.decode(
+          Uint8List.fromList([
+            0xF0,
+            0x00,
+            0x21,
+            0x27,
+            0x6A,
+            0x00,
+            0x31,
+            0x1B,
+            0x02,
+            0x01,
+            0xF7,
+          ]),
+        ),
+        isNull,
+      );
+    });
+
+    test('rejects values outside the MIDI 7-bit range when encoding', () {
+      expect(
+        () => codec.readSetting(deviceId: 128, settingId: 0x1B),
+        throwsArgumentError,
+      );
+      expect(
+        () => codec.writeSetting(deviceId: 0, settingId: -1, value: 2),
+        throwsArgumentError,
+      );
+      expect(
+        () => codec.writeSetting(deviceId: 0, settingId: 0x1B, value: 128),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('NTX-8CV session', () {
+    late _FakeNtx8cvMidiTransport transport;
+    late Ntx8cvSession session;
+
+    setUp(() {
+      transport = _FakeNtx8cvMidiTransport();
+      session = Ntx8cvSession(
+        transport: transport,
+        deviceId: 0,
+        timeout: const Duration(seconds: 1),
+      );
+    });
+
+    tearDown(() async {
+      await session.close();
+      await transport.close();
+    });
+
+    test('matches device information only from the selected NTX-8CV', () async {
+      final response = session.requestDeviceInformation();
+
+      expect(
+        transport.sent.single,
+        orderedEquals(Ntx8cvSysExFixtures.deviceInformationRequest),
+      );
+
+      transport.receive(
+        Uint8List.fromList([
+          0xF0,
+          0x00,
+          0x21,
+          0x27,
+          0x6A,
+          0x01,
+          0x32,
+          0x00,
+          0x00,
+          0xF7,
+        ]),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(transport.sent, hasLength(1));
+
+      transport.receive(Ntx8cvSysExFixtures.deviceInformationResponse);
+      expect((await response).serialText, 'fixture-serial');
+    });
+
+    test(
+      'writes then requires matching setting readback for confirmation',
+      () async {
+        final confirmation = session.writeAndConfirmSetting(
+          settingId: 0x1B,
+          value: 2,
+        );
+
+        expect(
+          transport.sent.single,
+          orderedEquals(Ntx8cvSysExFixtures.writeModeSetting),
+        );
+        await _flushMicrotasks();
+        expect(
+          transport.sent[1],
+          orderedEquals(Ntx8cvSysExFixtures.readModeSetting),
+        );
+
+        transport.receive(Ntx8cvSysExFixtures.modeSettingResponse);
+        expect((await confirmation).value, 2);
+      },
+    );
+
+    test(
+      'rejects a setting confirmation when readback does not match',
+      () async {
+        final confirmation = session.writeAndConfirmSetting(
+          settingId: 0x1B,
+          value: 2,
+        );
+        await _flushMicrotasks();
+
+        transport.receive(
+          Uint8List.fromList([
+            0xF0,
+            0x00,
+            0x21,
+            0x27,
+            0x6A,
+            0x00,
+            0x31,
+            0x1B,
+            0x01,
+            0xF7,
+          ]),
+        );
+
+        await expectLater(confirmation, throwsA(isA<StateError>()));
+      },
+    );
+
+    test('reports a configurable timeout when a response is absent', () {
+      fakeAsync((async) {
+        Object? failure;
+        final timeoutSession = Ntx8cvSession(
+          transport: transport,
+          deviceId: 0,
+          timeout: const Duration(milliseconds: 25),
+        );
+
+        () async {
+          try {
+            await timeoutSession.readSetting(settingId: 0x1B);
+          } catch (error) {
+            failure = error;
+          }
+        }();
+
+        async.flushMicrotasks();
+        async.elapse(const Duration(milliseconds: 25));
+        async.flushMicrotasks();
+
+        expect(failure, isA<Ntx8cvTimeoutException>());
+        final timeout = failure! as Ntx8cvTimeoutException;
+        expect(timeout.operation, 'read setting 0x1B');
+        expect(timeout.timeout, const Duration(milliseconds: 25));
+        timeoutSession.close();
+      });
+    });
+  });
+}
+
+Future<void> _flushMicrotasks() async {
+  await Future<void>.value();
+  await Future<void>.value();
+}
+
+class _FakeNtx8cvMidiTransport implements Ntx8cvMidiTransport {
+  final StreamController<Uint8List> _received =
+      StreamController<Uint8List>.broadcast(sync: true);
+  final List<Uint8List> sent = [];
+
+  @override
+  Stream<Uint8List> get receivedPackets => _received.stream;
+
+  @override
+  Future<void> send(Uint8List packet) async {
+    sent.add(packet);
+  }
+
+  void receive(Uint8List packet) => _received.add(packet);
+
+  Future<void> close() => _received.close();
+}

--- a/test/domain/ntx_8cv/ntx_8cv_sysex_test.dart
+++ b/test/domain/ntx_8cv/ntx_8cv_sysex_test.dart
@@ -35,6 +35,14 @@ void main() {
           orderedEquals(Ntx8cvSysExFixtures.writeEs5EnabledSetting),
         );
         expect(
+          codec.readSetting(deviceId: 0, settingId: 0x04),
+          orderedEquals(Ntx8cvSysExFixtures.readAudioChannel1EnabledSetting),
+        );
+        expect(
+          codec.writeSetting(deviceId: 0, settingId: 0x04, value: 0),
+          orderedEquals(Ntx8cvSysExFixtures.writeAudioChannel1DisabledSetting),
+        );
+        expect(
           codec.readSetting(deviceId: 0, settingId: 0x1B),
           orderedEquals(Ntx8cvSysExFixtures.readModeSetting),
         );
@@ -63,12 +71,15 @@ void main() {
     });
 
     test(
-      'decodes complete Channel Group, ES-5, and mode setting responses',
+      'decodes complete Channel Group, ES-5, audio-channel, and mode setting responses',
       () {
         final channelGroup = codec.decode(
           Ntx8cvSysExFixtures.channelGroupResponse,
         );
         final es5 = codec.decode(Ntx8cvSysExFixtures.es5EnabledResponse);
+        final audioChannel = codec.decode(
+          Ntx8cvSysExFixtures.audioChannel1EnabledResponse,
+        );
         final mode = codec.decode(Ntx8cvSysExFixtures.modeSettingResponse);
 
         expect(channelGroup, isA<Ntx8cvSettingValue>());
@@ -82,6 +93,12 @@ void main() {
         expect(es5Setting.deviceId, 0);
         expect(es5Setting.settingId, 0x01);
         expect(es5Setting.value, 1);
+
+        expect(audioChannel, isA<Ntx8cvSettingValue>());
+        final audioChannelSetting = audioChannel! as Ntx8cvSettingValue;
+        expect(audioChannelSetting.deviceId, 0);
+        expect(audioChannelSetting.settingId, 0x04);
+        expect(audioChannelSetting.value, 1);
 
         expect(mode, isA<Ntx8cvSettingValue>());
         final modeSetting = mode! as Ntx8cvSettingValue;
@@ -234,6 +251,21 @@ void main() {
         await expectLater(confirmation, throwsA(isA<StateError>()));
       },
     );
+
+    test('reports a malformed response from the selected device', () async {
+      final confirmation = session.writeAndConfirmSetting(
+        settingId: 0x1B,
+        value: 2,
+      );
+      await _flushMicrotasks();
+
+      transport.receive(Ntx8cvSysExFixtures.malformedSettingResponse);
+
+      await expectLater(
+        confirmation,
+        throwsA(isA<Ntx8cvMalformedResponseException>()),
+      );
+    });
 
     test('reports a configurable timeout when a response is absent', () {
       fakeAsync((async) {

--- a/test/domain/ntx_8cv/ntx_8cv_sysex_test.dart
+++ b/test/domain/ntx_8cv/ntx_8cv_sysex_test.dart
@@ -19,6 +19,14 @@ void main() {
           orderedEquals(Ntx8cvSysExFixtures.deviceInformationRequest),
         );
         expect(
+          codec.readSetting(deviceId: 0, settingId: 0x01),
+          orderedEquals(Ntx8cvSysExFixtures.readEs5EnabledSetting),
+        );
+        expect(
+          codec.writeSetting(deviceId: 0, settingId: 0x01, value: 1),
+          orderedEquals(Ntx8cvSysExFixtures.writeEs5EnabledSetting),
+        );
+        expect(
           codec.readSetting(deviceId: 0, settingId: 0x1B),
           orderedEquals(Ntx8cvSysExFixtures.readModeSetting),
         );
@@ -46,14 +54,21 @@ void main() {
       expect(information.textFields, ['fixture-firmware', 'fixture-serial']);
     });
 
-    test('decodes a complete setting response', () {
-      final decoded = codec.decode(Ntx8cvSysExFixtures.modeSettingResponse);
+    test('decodes complete ES-5 and mode setting responses', () {
+      final es5 = codec.decode(Ntx8cvSysExFixtures.es5EnabledResponse);
+      final mode = codec.decode(Ntx8cvSysExFixtures.modeSettingResponse);
 
-      expect(decoded, isA<Ntx8cvSettingValue>());
-      final setting = decoded! as Ntx8cvSettingValue;
-      expect(setting.deviceId, 0);
-      expect(setting.settingId, 0x1B);
-      expect(setting.value, 2);
+      expect(es5, isA<Ntx8cvSettingValue>());
+      final es5Setting = es5! as Ntx8cvSettingValue;
+      expect(es5Setting.deviceId, 0);
+      expect(es5Setting.settingId, 0x01);
+      expect(es5Setting.value, 1);
+
+      expect(mode, isA<Ntx8cvSettingValue>());
+      final modeSetting = mode! as Ntx8cvSettingValue;
+      expect(modeSetting.deviceId, 0);
+      expect(modeSetting.settingId, 0x1B);
+      expect(modeSetting.value, 2);
     });
 
     test('rejects malformed, wrong-product, and incomplete responses', () {

--- a/test/domain/ntx_8cv/ntx_8cv_sysex_test.dart
+++ b/test/domain/ntx_8cv/ntx_8cv_sysex_test.dart
@@ -19,6 +19,14 @@ void main() {
           orderedEquals(Ntx8cvSysExFixtures.deviceInformationRequest),
         );
         expect(
+          codec.readSetting(deviceId: 0, settingId: 0x00),
+          orderedEquals(Ntx8cvSysExFixtures.readChannelGroupSetting),
+        );
+        expect(
+          codec.writeSetting(deviceId: 0, settingId: 0x00, value: 7),
+          orderedEquals(Ntx8cvSysExFixtures.writeChannelGroupSetting),
+        );
+        expect(
           codec.readSetting(deviceId: 0, settingId: 0x01),
           orderedEquals(Ntx8cvSysExFixtures.readEs5EnabledSetting),
         );
@@ -54,22 +62,34 @@ void main() {
       expect(information.textFields, ['fixture-firmware', 'fixture-serial']);
     });
 
-    test('decodes complete ES-5 and mode setting responses', () {
-      final es5 = codec.decode(Ntx8cvSysExFixtures.es5EnabledResponse);
-      final mode = codec.decode(Ntx8cvSysExFixtures.modeSettingResponse);
+    test(
+      'decodes complete Channel Group, ES-5, and mode setting responses',
+      () {
+        final channelGroup = codec.decode(
+          Ntx8cvSysExFixtures.channelGroupResponse,
+        );
+        final es5 = codec.decode(Ntx8cvSysExFixtures.es5EnabledResponse);
+        final mode = codec.decode(Ntx8cvSysExFixtures.modeSettingResponse);
 
-      expect(es5, isA<Ntx8cvSettingValue>());
-      final es5Setting = es5! as Ntx8cvSettingValue;
-      expect(es5Setting.deviceId, 0);
-      expect(es5Setting.settingId, 0x01);
-      expect(es5Setting.value, 1);
+        expect(channelGroup, isA<Ntx8cvSettingValue>());
+        final channelGroupSetting = channelGroup! as Ntx8cvSettingValue;
+        expect(channelGroupSetting.deviceId, 0);
+        expect(channelGroupSetting.settingId, 0x00);
+        expect(channelGroupSetting.value, 7);
 
-      expect(mode, isA<Ntx8cvSettingValue>());
-      final modeSetting = mode! as Ntx8cvSettingValue;
-      expect(modeSetting.deviceId, 0);
-      expect(modeSetting.settingId, 0x1B);
-      expect(modeSetting.value, 2);
-    });
+        expect(es5, isA<Ntx8cvSettingValue>());
+        final es5Setting = es5! as Ntx8cvSettingValue;
+        expect(es5Setting.deviceId, 0);
+        expect(es5Setting.settingId, 0x01);
+        expect(es5Setting.value, 1);
+
+        expect(mode, isA<Ntx8cvSettingValue>());
+        final modeSetting = mode! as Ntx8cvSettingValue;
+        expect(modeSetting.deviceId, 0);
+        expect(modeSetting.settingId, 0x1B);
+        expect(modeSetting.value, 2);
+      },
+    );
 
     test('rejects malformed, wrong-product, and incomplete responses', () {
       expect(codec.decode(Ntx8cvSysExFixtures.malformedWrongProduct), isNull);

--- a/test/fixtures/ntx_8cv_sysex_fixtures.dart
+++ b/test/fixtures/ntx_8cv_sysex_fixtures.dart
@@ -1,0 +1,120 @@
+import 'dart:typed_data';
+
+/// Deterministic NTX-8CV frames derived from the approved protocol contract.
+///
+/// The device-information text is deliberately opaque fixture data rather than
+/// a claimed firmware or serial-number grammar. Both fields are NUL-terminated
+/// ASCII as required by the protocol contract.
+abstract final class Ntx8cvSysExFixtures {
+  static final Uint8List deviceInformationRequest = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x22,
+    0xF7,
+  ]);
+
+  static final Uint8List deviceInformationResponse = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x32,
+    ...'fixture-firmware'.codeUnits,
+    0x00,
+    ...'fixture-serial'.codeUnits,
+    0x00,
+    0xF7,
+  ]);
+
+  static final Uint8List readModeSetting = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x31,
+    0x1B,
+    0xF7,
+  ]);
+
+  static final Uint8List modeSettingResponse = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x31,
+    0x1B,
+    0x02,
+    0xF7,
+  ]);
+
+  static final Uint8List writeModeSetting = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x32,
+    0x1B,
+    0x02,
+    0xF7,
+  ]);
+
+  static final Uint8List reboot = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x7F,
+    0xF7,
+  ]);
+
+  static final Uint8List malformedWrongProduct = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6D,
+    0x00,
+    0x31,
+    0x1B,
+    0x02,
+    0xF7,
+  ]);
+
+  static final Uint8List malformedSettingResponse = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x31,
+    0x1B,
+    0xF7,
+  ]);
+
+  static final Uint8List malformedInformationResponse = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x32,
+    ...'unterminated'.codeUnits,
+    0xF7,
+  ]);
+}

--- a/test/fixtures/ntx_8cv_sysex_fixtures.dart
+++ b/test/fixtures/ntx_8cv_sysex_fixtures.dart
@@ -32,6 +32,44 @@ abstract final class Ntx8cvSysExFixtures {
     0xF7,
   ]);
 
+  static final Uint8List readChannelGroupSetting = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x31,
+    0x00,
+    0xF7,
+  ]);
+
+  static final Uint8List channelGroupResponse = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x31,
+    0x00,
+    0x07,
+    0xF7,
+  ]);
+
+  static final Uint8List writeChannelGroupSetting = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x32,
+    0x00,
+    0x07,
+    0xF7,
+  ]);
+
   static final Uint8List readEs5EnabledSetting = Uint8List.fromList([
     0xF0,
     0x00,

--- a/test/fixtures/ntx_8cv_sysex_fixtures.dart
+++ b/test/fixtures/ntx_8cv_sysex_fixtures.dart
@@ -121,6 +121,36 @@ abstract final class Ntx8cvSysExFixtures {
     0xF7,
   ]);
 
+  /// The released first per-audio-channel enable setting (`0x04`).
+  static final Uint8List readAudioChannel1EnabledSetting = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x31,
+    0x04,
+    0xF7,
+  ]);
+
+  static final Uint8List audioChannel1EnabledResponse = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x31,
+    0x04,
+    0x01,
+    0xF7,
+  ]);
+
+  static final Uint8List writeAudioChannel1DisabledSetting = Uint8List.fromList(
+    [0xF0, 0x00, 0x21, 0x27, 0x6A, 0x00, 0x32, 0x04, 0x00, 0xF7],
+  );
+
   static final Uint8List readModeSetting = Uint8List.fromList([
     0xF0,
     0x00,

--- a/test/fixtures/ntx_8cv_sysex_fixtures.dart
+++ b/test/fixtures/ntx_8cv_sysex_fixtures.dart
@@ -32,6 +32,57 @@ abstract final class Ntx8cvSysExFixtures {
     0xF7,
   ]);
 
+  static final Uint8List readEs5EnabledSetting = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x31,
+    0x01,
+    0xF7,
+  ]);
+
+  static final Uint8List es5DisabledResponse = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x31,
+    0x01,
+    0x00,
+    0xF7,
+  ]);
+
+  static final Uint8List writeEs5EnabledSetting = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x32,
+    0x01,
+    0x01,
+    0xF7,
+  ]);
+
+  static final Uint8List es5EnabledResponse = Uint8List.fromList([
+    0xF0,
+    0x00,
+    0x21,
+    0x27,
+    0x6A,
+    0x00,
+    0x31,
+    0x01,
+    0x01,
+    0xF7,
+  ]);
+
   static final Uint8List readModeSetting = Uint8List.fromList([
     0xF0,
     0x00,

--- a/test/ui/ntx_8cv/ntx_8cv_entry_screen_test.dart
+++ b/test/ui/ntx_8cv/ntx_8cv_entry_screen_test.dart
@@ -1,0 +1,148 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nt_helper/core/platform/platform_interaction_service.dart';
+import 'package:nt_helper/cubit/disting_cubit.dart';
+import 'package:nt_helper/db/daos/metadata_dao.dart';
+import 'package:nt_helper/db/daos/presets_dao.dart';
+import 'package:nt_helper/db/database.dart';
+import 'package:nt_helper/domain/i_disting_midi_manager.dart';
+import 'package:nt_helper/models/firmware_version.dart';
+import 'package:nt_helper/services/mcp_server_service.dart';
+import 'package:nt_helper/ui/ntx_8cv/ntx_8cv_screen.dart';
+import 'package:nt_helper/ui/synchronized_screen.dart';
+
+class _MockDistingCubit extends Mock implements DistingCubit {}
+
+class _MockDistingMidiManager extends Mock implements IDistingMidiManager {}
+
+class _MockAppDatabase extends Mock implements AppDatabase {}
+
+class _MockMetadataDao extends Mock implements MetadataDao {}
+
+class _MockPresetsDao extends Mock implements PresetsDao {}
+
+class _MockPlatformInteractionService extends Mock
+    implements PlatformInteractionService {}
+
+void main() {
+  group('NTX-8CV entry page', () {
+    testWidgets('uses a single connection-controls row on wide screens', (
+      tester,
+    ) async {
+      await _setScreenSize(tester, const Size(1280, 900));
+      await tester.pumpWidget(const MaterialApp(home: Ntx8cvScreen()));
+
+      expect(
+        find.byKey(const Key('ntx8cv-connection-controls-wide')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('ntx8cv-connection-controls-narrow')),
+        findsNothing,
+      );
+      expect(find.widgetWithText(TextFormField, 'MIDI input'), findsOneWidget);
+      expect(find.widgetWithText(TextFormField, 'MIDI output'), findsOneWidget);
+      expect(
+        find.widgetWithText(TextFormField, 'SysEx device ID'),
+        findsOneWidget,
+      );
+      expect(find.widgetWithText(FilledButton, 'Connect'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('stacks connection controls on narrow screens', (tester) async {
+      await _setScreenSize(tester, const Size(500, 900));
+      await tester.pumpWidget(const MaterialApp(home: Ntx8cvScreen()));
+
+      expect(
+        find.byKey(const Key('ntx8cv-connection-controls-narrow')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('ntx8cv-connection-controls-wide')),
+        findsNothing,
+      );
+      expect(find.text('Disconnected'), findsOneWidget);
+      expect(find.text('Settings'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('opens from the main overflow menu through Add-ons', (
+      tester,
+    ) async {
+      final cubit = _MockDistingCubit();
+      final midiManager = _MockDistingMidiManager();
+      final platformService = _MockPlatformInteractionService();
+      final database = _MockAppDatabase();
+      final metadataDao = _MockMetadataDao();
+      final presetsDao = _MockPresetsDao();
+      final state = DistingStateSynchronized(
+        disting: midiManager,
+        distingVersion: '1.10.0',
+        firmwareVersion: FirmwareVersion('1.10.0'),
+        presetName: 'Test Preset',
+        algorithms: const [],
+        slots: const [],
+        unitStrings: const [],
+        offline: false,
+      );
+
+      when(() => cubit.checkpoints).thenReturn([]);
+      when(() => cubit.cpuUsageStream).thenAnswer((_) => const Stream.empty());
+      when(() => cubit.database).thenReturn(database);
+      when(() => database.metadataDao).thenReturn(metadataDao);
+      when(() => database.presetsDao).thenReturn(presetsDao);
+      when(() => presetsDao.getTemplates()).thenAnswer((_) async => []);
+      when(() => cubit.state).thenReturn(state);
+      when(() => cubit.stream).thenAnswer((_) => Stream.value(state));
+      when(() => platformService.isMobilePlatform()).thenReturn(false);
+      McpServerService.initialize(distingCubit: cubit);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: BlocProvider<DistingCubit>.value(
+            value: cubit,
+            child: SynchronizedScreen(
+              distingVersion: '1.10.0',
+              firmwareVersion: FirmwareVersion('1.10.0'),
+              slots: const [],
+              algorithms: const [],
+              units: const [],
+              presetName: 'Test Preset',
+              screenshot: Uint8List(0),
+              loading: false,
+              platformService: platformService,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.bySemanticsLabel('More options'));
+      await tester.pumpAndSettle();
+      expect(find.text('Add-ons'), findsOneWidget);
+
+      await tester.tap(find.text('Add-ons'));
+      await tester.pumpAndSettle();
+      expect(find.text('NTX-8CV'), findsOneWidget);
+
+      await tester.tap(find.text('NTX-8CV'));
+      await tester.pumpAndSettle();
+      expect(find.byType(Ntx8cvScreen), findsOneWidget);
+      expect(find.text('Connection'), findsOneWidget);
+      expect(find.text('Settings'), findsOneWidget);
+    });
+  });
+}
+
+Future<void> _setScreenSize(WidgetTester tester, Size size) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1;
+  addTearDown(() {
+    tester.view.resetPhysicalSize();
+    tester.view.resetDevicePixelRatio();
+  });
+}

--- a/test/ui/ntx_8cv/ntx_8cv_entry_screen_test.dart
+++ b/test/ui/ntx_8cv/ntx_8cv_entry_screen_test.dart
@@ -52,9 +52,10 @@ void main() {
       );
       expect(find.widgetWithText(FilledButton, 'Connect'), findsOneWidget);
       expect(find.text('Enable ES-5'), findsOneWidget);
+      expect(find.text('Channel Group'), findsOneWidget);
       expect(
         find.text('Connect an NTX-8CV to read this setting.'),
-        findsOneWidget,
+        findsNWidgets(2),
       );
       expect(tester.takeException(), isNull);
     });

--- a/test/ui/ntx_8cv/ntx_8cv_entry_screen_test.dart
+++ b/test/ui/ntx_8cv/ntx_8cv_entry_screen_test.dart
@@ -44,8 +44,8 @@ void main() {
         find.byKey(const Key('ntx8cv-connection-controls-narrow')),
         findsNothing,
       );
-      expect(find.widgetWithText(TextFormField, 'MIDI input'), findsOneWidget);
-      expect(find.widgetWithText(TextFormField, 'MIDI output'), findsOneWidget);
+      expect(find.byKey(const Key('ntx8cv-midi-input')), findsOneWidget);
+      expect(find.byKey(const Key('ntx8cv-midi-output')), findsOneWidget);
       expect(
         find.widgetWithText(TextFormField, 'SysEx device ID'),
         findsOneWidget,

--- a/test/ui/ntx_8cv/ntx_8cv_entry_screen_test.dart
+++ b/test/ui/ntx_8cv/ntx_8cv_entry_screen_test.dart
@@ -51,6 +51,11 @@ void main() {
         findsOneWidget,
       );
       expect(find.widgetWithText(FilledButton, 'Connect'), findsOneWidget);
+      expect(find.text('Enable ES-5'), findsOneWidget);
+      expect(
+        find.text('Connect an NTX-8CV to read this setting.'),
+        findsOneWidget,
+      );
       expect(tester.takeException(), isNull);
     });
 

--- a/test/ui/ntx_8cv/ntx_8cv_entry_screen_test.dart
+++ b/test/ui/ntx_8cv/ntx_8cv_entry_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nt_helper/core/platform/platform_interaction_service.dart';
 import 'package:nt_helper/cubit/disting_cubit.dart';
+import 'package:nt_helper/cubit/ntx_8cv_connection_cubit.dart';
 import 'package:nt_helper/db/daos/metadata_dao.dart';
 import 'package:nt_helper/db/daos/presets_dao.dart';
 import 'package:nt_helper/db/database.dart';
@@ -77,6 +78,67 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
+    testWidgets(
+      'keeps the full page geometry stable through connection lifecycle feedback on narrow and wide screens',
+      (tester) async {
+        const lifecycleStates = [
+          Ntx8cvConnectionState(isLoadingEndpoints: true),
+          Ntx8cvConnectionState(
+            status: Ntx8cvConnectionStatus.connecting,
+            statusMessage: 'Connecting to the selected NTX-8CV.',
+            isLoadingEndpoints: false,
+          ),
+          Ntx8cvConnectionState(
+            status: Ntx8cvConnectionStatus.connected,
+            isLoadingEndpoints: false,
+          ),
+          Ntx8cvConnectionState(
+            status: Ntx8cvConnectionStatus.disconnected,
+            statusMessage: 'Disconnecting the selected NTX-8CV.',
+            isLoadingEndpoints: false,
+          ),
+          Ntx8cvConnectionState(
+            status: Ntx8cvConnectionStatus.connecting,
+            statusMessage: 'Rebooting the selected NTX-8CV, then reconnecting.',
+            isLoadingEndpoints: false,
+          ),
+          Ntx8cvConnectionState(
+            status: Ntx8cvConnectionStatus.disconnected,
+            statusMessage: 'Reacquiring the selected NTX-8CV after reboot.',
+            isLoadingEndpoints: false,
+          ),
+          Ntx8cvConnectionState(
+            status: Ntx8cvConnectionStatus.failed,
+            statusMessage:
+                'Could not reacquire the selected NTX-8CV after reboot. Check its MIDI endpoints and reconnect it.',
+            isLoadingEndpoints: false,
+          ),
+        ];
+
+        for (final size in [const Size(900, 2600), const Size(500, 2600)]) {
+          await _setScreenSize(tester, size);
+          final connectionCubit = _LifecycleConnectionCubit();
+          await tester.pumpWidget(
+            MaterialApp(home: Ntx8cvScreen(connectionCubit: connectionCubit)),
+          );
+          final settingsSection = find.byType(Ntx8cvSettingsSection);
+          final initialPosition = tester.getTopLeft(settingsSection);
+          final initialSize = tester.getSize(settingsSection);
+
+          for (final state in lifecycleStates) {
+            connectionCubit.show(state);
+            await tester.pump();
+            expect(tester.getTopLeft(settingsSection), initialPosition);
+            expect(tester.getSize(settingsSection), initialSize);
+          }
+          expect(tester.takeException(), isNull);
+
+          await tester.pumpWidget(const SizedBox.shrink());
+          await connectionCubit.close();
+        }
+      },
+    );
+
     testWidgets('opens from the main overflow menu through Add-ons', (
       tester,
     ) async {
@@ -142,6 +204,15 @@ void main() {
       expect(find.text('Settings'), findsOneWidget);
     });
   });
+}
+
+class _LifecycleConnectionCubit extends Ntx8cvConnectionCubit {
+  _LifecycleConnectionCubit() : super();
+
+  @override
+  Future<void> initialize() async {}
+
+  void show(Ntx8cvConnectionState value) => emit(value);
 }
 
 Future<void> _setScreenSize(WidgetTester tester, Size size) async {

--- a/test/ui/ntx_8cv/ntx_8cv_recovery_screen_test.dart
+++ b/test/ui/ntx_8cv/ntx_8cv_recovery_screen_test.dart
@@ -9,11 +9,13 @@ void main() {
     (tester) async {
       var retryCount = 0;
       final pendingState = Ntx8cvSettingsState(
-        confirmedEs5Enabled: false,
-        attemptedEs5Enabled: true,
-        es5Message:
-            'The ES-5 change was not confirmed by device readback. The '
-            'actual device state is uncertain.',
+        es5: const Ntx8cvSettingChange(
+          confirmedValue: 0,
+          attemptedValue: 1,
+          message:
+              'The ES-5 change was not confirmed by device readback. The '
+              'actual device state is uncertain.',
+        ),
       );
 
       Widget buildSection({required bool isConnected}) => MaterialApp(
@@ -25,6 +27,8 @@ void main() {
             onRetryEs5Change: () async {
               retryCount += 1;
             },
+            onModeChanged: (_) async {},
+            onRetryModeChange: () async {},
           ),
         ),
       );
@@ -49,6 +53,64 @@ void main() {
 
       await tester.tap(retry);
       expect(retryCount, 1);
+    },
+  );
+
+  testWidgets(
+    'shows a pending Mode separately from its confirmed value and reboot state',
+    (tester) async {
+      var retryCount = 0;
+      Widget buildSection(Ntx8cvSettingsState state) => MaterialApp(
+        home: Scaffold(
+          body: Ntx8cvSettingsSection(
+            isConnected: true,
+            state: state,
+            onEs5Changed: (_) async {},
+            onRetryEs5Change: () async {},
+            onModeChanged: (_) async {},
+            onRetryModeChange: () async {
+              retryCount += 1;
+            },
+          ),
+        ),
+      );
+      final pendingMode = Ntx8cvSettingsState(
+        modeCapabilityEvidenced: true,
+        mode: const Ntx8cvSettingChange(
+          confirmedValue: 2,
+          attemptedValue: 0,
+          message:
+              'The Mode change was not confirmed by device readback. The '
+              'actual device state is uncertain.',
+        ),
+      );
+
+      await tester.pumpWidget(buildSection(pendingMode));
+
+      final retry = find.byKey(const Key('ntx8cv-retry-mode-change'));
+      expect(retry, findsOneWidget);
+      expect(tester.widget<OutlinedButton>(retry).onPressed, isNotNull);
+      expect(
+        find.textContaining('Attempted NT expansion mode: 8x8 CV'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Last device-confirmed value: 2x8 16bit Audio'),
+        findsOneWidget,
+      );
+      await tester.tap(retry);
+      expect(retryCount, 1);
+
+      await tester.pumpWidget(
+        buildSection(
+          const Ntx8cvSettingsState(
+            modeCapabilityEvidenced: true,
+            modeRebootRequired: true,
+            mode: Ntx8cvSettingChange(confirmedValue: 0),
+          ),
+        ),
+      );
+      expect(find.textContaining('Reboot required'), findsOneWidget);
     },
   );
 }

--- a/test/ui/ntx_8cv/ntx_8cv_recovery_screen_test.dart
+++ b/test/ui/ntx_8cv/ntx_8cv_recovery_screen_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nt_helper/cubit/ntx_8cv_settings_cubit.dart';
+import 'package:nt_helper/ui/ntx_8cv/ntx_8cv_screen.dart';
+
+void main() {
+  testWidgets(
+    'keeps Retry send unavailable while disconnected and enables it after reconnect',
+    (tester) async {
+      var retryCount = 0;
+      final pendingState = Ntx8cvSettingsState(
+        confirmedEs5Enabled: false,
+        attemptedEs5Enabled: true,
+        es5Message:
+            'The ES-5 change was not confirmed by device readback. The '
+            'actual device state is uncertain.',
+      );
+
+      Widget buildSection({required bool isConnected}) => MaterialApp(
+        home: Scaffold(
+          body: Ntx8cvSettingsSection(
+            isConnected: isConnected,
+            state: pendingState,
+            onEs5Changed: (_) async {},
+            onRetryEs5Change: () async {
+              retryCount += 1;
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(buildSection(isConnected: false));
+
+      final retry = find.byKey(const Key('ntx8cv-retry-es5-change'));
+      expect(retry, findsOneWidget);
+      expect(find.bySemanticsLabel('Retry send'), findsOneWidget);
+      expect(tester.widget<OutlinedButton>(retry).onPressed, isNull);
+      expect(
+        find.textContaining('Attempted ES-5 value: enabled'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Last device-confirmed value: disabled'),
+        findsOneWidget,
+      );
+
+      await tester.pumpWidget(buildSection(isConnected: true));
+      expect(tester.widget<OutlinedButton>(retry).onPressed, isNotNull);
+
+      await tester.tap(retry);
+      expect(retryCount, 1);
+    },
+  );
+}

--- a/test/ui/ntx_8cv/ntx_8cv_recovery_screen_test.dart
+++ b/test/ui/ntx_8cv/ntx_8cv_recovery_screen_test.dart
@@ -366,6 +366,65 @@ void main() {
   );
 
   testWidgets(
+    'enables Retry send for a pending audio-channel change without enabling its switch',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      var retryCount = 0;
+      final pendingAudioState = Ntx8cvSettingsState(
+        modeCapabilityEvidenced: true,
+        mode: const Ntx8cvSettingChange(confirmedValue: 2),
+        audioChannels: const [
+          Ntx8cvSettingChange(
+            confirmedValue: 1,
+            attemptedValue: 0,
+            message:
+                'The Audio channel 1 change was not confirmed by device readback. The actual device state is uncertain.',
+          ),
+          Ntx8cvSettingChange(),
+          Ntx8cvSettingChange(),
+          Ntx8cvSettingChange(),
+          Ntx8cvSettingChange(),
+          Ntx8cvSettingChange(),
+          Ntx8cvSettingChange(),
+          Ntx8cvSettingChange(),
+        ],
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Ntx8cvSettingsSection(
+              isConnected: true,
+              state: pendingAudioState,
+              onChannelGroupChanged: (_) async {},
+              onRetryChannelGroupChange: () async {},
+              onEs5Changed: (_) async {},
+              onRetryEs5Change: () async {},
+              onModeChanged: (_) async {},
+              onRetryModeChange: () async {},
+              onAudioChannelChanged: (_, _) async {},
+              onRetryAudioChannelChange: (_) async {
+                retryCount += 1;
+              },
+              onReboot: () async {},
+            ),
+          ),
+        ),
+      );
+
+      final channelSwitch = tester.widget<SwitchListTile>(
+        find.widgetWithText(SwitchListTile, 'Audio channel 1'),
+      );
+      final retry = find.byKey(const Key('ntx8cv-retry-audio-channel-1'));
+      expect(channelSwitch.onChanged, isNull);
+      expect(tester.widget<TextButton>(retry).onPressed, isNotNull);
+
+      await tester.tap(retry);
+      expect(retryCount, 1);
+    },
+  );
+
+  testWidgets(
     'keeps settings geometry stable through loading, pending failure, and reboot feedback on narrow and wide layouts',
     (tester) async {
       await tester.binding.setSurfaceSize(const Size(900, 2200));

--- a/test/ui/ntx_8cv/ntx_8cv_recovery_screen_test.dart
+++ b/test/ui/ntx_8cv/ntx_8cv_recovery_screen_test.dart
@@ -7,7 +7,7 @@ void main() {
   testWidgets(
     'keeps Retry send unavailable while disconnected and enables it after reconnect',
     (tester) async {
-      await tester.binding.setSurfaceSize(const Size(800, 1200));
+      await tester.binding.setSurfaceSize(const Size(800, 1600));
       addTearDown(() => tester.binding.setSurfaceSize(null));
       var retryCount = 0;
       final pendingState = Ntx8cvSettingsState(
@@ -64,6 +64,8 @@ void main() {
   testWidgets(
     'offers exactly three Mode choices while ES-5 remains available in each',
     (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
       Widget buildSection(Ntx8cvExpansionMode mode) => MaterialApp(
         home: Scaffold(
           body: Ntx8cvSettingsSection(
@@ -115,6 +117,8 @@ void main() {
   testWidgets(
     'offers released Channel Group blocks and explains their separate role',
     (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
       Ntx8cvChannelGroup? selectedGroup;
       await tester.pumpWidget(
         MaterialApp(
@@ -146,7 +150,7 @@ void main() {
       );
       expect(find.text('Channel Group'), findsOneWidget);
       expect(
-        find.textContaining('does not replace the disting NT’s granular'),
+        find.textContaining('does not enable individual audio channels'),
         findsOneWidget,
       );
       expect(picker.onChanged, isNotNull);
@@ -174,7 +178,7 @@ void main() {
   testWidgets(
     'shows a pending Mode separately from its confirmed value and reboot state',
     (tester) async {
-      await tester.binding.setSurfaceSize(const Size(800, 1200));
+      await tester.binding.setSurfaceSize(const Size(800, 1600));
       addTearDown(() => tester.binding.setSurfaceSize(null));
       var retryCount = 0;
       Widget buildSection(Ntx8cvSettingsState state) => MaterialApp(
@@ -237,6 +241,8 @@ void main() {
   testWidgets(
     'reboots the selected NTX-8CV with one activation and no dialog',
     (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
       var rebootCount = 0;
       await tester.pumpWidget(
         MaterialApp(
@@ -270,6 +276,178 @@ void main() {
       await tester.tap(reboot);
       expect(rebootCount, 1);
       expect(find.byType(AlertDialog), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'shows all released audio channels, confirms their states, and disables them in CV mode',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final changes = <(Ntx8cvAudioChannel, bool)>[];
+      final audioState = Ntx8cvSettingsState(
+        modeCapabilityEvidenced: true,
+        mode: const Ntx8cvSettingChange(confirmedValue: 2),
+        audioChannels: const [
+          Ntx8cvSettingChange(confirmedValue: 1),
+          Ntx8cvSettingChange(confirmedValue: 0),
+          Ntx8cvSettingChange(confirmedValue: 1),
+          Ntx8cvSettingChange(confirmedValue: 0),
+          Ntx8cvSettingChange(confirmedValue: 1),
+          Ntx8cvSettingChange(confirmedValue: 0),
+          Ntx8cvSettingChange(confirmedValue: 1),
+          Ntx8cvSettingChange(confirmedValue: 0),
+        ],
+      );
+      Widget buildSection(Ntx8cvSettingsState state) => MaterialApp(
+        home: Scaffold(
+          body: Ntx8cvSettingsSection(
+            isConnected: true,
+            state: state,
+            onChannelGroupChanged: (_) async {},
+            onRetryChannelGroupChange: () async {},
+            onEs5Changed: (_) async {},
+            onRetryEs5Change: () async {},
+            onModeChanged: (_) async {},
+            onRetryModeChange: () async {},
+            onAudioChannelChanged: (channel, enabled) async {
+              changes.add((channel, enabled));
+            },
+            onRetryAudioChannelChange: (_) async {},
+            onReboot: () async {},
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(buildSection(audioState));
+      for (final channel in Ntx8cvAudioChannel.values) {
+        expect(
+          find.byKey(Key('ntx8cv-audio-channel-${channel.number}')),
+          findsOneWidget,
+        );
+        expect(find.text(channel.label), findsOneWidget);
+      }
+      expect(
+        find.textContaining('Device-confirmed: enabled.'),
+        findsNWidgets(4),
+      );
+      expect(
+        find.textContaining('Device-confirmed: disabled.'),
+        findsNWidgets(4),
+      );
+
+      final channel2 = tester.widget<SwitchListTile>(
+        find.widgetWithText(SwitchListTile, 'Audio channel 2'),
+      );
+      expect(channel2.onChanged, isNotNull);
+      channel2.onChanged!(true);
+      expect(changes, [(Ntx8cvAudioChannel.channel2, true)]);
+
+      await tester.pumpWidget(
+        buildSection(
+          const Ntx8cvSettingsState(
+            modeCapabilityEvidenced: true,
+            mode: Ntx8cvSettingChange(confirmedValue: 0),
+          ),
+        ),
+      );
+      final unavailableChannel = tester.widget<SwitchListTile>(
+        find.widgetWithText(SwitchListTile, 'Audio channel 1'),
+      );
+      expect(unavailableChannel.onChanged, isNull);
+      expect(
+        find.textContaining(
+          'Audio channels are not applicable while the device-confirmed Mode is 8x8 CV.',
+        ),
+        findsOneWidget,
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'keeps settings geometry stable through loading, pending failure, and reboot feedback on narrow and wide layouts',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(900, 2200));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final loading = const Ntx8cvSettingsState(
+        mode: Ntx8cvSettingChange(isLoading: true),
+        es5: Ntx8cvSettingChange(isLoading: true),
+      );
+      final recovering = Ntx8cvSettingsState(
+        modeCapabilityEvidenced: true,
+        mode: const Ntx8cvSettingChange(
+          confirmedValue: 2,
+          attemptedValue: 0,
+          message:
+              'The Mode change was not confirmed by device readback. The actual device state is uncertain.',
+        ),
+        es5: const Ntx8cvSettingChange(
+          confirmedValue: 0,
+          attemptedValue: 1,
+          message:
+              'The ES-5 change was not confirmed by device readback. The actual device state is uncertain.',
+        ),
+        audioChannels: const [
+          Ntx8cvSettingChange(
+            confirmedValue: 1,
+            attemptedValue: 0,
+            message:
+                'The Audio channel 1 change was not confirmed by device readback. The actual device state is uncertain.',
+          ),
+          Ntx8cvSettingChange(),
+          Ntx8cvSettingChange(),
+          Ntx8cvSettingChange(),
+          Ntx8cvSettingChange(),
+          Ntx8cvSettingChange(),
+          Ntx8cvSettingChange(),
+          Ntx8cvSettingChange(),
+        ],
+        isRebooting: true,
+        rebootMessage:
+            'Could not complete the NTX-8CV reboot and refresh. Check the selected MIDI endpoints and reconnect the device.',
+      );
+      Widget buildSection(Ntx8cvSettingsState state, bool isNarrow) =>
+          MaterialApp(
+            home: Scaffold(
+              body: SingleChildScrollView(
+                child: Ntx8cvSettingsSection(
+                  isConnected: true,
+                  isNarrow: isNarrow,
+                  state: state,
+                  onChannelGroupChanged: (_) async {},
+                  onRetryChannelGroupChange: () async {},
+                  onEs5Changed: (_) async {},
+                  onRetryEs5Change: () async {},
+                  onModeChanged: (_) async {},
+                  onRetryModeChange: () async {},
+                  onReboot: () async {},
+                ),
+              ),
+            ),
+          );
+
+      await tester.pumpWidget(buildSection(loading, false));
+      final wideLoadingSize = tester.getSize(
+        find.byType(Ntx8cvSettingsSection),
+      );
+      await tester.pumpWidget(buildSection(recovering, false));
+      expect(
+        tester.getSize(find.byType(Ntx8cvSettingsSection)),
+        wideLoadingSize,
+      );
+
+      await tester.binding.setSurfaceSize(const Size(500, 2200));
+      await tester.pumpWidget(buildSection(loading, true));
+      final narrowLoadingSize = tester.getSize(
+        find.byType(Ntx8cvSettingsSection),
+      );
+      await tester.pumpWidget(buildSection(recovering, true));
+      expect(
+        tester.getSize(find.byType(Ntx8cvSettingsSection)),
+        narrowLoadingSize,
+      );
+      expect(tester.takeException(), isNull);
     },
   );
 }

--- a/test/ui/ntx_8cv/ntx_8cv_recovery_screen_test.dart
+++ b/test/ui/ntx_8cv/ntx_8cv_recovery_screen_test.dart
@@ -7,6 +7,8 @@ void main() {
   testWidgets(
     'keeps Retry send unavailable while disconnected and enables it after reconnect',
     (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1200));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
       var retryCount = 0;
       final pendingState = Ntx8cvSettingsState(
         es5: const Ntx8cvSettingChange(
@@ -23,6 +25,8 @@ void main() {
           body: Ntx8cvSettingsSection(
             isConnected: isConnected,
             state: pendingState,
+            onChannelGroupChanged: (_) async {},
+            onRetryChannelGroupChange: () async {},
             onEs5Changed: (_) async {},
             onRetryEs5Change: () async {
               retryCount += 1;
@@ -68,6 +72,8 @@ void main() {
               mode: Ntx8cvSettingChange(confirmedValue: mode.value),
               modeCapabilityEvidenced: true,
             ),
+            onChannelGroupChanged: (_) async {},
+            onRetryChannelGroupChange: () async {},
             onEs5Changed: (_) async {},
             onRetryEs5Change: () async {},
             onModeChanged: (_) async {},
@@ -105,14 +111,76 @@ void main() {
   );
 
   testWidgets(
+    'offers released Channel Group blocks and explains their separate role',
+    (tester) async {
+      Ntx8cvChannelGroup? selectedGroup;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Ntx8cvSettingsSection(
+              isConnected: true,
+              state: const Ntx8cvSettingsState(
+                channelGroup: Ntx8cvSettingChange(confirmedValue: 0),
+              ),
+              onChannelGroupChanged: (group) async {
+                selectedGroup = group;
+              },
+              onRetryChannelGroupChange: () async {},
+              onEs5Changed: (_) async {},
+              onRetryEs5Change: () async {},
+              onModeChanged: (_) async {},
+              onRetryModeChange: () async {},
+            ),
+          ),
+        ),
+      );
+
+      final pickerFinder = find.byType(
+        DropdownButtonFormField<Ntx8cvChannelGroup>,
+      );
+      final picker = tester.widget<DropdownButtonFormField<Ntx8cvChannelGroup>>(
+        pickerFinder,
+      );
+      expect(find.text('Channel Group'), findsOneWidget);
+      expect(
+        find.textContaining('does not replace the disting NT’s granular'),
+        findsOneWidget,
+      );
+      expect(picker.onChanged, isNotNull);
+      await tester.tap(pickerFinder);
+      await tester.pumpAndSettle();
+      for (final label in [
+        '1–8',
+        '9–16',
+        '17–24',
+        '25–32',
+        '33–40',
+        '41–48',
+        '49–56',
+        '57–64',
+      ]) {
+        expect(find.text(label), findsWidgets);
+      }
+
+      await tester.tap(find.text('57–64').last);
+      await tester.pumpAndSettle();
+      expect(selectedGroup, Ntx8cvChannelGroup.channels57To64);
+    },
+  );
+
+  testWidgets(
     'shows a pending Mode separately from its confirmed value and reboot state',
     (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1200));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
       var retryCount = 0;
       Widget buildSection(Ntx8cvSettingsState state) => MaterialApp(
         home: Scaffold(
           body: Ntx8cvSettingsSection(
             isConnected: true,
             state: state,
+            onChannelGroupChanged: (_) async {},
+            onRetryChannelGroupChange: () async {},
             onEs5Changed: (_) async {},
             onRetryEs5Change: () async {},
             onModeChanged: (_) async {},

--- a/test/ui/ntx_8cv/ntx_8cv_recovery_screen_test.dart
+++ b/test/ui/ntx_8cv/ntx_8cv_recovery_screen_test.dart
@@ -57,6 +57,54 @@ void main() {
   );
 
   testWidgets(
+    'offers exactly three Mode choices while ES-5 remains available in each',
+    (tester) async {
+      Widget buildSection(Ntx8cvExpansionMode mode) => MaterialApp(
+        home: Scaffold(
+          body: Ntx8cvSettingsSection(
+            isConnected: true,
+            state: Ntx8cvSettingsState(
+              es5: const Ntx8cvSettingChange(confirmedValue: 1),
+              mode: Ntx8cvSettingChange(confirmedValue: mode.value),
+              modeCapabilityEvidenced: true,
+            ),
+            onEs5Changed: (_) async {},
+            onRetryEs5Change: () async {},
+            onModeChanged: (_) async {},
+            onRetryModeChange: () async {},
+          ),
+        ),
+      );
+
+      for (final mode in Ntx8cvExpansionMode.values) {
+        await tester.pumpWidget(buildSection(mode));
+
+        final modePickerFinder = find.byType(
+          DropdownButtonFormField<Ntx8cvExpansionMode>,
+        );
+        final modePicker = tester
+            .widget<DropdownButtonFormField<Ntx8cvExpansionMode>>(
+              modePickerFinder,
+            );
+        expect(modePicker.onChanged, isNotNull);
+        await tester.tap(modePickerFinder);
+        await tester.pumpAndSettle();
+        for (final label in ['8x8 CV', '1x8 32bit Audio', '2x8 16bit Audio']) {
+          expect(find.text(label), findsWidgets);
+        }
+        await tester.tapAt(Offset.zero);
+        await tester.pumpAndSettle();
+
+        final es5Switch = tester.widget<SwitchListTile>(
+          find.widgetWithText(SwitchListTile, 'Enable ES-5'),
+        );
+        expect(es5Switch.value, isTrue);
+        expect(es5Switch.onChanged, isNotNull);
+      }
+    },
+  );
+
+  testWidgets(
     'shows a pending Mode separately from its confirmed value and reboot state',
     (tester) async {
       var retryCount = 0;

--- a/test/ui/ntx_8cv/ntx_8cv_recovery_screen_test.dart
+++ b/test/ui/ntx_8cv/ntx_8cv_recovery_screen_test.dart
@@ -33,6 +33,7 @@ void main() {
             },
             onModeChanged: (_) async {},
             onRetryModeChange: () async {},
+            onReboot: () async {},
           ),
         ),
       );
@@ -78,6 +79,7 @@ void main() {
             onRetryEs5Change: () async {},
             onModeChanged: (_) async {},
             onRetryModeChange: () async {},
+            onReboot: () async {},
           ),
         ),
       );
@@ -130,6 +132,7 @@ void main() {
               onRetryEs5Change: () async {},
               onModeChanged: (_) async {},
               onRetryModeChange: () async {},
+              onReboot: () async {},
             ),
           ),
         ),
@@ -187,6 +190,7 @@ void main() {
             onRetryModeChange: () async {
               retryCount += 1;
             },
+            onReboot: () async {},
           ),
         ),
       );
@@ -227,6 +231,45 @@ void main() {
         ),
       );
       expect(find.textContaining('Reboot required'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'reboots the selected NTX-8CV with one activation and no dialog',
+    (tester) async {
+      var rebootCount = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Ntx8cvSettingsSection(
+              isConnected: true,
+              state: const Ntx8cvSettingsState(
+                modeRebootRequired: true,
+                modeCapabilityEvidenced: true,
+                mode: Ntx8cvSettingChange(confirmedValue: 0),
+              ),
+              onChannelGroupChanged: (_) async {},
+              onRetryChannelGroupChange: () async {},
+              onEs5Changed: (_) async {},
+              onRetryEs5Change: () async {},
+              onModeChanged: (_) async {},
+              onRetryModeChange: () async {},
+              onReboot: () async {
+                rebootCount += 1;
+              },
+            ),
+          ),
+        ),
+      );
+
+      final reboot = find.byKey(const Key('ntx8cv-reboot'));
+      expect(reboot, findsOneWidget);
+      expect(find.text('Reboot NTX-8CV'), findsOneWidget);
+      expect(tester.widget<FilledButton>(reboot).onPressed, isNotNull);
+
+      await tester.tap(reboot);
+      expect(rebootCount, 1);
+      expect(find.byType(AlertDialog), findsNothing);
     },
   );
 }


### PR DESCRIPTION
## Summary
- Stabilize NTX-8CV settings lifecycle geometry and status presentation (ticket 918d4e2e-5bde-4d71-96c5-70b09d7267f0).
- Add confirmed, recoverable individual audio-channel enablement using the audited NTX-8CV protocol path (ticket bb17ab37-e521-49e7-a97e-7f9370acdd90).
- Document remaining physical-hardware validation in `docs/ntx_8cv_hardware_validation.md`.

## Verification
- `flutter analyze && flutter test`
- `git diff --check main...HEAD`

Protocol evidence: checked-in `ntx8cv_config_tool.html` confirms settings `0x04`–`0x0B`, boolean encoding, `0x31` reads, and `0x32` writes.